### PR TITLE
Staging Terraform deployment

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,47 @@
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `pfb`:
+
+```bash
+$ vagrant ssh
+vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile pfb configure
+AWS Access Key ID [****************F2DQ]:
+AWS Secret Access Key [****************TLJ/]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+If you're deploying new application code, first set the commit to deploy, then build and push containers:
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ export GIT_COMMIT="<commit-to-deploy>"
+vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_AWS_ECR_ENDPOINT="<aws-account-id>.dkr.ecr.us-east-1.amazonaws.com"
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/cibuild && ./scripts/cipublish
+```
+
+Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_SETTINGS_BUCKET="staging-pfb-config-us-east-1"
+vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="pfb"
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra apply
+```
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -30,3 +30,6 @@ postgis_package_version: "2.3.1+dfsg-1.pgdg14.04+1"
 # azavea.docker
 # 1.11.* to match AWS ECS
 docker_version: 1.11.*
+
+# azavea.terraform
+terraform_version: 0.8.7

--- a/deployment/ansible/pfb.yml
+++ b/deployment/ansible/pfb.yml
@@ -8,5 +8,6 @@
 
   roles:
     - { role: "azavea.aws-cli" }
+    - { role: "azavea.terraform" }
     - { role: "pfb.env" }
     - { role: "pfb.docker" }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -2,3 +2,5 @@
   version: 0.1.0
 - src: azavea.docker
   version: 2.0.1
+- src: azavea.terraform
+  version: 0.3.1

--- a/deployment/terraform/alarms.tf
+++ b/deployment/terraform/alarms.tf
@@ -1,0 +1,44 @@
+# set up SNS topic for monitoring
+resource "aws_sns_topic" "global" {
+  name = "topic${var.environment}GlobalNotifications"
+}
+
+#
+# ECS Alarms
+#
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_util" {
+  alarm_name          = "alarm${var.environment}ECSCPUUtilization"
+  alarm_description   = "Container service CPU utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "75"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.container_instance.name}"
+  }
+
+  alarm_actions = ["${aws_sns_topic.global.arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_util" {
+  alarm_name          = "alarm${var.environment}ECSMemoryUtilization"
+  alarm_description   = "Container service memory utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "80"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.container_instance.name}"
+  }
+
+  alarm_actions = ["${aws_sns_topic.global.arn}"]
+}

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -1,0 +1,196 @@
+#
+# Security group resources
+#
+resource "aws_security_group" "pfb_app_alb" {
+  vpc_id = "${module.vpc.id}"
+
+  tags {
+    Name        = "sgAppServerLoadBalancer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# ALB resources
+#
+resource "aws_alb" "pfb_app" {
+  security_groups = ["${aws_security_group.pfb_app_alb.id}"]
+  subnets         = ["${module.vpc.public_subnet_ids}"]
+  name            = "alb${var.environment}AppServer"
+
+  tags {
+    Name        = "albAppServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_alb_target_group" "pfb_app_http" {
+  # Name can only be 32 characters long, so we MD5 hash the name and
+  # truncate it to fit.
+  name = "tf-tg-${replace("${md5("${var.environment}HTTPAppServer")}", "/(.{0,26})(.*)/", "$1")}"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "60"
+    matcher             = "301"
+    protocol            = "HTTP"
+    timeout             = "3"
+    path                = "/"
+    unhealthy_threshold = "2"
+  }
+
+  port     = "80"
+  protocol = "HTTP"
+  vpc_id   = "${module.vpc.id}"
+
+  tags {
+    Name        = "tg${var.environment}HTTPAppServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_alb_target_group" "pfb_app_https" {
+  # Name can only be 32 characters long, so we MD5 hash the name and
+  # truncate it to fit.
+  name = "tf-tg-${replace("${md5("${var.environment}HTTPSAppServer")}", "/(.{0,26})(.*)/", "$1")}"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    timeout             = "3"
+    path                = "/healthcheck/"
+    unhealthy_threshold = "2"
+  }
+
+  port     = "443"
+  protocol = "HTTP"
+  vpc_id   = "${module.vpc.id}"
+
+  tags {
+    Name        = "tg${var.environment}HTTPSAppServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_alb_listener" "pfb_app_http" {
+  load_balancer_arn = "${aws_alb.pfb_app.id}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.pfb_app_http.id}"
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_listener" "pfb_app_https" {
+  load_balancer_arn = "${aws_alb.pfb_app.id}"
+  port              = "443"
+  protocol          = "HTTPS"
+  certificate_arn   = "${var.ssl_certificate_arn}"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.pfb_app_https.id}"
+    type             = "forward"
+  }
+}
+
+data "template_file" "pfb_app_http_ecs_task" {
+  template = "${file("task-definitions/nginx.json")}"
+
+  vars = {
+    app_server_nginx_url       = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb-nginx:${var.git_commit}"
+    pfb_app_papertrail_endpoint = "${var.papertrail_host}:${var.papertrail_port}"
+  }
+}
+
+resource "aws_ecs_task_definition" "pfb_app_http" {
+  family                = "${var.environment}HTTPAppServer"
+  container_definitions = "${data.template_file.pfb_app_http_ecs_task.rendered}"
+}
+
+resource "aws_ecs_service" "pfb_app_http" {
+  name                               = "${var.environment}HTTPAppServer"
+  cluster                            = "${aws_ecs_cluster.container_instance.id}"
+  task_definition                    = "${aws_ecs_task_definition.pfb_app_http.arn}"
+  desired_count                      = "${var.pfb_app_http_ecs_desired_count}"
+  deployment_minimum_healthy_percent = "${var.pfb_app_http_ecs_deployment_min_percent}"
+  deployment_maximum_percent         = "${var.pfb_app_http_ecs_deployment_max_percent}"
+  iam_role                           = "${aws_iam_role.container_instance_ecs.name}"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.pfb_app_http.id}"
+    container_name   = "nginx"
+    container_port   = "80"
+  }
+}
+
+data "template_file" "pfb_app_https_ecs_task" {
+  template = "${file("task-definitions/app.json")}"
+
+  vars = {
+    app_server_nginx_url       = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb-nginx:${var.git_commit}"
+    app_server_django_url      = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb-app:${var.git_commit}"
+    django_env                 = "${var.django_env}"
+    django_secret_key          = "${var.django_secret_key}"
+    rds_host                   = "${module.database.hostname}"
+    rds_password               = "${var.rds_password}"
+    rds_username               = "${var.rds_username}"
+    rds_database_name          = "${var.rds_database_name}"
+    s3_storage_bucket          = "${aws_s3_bucket.static.id}"
+    django_allowed_hosts       = "${var.django_allowed_hosts}"
+    git_commit                 = "${var.git_commit}"
+    pfb_app_papertrail_endpoint = "${var.papertrail_host}:${var.papertrail_port}"
+    aws_region                 = "${var.aws_region}"
+  }
+}
+
+resource "aws_ecs_task_definition" "pfb_app_https" {
+  family                = "${var.environment}HTTPSAppServer"
+  container_definitions = "${data.template_file.pfb_app_https_ecs_task.rendered}"
+}
+
+resource "aws_ecs_service" "pfb_app_https" {
+  name                               = "${var.environment}HTTPSAppServer"
+  cluster                            = "${aws_ecs_cluster.container_instance.id}"
+  task_definition                    = "${aws_ecs_task_definition.pfb_app_https.arn}"
+  desired_count                      = "${var.pfb_app_https_ecs_desired_count}"
+  deployment_minimum_healthy_percent = "${var.pfb_app_https_ecs_deployment_min_percent}"
+  deployment_maximum_percent         = "${var.pfb_app_https_ecs_deployment_max_percent}"
+  iam_role                           = "${aws_iam_role.container_instance_ecs.name}"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.pfb_app_https.id}"
+    container_name   = "nginx"
+    container_port   = "443"
+  }
+}
+
+data "template_file" "pfb_app_management_ecs_task" {
+  template = "${file("task-definitions/management.json")}"
+
+  vars {
+    management_url             = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb:${var.git_commit}"
+    django_env                 = "${var.django_env}"
+    django_secret_key          = "${var.django_secret_key}"
+    rds_host                   = "${module.database.hostname}"
+    rds_password               = "${var.rds_password}"
+    rds_username               = "${var.rds_username}"
+    rds_database_name          = "${var.rds_database_name}"
+    s3_storage_bucket          = "${aws_s3_bucket.static.id}"
+    django_allowed_hosts       = "${var.django_allowed_hosts}"
+    git_commit                 = "${var.git_commit}"
+    pfb_app_papertrail_endpoint = "${var.papertrail_host}:${var.papertrail_port}"
+    aws_region                 = "${var.aws_region}"
+  }
+}
+
+resource "aws_ecs_task_definition" "pfb_app_management" {
+  family                = "${var.environment}Management"
+  container_definitions = "${data.template_file.pfb_app_management_ecs_task.rendered}"
+}

--- a/deployment/terraform/cloud-config/ecs-user-data.yml
+++ b/deployment/terraform/cloud-config/ecs-user-data.yml
@@ -1,0 +1,67 @@
+#cloud-config
+
+packages:
+    - awslogs
+
+runcmd:
+  - curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
+
+write_files:
+  - path: /etc/ecs/ecs.config
+    permissions: 0644
+    owner: root:root
+    content: |
+      ECS_CLUSTER=${ecs_cluster_name}
+  - path: /etc/awslogs/awslogs.conf
+    permissions: 0644
+    owner: root:root
+    content: |
+      [general]
+      state_file = /var/lib/awslogs/agent-state
+
+      [/var/log/dmesg]
+      file = /var/log/dmesg
+      log_group_name = log${environment}ContainerInstance
+      log_stream_name = dmesg/{instance_id}
+
+      [/var/log/messages]
+      file = /var/log/messages
+      log_group_name = log${environment}ContainerInstance
+      log_stream_name = messages/{instance_id}
+      datetime_format = %b %d %H:%M:%S
+
+      [/var/log/docker]
+      file = /var/log/docker
+      log_group_name = log${environment}ContainerInstance
+      log_stream_name = docker/{instance_id}
+      datetime_format = %Y-%m-%dT%H:%M:%S.%f
+
+      [/var/log/ecs/ecs-init.log]
+      file = /var/log/ecs/ecs-init.log.*
+      log_group_name = log${environment}ContainerInstance
+      log_stream_name = ecs-init/{instance_id}
+      datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+      [/var/log/ecs/ecs-agent.log]
+      file = /var/log/ecs/ecs-agent.log.*
+      log_group_name = log${environment}ContainerInstance
+      log_stream_name = ecs-agent/{instance_id}
+      datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+  - path: /etc/init/awslogs.conf
+    permissions: 0644
+    owner: root:root
+    content: |
+      description "Configure and start CloudWatch Logs agent on Amazon ECS container instance"
+      author "Amazon Web Services"
+      start on started ecs
+      script
+          exec 2>>/var/log/ecs/cloudwatch-logs-start.log
+          set -x
+          until curl -s http://localhost:51678/v1/metadata
+          do
+              sleep 1
+          done
+          service awslogs start
+          chkconfig awslogs on
+      end script

--- a/deployment/terraform/container-service.tf
+++ b/deployment/terraform/container-service.tf
@@ -1,0 +1,87 @@
+#
+# Security group resources
+#
+resource "aws_security_group" "container_instance" {
+  vpc_id = "${module.vpc.id}"
+
+  tags {
+    Name        = "sgContainerInstance"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# Autoscaling Resources
+#
+data "template_file" "container_instance_cloud_config" {
+  template = "${file("cloud-config/ecs-user-data.yml")}"
+
+  vars {
+    ecs_cluster_name = "${aws_ecs_cluster.container_instance.name}"
+    environment      = "${var.environment}"
+  }
+}
+
+resource "aws_launch_configuration" "container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
+  image_id             = "${var.ecs_instance_ami_id}"
+  instance_type        = "${var.container_instance_type}"
+  key_name             = "${var.aws_key_name}"
+  security_groups      = ["${aws_security_group.container_instance.id}"]
+
+  user_data = "${data.template_file.container_instance_cloud_config.rendered}"
+}
+
+resource "aws_autoscaling_group" "container_instance" {
+  name = "asg${var.environment}ContainerInstance"
+
+  launch_configuration      = "${aws_launch_configuration.container_instance.name}"
+  health_check_grace_period = 600
+  health_check_type         = "EC2"
+  desired_capacity          = "${var.container_instance_asg_desired_capacity}"
+  min_size                  = "${var.container_instance_asg_min_size}"
+  max_size                  = "${var.container_instance_asg_max_size}"
+
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+
+  vpc_zone_identifier = ["${module.vpc.private_subnet_ids}"]
+
+  tag {
+    key                 = "Name"
+    value               = "ContainerInstance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = "${var.project}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.environment}"
+    propagate_at_launch = true
+  }
+}
+
+#
+# ECS Resources
+#
+resource "aws_ecs_cluster" "container_instance" {
+  name = "ecs${var.environment}Cluster"
+}

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -1,0 +1,84 @@
+resource "aws_db_subnet_group" "default" {
+  name        = "${var.rds_database_identifier}"
+  description = "Private subnets for the RDS instances"
+  subnet_ids  = ["${module.vpc.private_subnet_ids}"]
+
+  tags {
+    Name        = "dbsngDatabaseServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_db_parameter_group" "default" {
+  name        = "${var.rds_database_identifier}"
+  description = "Parameter group for the RDS instances"
+  family      = "${var.rds_parameter_group_family}"
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "500"
+  }
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_lock_waits"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_temp_files"
+    value = "500"
+  }
+
+  parameter {
+    name  = "log_autovacuum_min_duration"
+    value = "250"
+  }
+
+  tags {
+    Name        = "dbpgDatabaseServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+module "database" {
+  source                     = "github.com/azavea/terraform-aws-postgresql-rds?ref=2.1.0"
+  vpc_id                     = "${module.vpc.id}"
+  allocated_storage          = "${var.rds_storage_size_gb}"
+  engine_version             = "${var.rds_engine_version}"
+  instance_type              = "${var.rds_instance_type}"
+  storage_type               = "${var.rds_storage_type}"
+  database_identifier        = "${var.rds_database_identifier}"
+  database_name              = "${var.rds_database_name}"
+  database_username          = "${var.rds_username}"
+  database_password          = "${var.rds_password}"
+  database_port              = "${var.rds_database_port}"
+  backup_retention_period    = "${var.rds_backup_retention_period}"
+  backup_window              = "${var.rds_backup_window}"
+  maintenance_window         = "${var.rds_maintenance_window}"
+  multi_availability_zone    = "${var.rds_multi_availability_zone}"
+  storage_encrypted          = "${var.rds_sorage_encrypted}"
+  auto_minor_version_upgrade = "${var.rds_auto_minor_version_upgrade}"
+  subnet_group               = "${aws_db_subnet_group.default.name}"
+  parameter_group            = "${aws_db_parameter_group.default.name}"
+
+  alarm_cpu_threshold         = "${var.rds_alarm_cpu_threshold}"
+  alarm_disk_queue_threshold  = "${var.rds_alarm_disk_queue_threshold}"
+  alarm_free_disk_threshold   = "${var.rds_alarm_free_disk_threshold}"
+  alarm_free_memory_threshold = "${var.rds_alarm_free_memory_threshold}"
+  alarm_actions               = ["${aws_sns_topic.global.arn}"]
+
+  project     = "${var.project}"
+  environment = "${var.environment}"
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,48 @@
+#
+# Private DNS resources
+#
+resource "aws_route53_zone" "internal" {
+  name       = "${var.r53_private_hosted_zone}"
+  vpc_id     = "${module.vpc.id}"
+  vpc_region = "${var.aws_region}"
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_route53_record" "database" {
+  zone_id = "${aws_route53_zone.internal.zone_id}"
+  name    = "database.service.${var.r53_private_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "10"
+  records = ["${module.database.hostname}"]
+}
+
+#
+# Public DNS resources
+#
+resource "aws_route53_zone" "external" {
+  name = "${var.r53_public_hosted_zone}"
+}
+
+resource "aws_route53_record" "bastion" {
+  zone_id = "${aws_route53_zone.external.zone_id}"
+  name    = "bastion.${var.r53_public_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${module.vpc.bastion_hostname}"]
+}
+
+resource "aws_route53_record" "pfb_app" {
+  zone_id = "${aws_route53_zone.external.zone_id}"
+  name    = "${var.r53_public_hosted_zone}"
+  type    = "A"
+
+  alias {
+    name                   = "${lower(aws_alb.pfb_app.dns_name)}"
+    zone_id                = "${aws_alb.pfb_app.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,0 +1,220 @@
+#
+# Bastion security group resources
+#
+resource "aws_security_group_rule" "bastion_ssh_ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.vpc_external_access_cidr_block}"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_ssh_egress" {
+  type              = "egress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${module.vpc.cidr_block}"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_http_egress" {
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_https_egress" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_postgresql_egress" {
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = "${module.vpc.bastion_security_group_id}"
+  source_security_group_id = "${module.database.database_security_group_id}"
+}
+
+#
+# RDS security group resources
+#
+resource "aws_security_group_rule" "postgresql_bastion_ingress" {
+  type      = "ingress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  security_group_id        = "${module.database.database_security_group_id}"
+  source_security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "postgresql_bastion_egress" {
+  type      = "egress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  security_group_id        = "${module.database.database_security_group_id}"
+  source_security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "postgresql_container_instance_ingress" {
+  type      = "ingress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  security_group_id        = "${module.database.database_security_group_id}"
+  source_security_group_id = "${aws_security_group.container_instance.id}"
+}
+
+resource "aws_security_group_rule" "postgresql_container_instance_egress" {
+  type      = "egress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  security_group_id        = "${module.database.database_security_group_id}"
+  source_security_group_id = "${aws_security_group.container_instance.id}"
+}
+
+#
+# API ALB security group resources
+#
+resource "aws_security_group_rule" "alb_pfb_app_http_ingress" {
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = "${var.pfb_app_alb_ingress_cidr_block}"
+
+  security_group_id = "${aws_security_group.pfb_app_alb.id}"
+}
+
+resource "aws_security_group_rule" "alb_pfb_app_https_ingress" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = "${var.pfb_app_alb_ingress_cidr_block}"
+
+  security_group_id = "${aws_security_group.pfb_app_alb.id}"
+}
+
+resource "aws_security_group_rule" "alb_pfb_app_nat_http_ingress" {
+  count = "${length(var.vpc_private_subnet_cidr_blocks)}"
+
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = ["${element(module.vpc.nat_gateway_ips, count.index)}/32"]
+
+  security_group_id = "${aws_security_group.pfb_app_alb.id}"
+}
+
+resource "aws_security_group_rule" "alb_pfb_app_nat_https_ingress" {
+  count = "${length(var.vpc_private_subnet_cidr_blocks)}"
+
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["${element(module.vpc.nat_gateway_ips, count.index)}/32"]
+
+  security_group_id = "${aws_security_group.pfb_app_alb.id}"
+}
+
+resource "aws_security_group_rule" "alb_pfb_app_container_instance_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.pfb_app_alb.id}"
+  source_security_group_id = "${aws_security_group.container_instance.id}"
+}
+
+#
+# Container instance security group resources
+#
+resource "aws_security_group_rule" "container_instance_http_egress" {
+  type        = "egress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.container_instance.id}"
+}
+
+resource "aws_security_group_rule" "container_instance_https_egress" {
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.container_instance.id}"
+}
+
+resource "aws_security_group_rule" "container_instance_postgresql_egress" {
+  type      = "egress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.container_instance.id}"
+  source_security_group_id = "${module.database.database_security_group_id}"
+}
+
+resource "aws_security_group_rule" "container_instance_bastion_ssh_ingress" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.container_instance.id}"
+  source_security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "container_instance_alb_pfb_app_all_ingress" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.container_instance.id}"
+  source_security_group_id = "${aws_security_group.pfb_app_alb.id}"
+}
+
+resource "aws_security_group_rule" "container_instance_alb_pfb_app_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.container_instance.id}"
+  source_security_group_id = "${aws_security_group.pfb_app_alb.id}"
+}
+
+resource "aws_security_group_rule" "container_instance_papertrail_egress" {
+  type        = "egress"
+  from_port   = "${var.papertrail_port}"
+  to_port     = "${var.papertrail_port}"
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.container_instance.id}"
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -1,0 +1,94 @@
+#
+# IAM Resources
+#
+data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "container_instance_ecs_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "container_instance_ses_send_email" {
+  statement {
+    effect = "Allow"
+
+    resources = ["*"]
+    actions   = ["ses:SendRawEmail"]
+  }
+}
+
+#
+# ECS roles
+#
+resource "aws_iam_role" "container_instance_ecs" {
+  name               = "ecs${var.environment}InstanceRole"
+  assume_role_policy = "${data.aws_iam_policy_document.container_instance_ecs_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_for_ec2_policy_pfb_app_ecs_role" {
+  role       = "${aws_iam_role.container_instance_ecs.name}"
+  policy_arn = "${var.aws_ecs_for_ec2_service_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_policy" {
+  role       = "${aws_iam_role.container_instance_ecs.name}"
+  policy_arn = "${var.aws_ecs_service_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy" "ses_send_email" {
+  name   = "SESSendEmail"
+  role   = "${aws_iam_role.container_instance_ecs.id}"
+  policy = "${data.aws_iam_policy_document.container_instance_ses_send_email.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "sqs_read_write" {
+  role       = "${aws_iam_role.container_instance_ecs.name}"
+  policy_arn = "${var.aws_sqs_read_write_policy_arn}"
+}
+
+#
+# EC2 roles
+#
+resource "aws_iam_role" "container_instance_ec2" {
+  name               = "${var.environment}ContainerInstanceProfile"
+  assume_role_policy = "${data.aws_iam_policy_document.container_instance_ec2_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_logs_policy_container_instance_role" {
+  role       = "${aws_iam_role.container_instance_ec2.name}"
+  policy_arn = "${var.aws_cloudwatch_logs_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_s3_policy" {
+  role       = "${aws_iam_role.container_instance_ec2.name}"
+  policy_arn = "${var.aws_s3_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_for_ec2_policy_container_instance_role" {
+  role       = "${aws_iam_role.container_instance_ec2.name}"
+  policy_arn = "${var.aws_ecs_for_ec2_service_role_policy_arn}"
+}
+
+resource "aws_iam_instance_profile" "container_instance" {
+  name  = "${aws_iam_role.container_instance_ec2.name}"
+  roles = ["${aws_iam_role.container_instance_ec2.name}"]
+}

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,0 +1,17 @@
+# VPC module for setting up vpc
+module "vpc" {
+  source                     = "github.com/azavea/terraform-aws-vpc?ref=3.1.1"
+  name                       = "pfb${var.environment}"
+  region                     = "${var.aws_region}"
+  key_name                   = "${var.aws_key_name}"
+  cidr_block                 = "${var.vpc_cidr_block}"
+  external_access_cidr_block = "${var.vpc_external_access_cidr_block}"
+  private_subnet_cidr_blocks = "${var.vpc_private_subnet_cidr_blocks}"
+  public_subnet_cidr_blocks  = "${var.vpc_public_subnet_cidr_blocks}"
+  availability_zones         = "${var.vpc_availibility_zones}"
+  bastion_ami                = "${var.bastion_ami}"
+  bastion_instance_type      = "${var.vpc_bastion_instance_type}"
+
+  project     = "${var.project}"
+  environment = "${var.environment}"
+}

--- a/deployment/terraform/provider.tf
+++ b/deployment/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket" "static" {
+  bucket = "${lower("${var.environment}")}-pfb-static-${var.aws_region}"
+  acl    = "private"
+
+  cors_rule {
+    allowed_origins = ["*"]
+    allowed_methods = ["GET"]
+    max_age_seconds = 3000
+    allowed_headers = ["Authorization"]
+  }
+
+  tags {
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+  }
+}

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -1,0 +1,88 @@
+[
+  {
+    "cpu": 10,
+    "essential": true,
+    "memory": 512,
+    "name": "nginx",
+    "image": "${app_server_nginx_url}",
+    "links": [
+      "django"
+    ],
+    "portMappings": [
+        {
+            "containerPort": 443,
+            "hostPort": 0
+        }
+    ],
+    "logConfiguration": {
+        "logDriver": "syslog",
+        "options": {
+            "syslog-address": "${pfb_app_papertrail_endpoint}",
+            "syslog-tls-ca-cert": "/etc/papertrail-bundle.pem",
+            "tag": "nginx"
+        }
+    }
+  },
+  {
+    "cpu": 10,
+    "essential": true,
+    "memory": 1024,
+    "name": "django",
+    "image": "${app_server_django_url}",
+    "portMappings": [],
+    "environment": [
+      {
+        "name": "DJANGO_ENV",
+        "value": "${django_env}"
+      },
+      {
+        "name": "PFB_SECRET_KEY",
+        "value": "${django_secret_key}"
+      },
+      {
+        "name": "PFB_DB_HOST",
+        "value": "${rds_host}"
+      },
+      {
+        "name": "PFB_DB_PORT",
+        "value": "5432"
+      },
+      {
+        "name": "PFB_DB_PASSWORD",
+        "value": "${rds_password}"
+      },
+      {
+        "name": "PFB_DB_USER",
+        "value": "${rds_username}"
+      },
+      {
+        "name": "PFB_DB_DATABASE",
+        "value": "${rds_database_name}"
+      },
+      {
+        "name": "AWS_DEFAULT_REGION",
+        "value": "${aws_region}"
+      },
+      {
+        "name": "PFB_S3STORAGE_BUCKET",
+        "value": "${s3_storage_bucket}"
+      },
+      {
+        "name": "PFB_ALLOWED_HOSTS",
+        "value": "${django_allowed_hosts}"
+      },
+      {
+        "name": "COMMIT",
+        "value": "${git_commit}"
+      }
+    ],
+    "logConfiguration": {
+          "logDriver": "syslog",
+          "options": {
+              "syslog-address": "${pfb_app_papertrail_endpoint}",
+              "syslog-tls-ca-cert": "/etc/papertrail-bundle.pem",
+              "tag": "django"
+          }
+      }
+  }
+]

--- a/deployment/terraform/task-definitions/management.json
+++ b/deployment/terraform/task-definitions/management.json
@@ -1,0 +1,70 @@
+[
+  {
+    "cpu": 0,
+    "memory": 2048,
+    "entryPoint": [
+      "./manage.py"
+    ],
+    "mountPoints": [],
+    "name": "management",
+    "image": "${management_url}",
+    "environment": [
+      {
+        "name": "DJANGO_ENV",
+        "value": "${django_env}"
+      },
+      {
+        "name": "PFB_SECRET_KEY",
+        "value": "${django_secret_key}"
+      },
+      {
+        "name": "PFB_DB_HOST",
+        "value": "${rds_host}"
+      },
+      {
+        "name": "PFB_DB_PORT",
+        "value": "5432"
+      },
+      {
+        "name": "PFB_DB_PASSWORD",
+        "value": "${rds_password}"
+      },
+      {
+        "name": "PFB_DB_USER",
+        "value": "${rds_username}"
+      },
+      {
+        "name": "PFB_DB_DATABASE",
+        "value": "${rds_database_name}"
+      },
+      {
+        "name": "AWS_DEFAULT_REGION",
+        "value": "${aws_region}"
+      },
+      {
+        "name": "PFB_S3STORAGE_BUCKET",
+        "value": "${s3_storage_bucket}"
+      },
+      {
+        "name": "PFB_ALLOWED_HOSTS",
+        "value": "${django_allowed_hosts}"
+      },
+      {
+        "name": "COMMIT",
+        "value": "${git_commit}"
+      },
+      {
+        "name": "DJANGO_LOG_LEVEL",
+        "value": "INFO"
+      }
+    ],
+    "logConfiguration": {
+        "logDriver": "syslog",
+        "options": {
+            "syslog-address": "${pfb_app_papertrail_endpoint}",
+            "syslog-tls-ca-cert": "/etc/papertrail-bundle.pem",
+            "tag": "management"
+        }
+    }
+  }
+]

--- a/deployment/terraform/task-definitions/nginx.json
+++ b/deployment/terraform/task-definitions/nginx.json
@@ -1,0 +1,29 @@
+[
+  {
+    "cpu": 10,
+    "essential": true,
+    "image": "${app_server_nginx_url}",
+    "extraHosts": [
+        {
+            "hostname": "django",
+            "ipAddress": "127.0.0.1"
+        }
+    ],
+    "memory": 256,
+    "name": "nginx",
+    "portMappings": [
+        {
+            "containerPort": 80,
+            "hostPort": 0
+        }
+    ],
+    "logConfiguration": {
+        "logDriver": "syslog",
+        "options": {
+            "syslog-address": "${pfb_app_papertrail_endpoint}",
+            "syslog-tls-ca-cert": "/etc/papertrail-bundle.pem",
+            "tag": "nginx-redirect"
+        }
+    }
+  }
+]

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,119 @@
+# Variables stored in S3 for each environment
+# This file defines which variables must be
+# defined in order to run terraform
+
+variable "project" {
+  default = "PFB Network Connectivity"
+}
+
+variable "aws_account_id" {
+  default = "950872791630"
+}
+
+variable "aws_region" {}
+# Must be one of release, staging, production
+variable "environment" {}
+
+variable "bastion_ami" {
+  default = "ami-f5f41398"
+}
+
+variable "r53_private_hosted_zone" {}
+variable "r53_public_hosted_zone" {}
+
+# Scaling
+variable "container_instance_asg_desired_capacity" {}
+variable "container_instance_asg_min_size" {}
+variable "container_instance_asg_max_size" {}
+variable "container_instance_type" {}
+variable "aws_key_name" {}
+variable "ecs_instance_ami_id" {}
+
+# ECS
+## HTTP API server
+variable "pfb_app_http_ecs_desired_count" {}
+variable "pfb_app_http_ecs_deployment_min_percent" {}
+variable "pfb_app_http_ecs_deployment_max_percent" {}
+
+## HTTPS API server
+variable "pfb_app_https_ecs_deployment_max_percent" {}
+variable "pfb_app_https_ecs_desired_count" {}
+variable "pfb_app_https_ecs_deployment_min_percent" {}
+
+# IAM
+variable "aws_ecs_for_ec2_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+variable "aws_ecs_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+}
+
+variable "aws_s3_policy_arn" {
+  default = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+variable "aws_sqs_read_write_policy_arn" {
+  default = "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
+}
+
+# Variables that must be defined for VPC
+variable "vpc_cidr_block" {}
+
+variable "vpc_private_subnet_cidr_blocks" {
+  type = "list"
+}
+
+variable "vpc_public_subnet_cidr_blocks" {
+  type = "list"
+}
+
+variable "vpc_external_access_cidr_block" {}
+variable "vpc_bastion_instance_type" {}
+
+variable "vpc_availibility_zones" {
+  type = "list"
+}
+
+#variable "ecs_iam_role" {}
+#variable "ecs_iam_profile" {}
+variable "git_commit" {}
+
+# RDS
+variable "rds_storage_size_gb" {}
+variable "rds_engine_version" {}
+variable "rds_instance_type" {}
+variable "rds_storage_type" {}
+variable "rds_database_identifier" {}
+variable "rds_database_name" {}
+variable "rds_username" {}
+variable "rds_password" {}
+variable "rds_database_port" {}
+variable "rds_backup_retention_period" {}
+variable "rds_parameter_group_family" {}
+variable "rds_backup_window" {}
+variable "rds_maintenance_window" {}
+variable "rds_multi_availability_zone" {}
+variable "rds_sorage_encrypted" {}
+variable "rds_auto_minor_version_upgrade" {}
+variable "rds_alarm_cpu_threshold" {}
+variable "rds_alarm_disk_queue_threshold" {}
+variable "rds_alarm_free_disk_threshold" {}
+variable "rds_alarm_free_memory_threshold" {}
+
+variable "django_env" {}
+variable "django_secret_key" {}
+variable "django_allowed_hosts" {}
+
+variable "papertrail_host" {}
+variable "papertrail_port" {}
+
+variable "ssl_certificate_arn" {}
+
+variable "aws_cloudwatch_logs_policy_arn" {
+  default = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+}
+
+variable "pfb_app_alb_ingress_cidr_block" {
+  type = "list"
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
 
   django:
-    image: pfb-django:${GIT_COMMIT}
+    image: pfb-app:${GIT_COMMIT}
     build:
       context: ./src/django
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./src/nginx/srv/dist:/srv/dist:ro
 
   django:
-    image: pfb-django
+    image: pfb-app
     extends:
       service: django
       file: common.yml
@@ -31,15 +31,6 @@ services:
       - database:database.service.pfb.internal
     environment:
       - DEV_USER
-
-# TODO: Re-add this container once the SQS broker is setup (issue #20)
-  # celery:
-  #   image: pfb-django
-  #   extends:
-  #     service: celery
-  #     file: common.yml
-  #   links:
-  #     - database:database.service.pfb.internal
 
   angularjs:
     image: pfb-angularjs

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+
+Publish container images to Elastic Container Registry (ECR) and
+other artifacts to S3.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+
+DIR="$(dirname "$0")"
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        if [[ -n "${PFB_AWS_ECR_ENDPOINT}" ]]; then
+            # Evaluate the return value of the get-login subcommand, which
+            # is a docker login command with temporarily ECR credentials.
+            eval "$(aws ecr get-login)"
+
+            docker tag "pfb-nginx:${GIT_COMMIT}" \
+                   "${PFB_AWS_ECR_ENDPOINT}/pfb-nginx:${GIT_COMMIT}"
+            docker tag "pfb-app:${GIT_COMMIT}" \
+                   "${PFB_AWS_ECR_ENDPOINT}/pfb-app:${GIT_COMMIT}"
+
+            docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-nginx:${GIT_COMMIT}"
+            docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-app:${GIT_COMMIT}"
+
+            echo "Uploading static files to S3..."
+            PFB_S3STORAGE_BUCKET="${PFB_S3STORAGE_BUCKET}" \
+            GIT_COMMIT="${GIT_COMMIT}" \
+            docker-compose \
+                -f docker-compose.yml \
+                -f docker-compose.test.yml \
+                run --rm --no-deps --entrypoint "./manage.py" \
+                django collectstatic --noinput
+
+            echo "Upload complete!"
+
+        else
+            echo "ERROR: No PFB_AWS_ECR_ENDPOINT variable defined."
+            exit 1
+        fi
+    fi
+fi

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+set -u
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        TERRAFORM_DIR="${DIR}/../deployment/terraform"
+        echo
+        echo "Attempting to deploy application version [${GIT_COMMIT}]..."
+        echo "-----------------------------------------------------"
+        echo
+    fi
+
+    if [[ -n "${PFB_SETTINGS_BUCKET}" ]]; then
+        pushd "${TERRAFORM_DIR}"
+
+        # Stop Terraform from trying to apply incorrect state across environments
+        if [ -f ".terraform/terraform.tfstate" ] && ! grep -q "${PFB_SETTINGS_BUCKET}" ".terraform/terraform.tfstate"; then
+            echo "ERROR: Incorrect target environment detected in Terraform state! Please run"
+            echo "       the following command before proceeding:"
+            echo
+            echo "  rm -rf terraform/.terraform"
+            echo
+           exit 1
+        fi
+
+        aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${PFB_SETTINGS_BUCKET}.tfvars"
+
+        terraform remote config \
+                  -backend="s3" \
+                  -backend-config="region=us-east-1" \
+                  -backend-config="bucket=${PFB_SETTINGS_BUCKET}" \
+                  -backend-config="key=terraform/state" \
+                  -backend-config="encrypt=true"
+
+        case "${1}" in
+            fmt)
+                terraform "$@"
+                ;;
+            taint)
+                terraform "$@"
+                ;;
+            remote-push)
+                terraform remote push
+                ;;
+            plan)
+                terraform get -update
+                terraform plan \
+                          -var-file="${PFB_SETTINGS_BUCKET}.tfvars" \
+                          -var="git_commit=${GIT_COMMIT}" \
+                          -out="${PFB_SETTINGS_BUCKET}.tfplan"
+                ;;
+            apply)
+                terraform apply "${PFB_SETTINGS_BUCKET}.tfplan"
+                terraform remote push
+                ;;
+            *)
+                echo "ERROR: I don't have support for that Terraform subcommand!"
+                exit 1
+                ;;
+        esac
+
+        popd
+    else
+        echo "ERROR: No PFB_SETTINGS_BUCKET variable defined."
+        exit 1
+    fi
+fi

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = [
     'django_filters',
     'rest_framework',
     'rest_framework.authtoken',
+    'watchman',
 
     # project apps
     'pfb_network_connectivity',
@@ -216,6 +217,14 @@ REST_FRAMEWORK = {
     ],
     'PAGE_SIZE': 20
 }
+
+# Watchman
+# http://django-watchman.readthedocs.io/en/latest/
+WATCHMAN_ERROR_CODE = 503
+WATCHMAN_CHECKS = (
+    'watchman.checks.databases',
+)
+
 
 # Email
 DEFAULT_FROM_EMAIL = 'noreply@pfb.azavea.com'

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -14,6 +14,8 @@ from datetime import timedelta
 import os
 import logging.config
 
+import requests
+
 from django.core.exceptions import ImproperlyConfigured
 
 
@@ -26,14 +28,28 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 DJANGO_ENV = os.getenv('DJANGO_ENV', 'development')
 
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+SECRET_KEY = os.getenv('PFB_SECRET_KEY', 'SECRET_KEY_R$^3Pc135NUbst4OIt$Kzrd5zqLo$1h4')
+if DJANGO_ENV not in ('development', 'testing') and SECRET_KEY.startswith('SECRET_KEY'):
+    raise ImproperlyConfigured('Non-development environments require that env.PFB_SECRET_KEY ' +
+                               'be set')
 
 DEV_USER = os.getenv('DEV_USER')
 
 DEBUG = DJANGO_ENV == 'development'
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.getenv('PFB_ALLOWED_HOSTS', '').split(',')
+if '' in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.remove('')
 
+# solution from https://dryan.com/articles/elb-django-allowed-hosts/
+EC2_PRIVATE_IP = None
+try:
+    EC2_PRIVATE_IP = requests.get('http://169.254.169.254/latest/meta-data/local-ipv4',
+                                  timeout=0.1).text
+except requests.exceptions.RequestException:
+    pass
+if EC2_PRIVATE_IP:
+    ALLOWED_HOSTS.append(EC2_PRIVATE_IP)
 
 # Application definition
 
@@ -94,11 +110,11 @@ WSGI_APPLICATION = 'pfb_network_connectivity.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': os.getenv('PGDATABASE'),
-        'USER': os.getenv('PGUSER'),
-        'PASSWORD': os.getenv('PGPASSWORD'),
-        'HOST': os.getenv('PGHOST'),
-        'PORT': os.getenv('PGPORT', 5432)
+        'NAME': os.getenv('PFB_DB_DATABASE', 'pfb'),
+        'USER': os.getenv('PFB_DB_USER', 'pfb'),
+        'PASSWORD': os.getenv('PFB_DB_PASSWORD', 'pfb'),
+        'HOST': os.getenv('PFB_DB_HOST', 'database.service.pfb.internal'),
+        'PORT': os.getenv('PFB_DB_PORT', 5432)
     }
 }
 

--- a/src/django/pfb_network_connectivity/urls.py
+++ b/src/django/pfb_network_connectivity/urls.py
@@ -43,6 +43,8 @@ urlpatterns = [
     url(r'^api/request-password-reset/', user_views.PFBRequestPasswordReset.as_view()),
     url(r'^api/reset-password/', user_views.PFBResetPassword.as_view()),
 
+    # 3rd party
+    url(r'^healthcheck/', include('watchman.urls'))
 ]
 
 if settings.DEBUG:

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -3,3 +3,4 @@ django-filter==1.0.1
 celery[sqs]==4.0
 boto==2.45.0
 django-extensions==1.7.6
+requests==2.13.0

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -3,4 +3,5 @@ django-filter==1.0.1
 celery[sqs]==4.0
 boto==2.45.0
 django-extensions==1.7.6
+django-watchman==0.11.1
 requests==2.13.0

--- a/src/nginx/etc/nginx/nginx.conf
+++ b/src/nginx/etc/nginx/nginx.conf
@@ -29,11 +29,10 @@ http {
     gzip_types application/javascript text/css application/json;
     gzip_disable "msie6";
 
-    # TODO: Update these as necessary for ECS environment
     set_real_ip_from 10.0.0.0/24;
     set_real_ip_from 10.0.2.0/24;
-    set_real_ip_from 10.0.4.0/24;
-    set_real_ip_from 10.0.6.0/24;
+    set_real_ip_from 10.0.1.0/24;
+    set_real_ip_from 10.0.3.0/24;
 
     real_ip_header X-Forwarded-For;
 


### PR DESCRIPTION
## Overview

Adds the terraform tooling necessary to deploy the staging environment to AWS.

Not much there, just the healthcheck and an API you can't log into yet because I haven't run migrations, which I will do in a bit.

## Demo

https://staging.pfb.azavea.com

## Notes

Peripheral stuff I had to add:
- django-watchman for the healthcheck endpoint
- Fixup settings.py to properly set things based on the actual ENV variables
- Remaining scripts to rule them all
- Update Jenkinsfile (currently untested)

## Testing

After following instructions to set env properly in deployment/README.md, a `./scripts/infra plan` should show no assets to update