### PR TITLE
Run export connectivity in docker analysis

### DIFF
--- a/pfb-analysis/import/import_jobs.sh
+++ b/pfb-analysis/import/import_jobs.sh
@@ -35,7 +35,7 @@ NB_POSTGRESQL_PASSWORD - Default: gis
 function import_job_data() {
     NB_TEMPDIR=`mktemp -d`
     NB_STATE_ABBREV="${1}"
-    NB_DATA_TYPE="${2-main}"    # Either 'main' or 'aux'
+    NB_DATA_TYPE="${2:-main}"    # Either 'main' or 'aux'
     NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2014.csv"
 
     if [[ -f "/data/${NB_JOB_FILENAME}.gz" ]]; then

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -46,6 +46,7 @@ export NB_OUTPUT_SRID="$(./scripts/detect_utm_zone.py $PFB_SHPFILE)"
 
 ./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS $PFB_OSM_FILE
 ./scripts/run_connectivity.sh
+./scripts/export_connectivity.sh $NB_OUTPUT_DIR
 
 # print scores (TODO: replace with export script)
 psql -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" <<EOF

--- a/pfb-analysis/scripts/export_connectivity.sh
+++ b/pfb-analysis/scripts/export_connectivity.sh
@@ -74,7 +74,9 @@ then
     then
         ec_usage
     else
+        echo "Exporting analysis to ${NB_OUTPUT_DIR}"
         NB_OUTPUT_DIR="${1}"
+        mkdir -p "${NB_OUTPUT_DIR}"
 
         # Export neighborhood_ways as SHP
         ec_export_table_shp "${NB_OUTPUT_DIR}" "neighborhood_ways"


### PR DESCRIPTION
Connects #80.

Adds export_connectivity.sh to entrypoint.sh, using `NB_OUTPUT_DIR`.

Notes:
- It doesn't define a default nor does it raise an error at the beginning of the run if the variable isn't set. This could be a pain, since we could run analyses and then end up not getting the results, but on the other hand once we've built further tooling around running the analysis it might not be a problem in practice.  In any case there are ways to get into an image and re-run the export if necessary.
- It does, however, run `mkdir -p NB_OUTPUT_DIR`, so if you give it a path that doesn't exist but does make sense, it create and use that directory (regular mkdir throws an error if a directory already exists, but with `-p` it's fine)
- This branch also includes a change to `import_neighborhood.sh` to speed up how the boundary and census blocks shapefiles get loaded.
- With that and the "pre-downloaded files" trick in PR #112, it's possible to run the littlest analysis run in, on my machine, 2 minutes.

***The littlest analysis run***
Not intended to produce useful or correct results, but it provides a way to test the basic functionality of options and code changes (i.e. whether things run and produce results) without having to wait forever.  (Except it doesn't produce school results. There are schools in the OSM data but I don't think any of them are actually inside the boundary+tiny buffer.)

Steps:
1. Get `gtown_westside.osm` and `gtown_westside.zip` from the fileshare, copying the former and extracting the latter into your `data` directory.
2. In a shell in your `data` directory, run:
```
wget http://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/tabblock2010_42_pophu.zip
wget http://lehd.ces.census.gov/data/lodes/LODES7/pa/od/pa_od_aux_JT00_2014.csv.gz
wget http://lehd.ces.census.gov/data/lodes/LODES7/pa/od/pa_od_main_JT00_2014.csv.gz
```
3. In `/vagrant/` in the VM, run:
```
docker run -e PFB_SHPFILE=/data/gtown_westside.shp -e PFB_STATE=pa -e PFB_STATE_FIPS=42 \
    -e NB_INPUT_SRID=4326 -e NB_BOUNDARY_BUFFER=50 \
    -e PFB_OSM_FILE=/data/gtown_westside.osm -e NB_OUTPUT_DIR=/data/output \
    -v /vagrant/data/:/data/ pfb-analysis
```