### PR TITLE
Enable local copies of downloads

### DIFF
--- a/pfb-analysis/import/import_jobs.sh
+++ b/pfb-analysis/import/import_jobs.sh
@@ -38,8 +38,12 @@ function import_job_data() {
     NB_DATA_TYPE="${2-main}"    # Either 'main' or 'aux'
     NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2014.csv"
 
-    wget -P "${NB_TEMPDIR}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
-    gunzip -c "${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz" > "${NB_TEMPDIR}/${NB_JOB_FILENAME}"
+    if [[ -f "/data/${NB_JOB_FILENAME}.gz" ]]; then
+        gunzip -c "/data/${NB_JOB_FILENAME}.gz" > "${NB_TEMPDIR}/${NB_JOB_FILENAME}"
+    else
+        wget -P "${NB_TEMPDIR}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
+        gunzip -c "${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz" > "${NB_TEMPDIR}/${NB_JOB_FILENAME}"
+    fi
 
     # Import to postgresql
     psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \

--- a/pfb-analysis/import/import_neighborhood.sh
+++ b/pfb-analysis/import/import_neighborhood.sh
@@ -56,8 +56,12 @@ then
 
         # Get blocks for the state requested
         NB_BLOCK_FILENAME="tabblock2010_${NB_STATE_FIPS}_pophu"
-        wget -P "${NB_TEMPDIR}" "http://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/${NB_BLOCK_FILENAME}.zip"
-        unzip "${NB_TEMPDIR}/${NB_BLOCK_FILENAME}.zip" -d "${NB_TEMPDIR}"
+        if [[ -f "/data/${NB_BLOCK_FILENAME}.zip" ]]; then
+            unzip "/data/${NB_BLOCK_FILENAME}.zip" -d "${NB_TEMPDIR}"
+        else
+            wget -P "${NB_TEMPDIR}" "http://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/${NB_BLOCK_FILENAME}.zip"
+            unzip "${NB_TEMPDIR}/${NB_BLOCK_FILENAME}.zip" -d "${NB_TEMPDIR}"
+        fi
 
         # Import block shapefile
         echo "START: Importing blocks"

--- a/pfb-analysis/import/import_osm.sh
+++ b/pfb-analysis/import/import_osm.sh
@@ -58,11 +58,18 @@ BBOX_SW_LAT=`bc <<< "$BBOX_SW_LAT - $LAT_DIFF"`
 BBOX_SW_LNG=`bc <<< "$BBOX_SW_LNG - $LNG_DIFF"`
 BBOX_NE_LAT=`bc <<< "$BBOX_NE_LAT + $LAT_DIFF"`
 BBOX_NE_LNG=`bc <<< "$BBOX_NE_LNG + $LNG_DIFF"`
-# Download OSM data
-OSM_API_URL="http://www.overpass-api.de/api/xapi?*[bbox=${BBOX_SW_LNG},${BBOX_SW_LAT},${BBOX_NE_LNG},${BBOX_NE_LAT}]"
-OSM_TEMPDIR=`mktemp -d`
-OSM_DATA_FILE="${OSM_TEMPDIR}/overpass.osm"
-wget -O "${OSM_DATA_FILE}" "${OSM_API_URL}"
+
+if [[ -f ${1} ]]; then
+  echo "Importing provided OSM file"
+  OSM_DATA_FILE=${1}
+else
+  echo "Downloading OSM data"
+  # Download OSM data
+  OSM_API_URL="http://www.overpass-api.de/api/xapi?*[bbox=${BBOX_SW_LNG},${BBOX_SW_LAT},${BBOX_NE_LNG},${BBOX_NE_LAT}]"
+  OSM_TEMPDIR=`mktemp -d`
+  OSM_DATA_FILE="${OSM_TEMPDIR}/overpass.osm"
+  wget -O "${OSM_DATA_FILE}" "${OSM_API_URL}"
+fi
 
 # import the osm with highways
 osm2pgrouting \

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -44,7 +44,7 @@ cd /pfb
 # determine coordinate reference system based on input shapefile UTM zone
 export NB_OUTPUT_SRID="$(./scripts/detect_utm_zone.py $PFB_SHPFILE)"
 
-./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS
+./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS $PFB_OSM_FILE
 ./scripts/run_connectivity.sh
 
 # print scores (TODO: replace with export script)

--- a/pfb-analysis/scripts/import.sh
+++ b/pfb-analysis/scripts/import.sh
@@ -27,6 +27,6 @@ then
     else
         ../import/import_neighborhood.sh "${1}" "${3}"
         ../import/import_jobs.sh "${2}"
-        ../import/import_osm.sh
+        ../import/import_osm.sh "${4}"
     fi
 fi


### PR DESCRIPTION
These are changes I made in the course of working on PR #107 because I got tired of waiting for the downloads over and over (the PA tabblock file is 247MB...), and they seem useful enough and harmless enough to commit.

For the jobs and blocks files, this just makes it so that if the exact filename the script is looking to download already exists in the `data` directory, it will use that.  If it doesn't, it acts normally.  It doesn't copy the script once downloaded into the data dir to be used for next time, just uses it if it's there, so to take advantage of this you have to download it manually (or copy it out of a container that downloaded it, but that's tricky because it gets deleted as soon as it's been used...).

For the OSM file, since it's based on the boundary rather than being standard for a state, this adds an environment variable `PFB_OSM_FILE` that will be used if provided in lieu of downloading from Overpass.  This has the added benefits of reducing requests to Overpass and allowing us to do multiple runs for comparison without the risk that changes to live OSM data would affect the results.