### PR TITLE
Add -I flag to shp2pgsql calls to build spatial index on tables

### DIFF
--- a/pfb-analysis/import/import_neighborhood.sh
+++ b/pfb-analysis/import/import_neighborhood.sh
@@ -51,7 +51,7 @@ then
         NB_STATE_FIPS="${2}"
 
         # Import neighborhood boundary
-        shp2pgsql -d -s "${NB_INPUT_SRID}":"${NB_OUTPUT_SRID}" "${NB_BOUNDARY_FILE}" neighborhood_boundary \
+        shp2pgsql -I -d -s "${NB_INPUT_SRID}":"${NB_OUTPUT_SRID}" "${NB_BOUNDARY_FILE}" neighborhood_boundary \
             | psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}"
 
         # Get blocks for the state requested
@@ -61,7 +61,7 @@ then
 
         # Import block shapefile
         echo "START: Importing blocks"
-        shp2pgsql -d -s 4326:"${NB_OUTPUT_SRID}" "${NB_TEMPDIR}/${NB_BLOCK_FILENAME}.shp" neighborhood_census_blocks \
+        shp2pgsql -I -d -s 4326:"${NB_OUTPUT_SRID}" "${NB_TEMPDIR}/${NB_BLOCK_FILENAME}.shp" neighborhood_census_blocks \
             | psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" > /dev/null
         echo "DONE: Importing blocks"
 


### PR DESCRIPTION
I noticed we're not building a spatial index on the neighborhood or the census tables when we import them. It's possible these are being built elsewhere, but it seems easiest to build them on import with the -I flag.