### PR TITLE
Switch to ansible-local provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ PFB Bicycle Network Connectivity
 Requirements:
 - Vagrant 1.8+
 - VirtualBox 4.3+
-- Ansible 2.0+
 
 Run `./script/setup` to install project dependencies and prepare the development environment. Then, SSH into the VM:
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,11 +47,17 @@ Vagrant.configure("2") do |config|
     s.args = "'#{ROOT_VM_DIR}'"
   end
 
-  config.vm.provision "ansible" do |ansible|
+  config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "deployment/ansible/pfb.yml"
     ansible.galaxy_role_file = "deployment/ansible/roles.yml"
     ansible.verbose = true
     ansible.raw_arguments = ["--timeout=60"]
+
+    # local arguments
+    # Ubuntu trusty base box already has system python + pip installed, no need to reinstall here
+    ansible.install = true
+    ansible.install_mode = "pip"
+    ansible.version = "2.2.1"
   end
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
## Overview

Switch to ansible-local provisioning so that the VM can be used easily on all three major OSs. 

## Testing

`vagrant destroy` then `vagrant up --provision`. The VM should still provision successfully, using ansible-local instead of ansible.

This is untested on Windows ATM. Will attempt to test on Windows over the weekend at home and update as necessary.