### PR TITLE
Prepare VM for parallel processing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :virtualbox do |v|
     v.memory = ENV.fetch("PFB_MEM", 4096)
-    v.cpus = ENV.fetch("PFB_CPUS", 4)
+    v.cpus = ENV.fetch("PFB_CPUS", 8)
   end
 end

--- a/deployment/ansible/roles/pfb.analysis/tasks/main.yml
+++ b/deployment/ansible/roles/pfb.analysis/tasks/main.yml
@@ -6,6 +6,9 @@
 - name: Install unzip package (used by analysis importers)
   apt: name=unzip
 
+- name: Install parallel package (used by analysis)
+  apt: name=parallel
+
 - name: Create PostgreSQL super user
   become_user: postgres
   postgresql_user: name="{{ postgresql_database_user }}"


### PR DESCRIPTION
## Overview

Installs GNU `parallel` and ups the default amount of CPUs in the `Vagrantfile` to 8.

Allows https://github.com/azavea/pfb/pull/11 to run.

Connects #44 