### PR TITLE
Push analysis container to ECR repository on CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In this example, we configure the analysis to be run for Cambridge MA.
 Run:
 ```
 pushd pfb-analysis
-docker build -t pfb .
+docker build -t pfb-analysis .
 popd
 
 docker run \
@@ -68,9 +68,9 @@ docker run \
     -e PFB_STATE=ma \
     -e PFB_STATE_FIPS=25 \
     -e NB_INPUT_SRID=2249 \
-    -e NB_BOUNDARY_BUFFER=11000 \
+    -e NB_BOUNDARY_BUFFER=3600 \
     -v /vagrant/data/:/data/ \
-    pfb
+    pfb-analysis
 ```
 
 This will take up to 1hr, so just let it work. Consider piping script output to a file and running in
@@ -101,7 +101,7 @@ docker run \
     -e PFB_STATE=<state abbrev> \
     -e PFB_STATE_FIPS=<state fips> \
     -e NB_INPUT_SRID=<input srid> \
-    -e NB_BOUNDARY_BUFFER=<buffer distance in units of NB_OUTPUT_SRID> \
+    -e NB_BOUNDARY_BUFFER=<buffer distance in meters> \
     -v /vagrant/data/:/data/ \
-    pfb
+    pfb-analysis
 ```

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -44,5 +44,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -f "${DIR}/../docker-compose.yml" \
                   -f "${DIR}/../docker-compose.test.yml" \
                   build
+
+        echo "Building pfb-analysis container image"
+        pushd pfb-analysis
+        GIT_COMMIT="${GIT_COMMIT}" docker build -t "pfb-analysis:${GIT_COMMIT}" .
+        popd
     fi
 fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -37,9 +37,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                    "${PFB_AWS_ECR_ENDPOINT}/pfb-nginx:${GIT_COMMIT}"
             docker tag "pfb-app:${GIT_COMMIT}" \
                    "${PFB_AWS_ECR_ENDPOINT}/pfb-app:${GIT_COMMIT}"
+            docker tag "pfb-analysis:${GIT_COMMIT}" \
+                   "${PFB_AWS_ECR_ENDPOINT}/pfb-analysis:${GIT_COMMIT}"
 
             docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-nginx:${GIT_COMMIT}"
             docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-app:${GIT_COMMIT}"
+            docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-analysis:${GIT_COMMIT}"
 
             echo "Uploading static files to S3..."
             PFB_S3STORAGE_BUCKET="${PFB_S3STORAGE_BUCKET}" \


### PR DESCRIPTION
## Overview

Builds and pushes the pfb-analysis container, formerly tagged as `pfb` to a new `pfb-analysis` ECR endpoint.

I renamed the `pfb` container in the README to keep naming conventions consistent.

## Testing

Log into AWS and check to ensure that a tagged container exists in the pfb-analysis registry.