### PR TITLE
Fix reference to ./scripts/setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements:
 
 ### Provisioning the VM
 
-Run `./script/setup` to install project dependencies and prepare the development environment. Then, SSH into the VM:
+Run `./scripts/setup` to install project dependencies and prepare the development environment. Then, SSH into the VM:
 ```
 vagrant ssh
 ```


### PR DESCRIPTION
Just fixing a typo I noticed in the docs as I was setting up the VM.