### PR TITLE
Add NB_BOUNDARY_BUFFER to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Copy the 'neighborhood_boundary_02138.zip' file on fileshare and unzip to `./dat
 
 Run:
 ```
-NB_INPUT_SRID=2249 NB_OUTPUT_SRID=2249 ./pfb-analysis/import.sh /vagrant/data/neighborhood_boundary.shp ma 25
-NB_OUTPUT_SRID=2249 ./pfb-analysis/run_connectivity.sh
+NB_INPUT_SRID=2249 NB_OUTPUT_SRID=2249 NB_BOUNDARY_BUFFER=11000 ./pfb-analysis/import.sh /vagrant/data/neighborhood_boundary.shp ma 25
+NB_OUTPUT_SRID=2249 NB_BOUNDARY_BUFFER=11000 ./pfb-analysis/run_connectivity.sh
 ```
 
 This will take up to 1hr, so just let it work. Consider piping script output to a file and running in


### PR DESCRIPTION
Running the analysis without explicitly setting NB_BOUNDARY_BUFFER can lead to a confusing scenario where you end up with no linked census blocks, and all of the statistics in the `neighborhood_overall_scores` table are zero.