### PR TITLE
Add helper script to clean up old pfb-analysis docker containers/volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ a screen/tmux session.
 If you want to run a different neighborhood, simply rerun the `docker run` command with the
 appropriate arguments, which are described below, in [Importing other neighborhoods](#importing-other-neighborhoods).
 
+#### Cleaning up old analysis runs
+
+Each analysis run takes up a significant amount of limited VM disk space. To clear old analysis volumes once finished with them, run:
+```
+./scripts/clean-analysis-volumes
+```
+
 
 ## Importing other neighborhoods
 

--- a/pfb-analysis/Dockerfile
+++ b/pfb-analysis/Dockerfile
@@ -1,5 +1,6 @@
 FROM quay.io/azavea/postgis:postgres9.6-postgis2.3
 MAINTAINER Azavea
+LABEL type=pfb-analysis
 
 ENV GIT_BRANCH_OSM2PGROUTING osm2pgrouting-2.1.0
 ENV GIT_BRANCH_OSM2PGSQL 0.90.1

--- a/scripts/clean-analysis-volumes
+++ b/scripts/clean-analysis-volumes
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname "${0}")
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+
+Removes all 'pfb-analysis' docker containers and their volumes to free up storage space,
+as well as any dangling docker volumes.
+
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        FILTERS='--filter "label=type=pfb-analysis" --filter "status=exited"'
+
+        echo "The following containers and their volumes will be deleted:"
+        eval docker ps -a $FILTERS
+        echo "The following dangling docker volumes will be deleted:"
+        docker volume ls -f 'dangling=true'
+
+        read -r -p "Are you sure? [y/N] " response
+        response=${response,,}    # tolower
+        if [[ "$response" =~ ^(yes|y)$ ]]
+        then
+            docker rm -v $(eval docker ps -aq $FILTERS)
+            docker volume rm $(docker volume ls -f 'dangling=true' -q)
+        fi
+    fi
+fi


### PR DESCRIPTION
## Overview

Adds helper script to easily cleanup old pfb-analysis docker containers/volumes that take up large amounts of the limited disk space available to the VM.

## Demo

```
vagrant@pfb-network-connectivity:/vagrant$ ./scripts/clean-analysis-volumes
This script will delete the following containers:
CONTAINER ID        IMAGE                COMMAND                  CREATED             STATUS                          PORTS               NAMES
8208464a6078        pfb-analysis-label   "/bin/sh -c /pfb/scri"   3 minutes ago       Exited (0) About a minute ago                       focused_sammet
Are you sure? [y/N] y
8208464a6078
vagrant@pfb-network-connectivity:/vagrant$
vagrant@pfb-network-connectivity:/vagrant$
vagrant@pfb-network-connectivity:/vagrant$ docker ps -a --filter "label=type=pfb-analysis"
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
vagrant@pfb-network-connectivity:/vagrant$
```

## Testing

- Create and run a new analysis using the new iteration of the Dockerfile
- After completion, run `./scripts/clean-analysis-volumes`. The script should ask for confirmation and then delete the old volumes.
- Verify the container/volumes no longer exist with `docker ps -a --filter "label=type=pfb-analysis"`