### PR TITLE
`work_mem` and checkpoint-related database settings

### DIFF
--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -57,5 +57,5 @@ EOF
 bash
 
 # shutdown postgres
-kill $POSTGRES_PROC
+su postgres -c "/usr/lib/postgresql/9.6/bin/pg_ctl stop"
 wait

--- a/pfb-analysis/scripts/run_connectivity.sh
+++ b/pfb-analysis/scripts/run_connectivity.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export SHELL  # makes 'parallel' stop complaining about $SHELL being unset
+
 cd `dirname $0`
 
 NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -6,11 +6,16 @@ NB_POSTGRESQL_DB=pfb
 NB_POSTGRESQL_USER=gis
 NB_POSTGRESQL_PASSWORD=gis
 
+# Set defaults for overridable configuration params
+PFB_WORK_MEM="${PFB_WORK_MEM:-2048MB}"
+PFB_CHECKPOINT_COMPLETION="${PFB_CHECKPOINT_COMPLETION:-0.8}"
+PFB_MAX_WAL_SIZE="${PFB_MAX_WAL_SIZE:-2GB}"
+
 # Set configuration parameters
 su postgres bash -c psql <<EOF
-ALTER SYSTEM SET work_mem TO '4096MB';
-ALTER SYSTEM SET checkpoint_completion_target TO 0.8;
-ALTER SYSTEM SET max_wal_size TO '5GB';
+ALTER SYSTEM SET work_mem TO '${PFB_WORK_MEM}';
+ALTER SYSTEM SET checkpoint_completion_target TO ${PFB_CHECKPOINT_COMPLETION};
+ALTER SYSTEM SET max_wal_size TO '${PFB_MAX_WAL_SIZE}';
 EOF
 
 # set up database

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -6,6 +6,13 @@ NB_POSTGRESQL_DB=pfb
 NB_POSTGRESQL_USER=gis
 NB_POSTGRESQL_PASSWORD=gis
 
+# Set configuration parameters
+su postgres bash -c psql <<EOF
+ALTER SYSTEM SET work_mem TO '4096MB';
+ALTER SYSTEM SET checkpoint_completion_target TO 0.8;
+ALTER SYSTEM SET max_wal_size TO '5GB';
+EOF
+
 # set up database
 su postgres bash -c psql <<EOF
 CREATE USER ${NB_POSTGRESQL_USER} WITH PASSWORD '${NB_POSTGRESQL_PASSWORD}';

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -8,9 +8,9 @@ NB_POSTGRESQL_PASSWORD=gis
 
 # set up database
 su postgres bash -c psql <<EOF
-CREATE USER gis WITH PASSWORD 'gis';
-ALTER USER gis WITH SUPERUSER;
-CREATE DATABASE pfb WITH OWNER gis ENCODING 'UTF-8';
+CREATE USER ${NB_POSTGRESQL_USER} WITH PASSWORD '${NB_POSTGRESQL_PASSWORD}';
+ALTER USER ${NB_POSTGRESQL_USER} WITH SUPERUSER;
+CREATE DATABASE ${NB_POSTGRESQL_DB} WITH OWNER ${NB_POSTGRESQL_USER} ENCODING 'UTF-8';
 EOF
 
 # install extensions
@@ -22,5 +22,5 @@ CREATE EXTENSION "plpythonu";
 CREATE EXTENSION "pgrouting";
 CREATE EXTENSION "quantile";
 CREATE EXTENSION "tdg";
-ALTER USER gis SET search_path TO generated,received,scratch,"\$user",tdg,public;
+ALTER USER ${NB_POSTGRESQL_USER} SET search_path TO generated,received,scratch,"\$user",tdg,public;
 EOF


### PR DESCRIPTION
A few tiny tweaks, plus...

Adds some configuration commands to setup_database.sh that:
- per issue #90, increases work_mem (by a lot--4mb to 4gb)
- per issue #76, makes checkpoints happen less frequently
    Note that this used to be controlled by `checkpoint_segments` but is
    now (as of Postgres 9.6) mainly a function of `max_wal_size`.
- Related to checkpoints, I also increased `checkpoint_completion_target`
  which should have the effect of reducing write bottlenecks at the cost
  off less robust crash recovery (which I don't think we care much
  about in this context)