### PR TITLE
Add DEV_USER environment variable to separate AWS dev environments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,9 @@ Vagrant.configure("2") do |config|
     ansible.playbook = "deployment/ansible/pfb.yml"
     ansible.galaxy_role_file = "deployment/ansible/roles.yml"
     ansible.verbose = true
-    ansible.raw_arguments = ["--timeout=60"]
+    ansible.raw_arguments = ["--timeout=60",
+                             "--extra-vars",
+                             "dev_user=#{ENV.fetch("USER", "vagrant")}"]
 
     # local arguments
     # Ubuntu trusty base box already has system python + pip installed, no need to reinstall here

--- a/deployment/ansible/pfb.yml
+++ b/deployment/ansible/pfb.yml
@@ -8,4 +8,5 @@
 
   roles:
     - { role: "azavea.aws-cli" }
+    - { role: "pfb.env" }
     - { role: "pfb.docker" }

--- a/deployment/ansible/roles/pfb.env/defaults/main.yml
+++ b/deployment/ansible/roles/pfb.env/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+dev_user: "developer"

--- a/deployment/ansible/roles/pfb.env/tasks/main.yml
+++ b/deployment/ansible/roles/pfb.env/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Set DEV_USER environment variable
+  lineinfile: dest=/etc/environment regexp=^DEV_USER line="DEV_USER={{ dev_user }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - "9203:9203"
     links:
       - database:database.service.pfb.internal
+    environment:
+      - DEV_USER
 
 # TODO: Re-add this container once the SQS broker is setup (issue #20)
   # celery:

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -24,6 +24,8 @@ DJANGO_ENV = os.getenv('DJANGO_ENV', 'development')
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
+DEV_USER = os.getenv('DEV_USER')
+
 DEBUG = DJANGO_ENV == 'development'
 
 ALLOWED_HOSTS = []


### PR DESCRIPTION
## Overview

In order to separate development resources on AWS (such as S3 buckets), we need to pass the developer's username from their host machine through the vagrant VM, into the docker container, and finally into the django instance.

This pull request accomplishes this by passing the username from the host environment to Ansible through the `Vagrantfile`. Ansible writes this to `/etc/environment` as the `DEV_USER` variable. When `docker-compose up` is run, this environment variable is passed into the container as specified in `docker-compose.yml`.

## Testing

* Reprovision
* `docker-compose up`
* While `docker-compose` is running, `docker exec -it vagrant_django_1 /bin/bash`
* `./manage.py shell`
* `from django.conf import settings; print settings.DEV_USER`
* Ensure your username is printed

Connects #61 