### PR TITLE
Feature/awf/fix docker analysis

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -35,6 +35,7 @@ postgis_package_version: "2.3.1+dfsg-1.pgdg14.04+1"
 # azavea.docker
 # 1.11.* to match AWS ECS
 docker_version: 1.11.*
+docker_options: "--storage-opt dm.basesize=20G"
 
 # azavea.terraform
 terraform_version: 0.8.7

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -33,8 +33,8 @@ postgis_version: "2.3"
 postgis_package_version: "2.3.1+dfsg-1.pgdg14.04+1"
 
 # azavea.docker
-# 1.11.* to match AWS ECS
-docker_version: 1.11.*
+# 1.12.* to match AWS ECS
+docker_version: 1.12.*
 docker_options: "--storage-opt dm.basesize=20G"
 
 # azavea.terraform

--- a/pfb-analysis/connectivity/census_block_roads.sql
+++ b/pfb-analysis/connectivity/census_block_roads.sql
@@ -23,7 +23,7 @@ CREATE TEMP TABLE tmp_block_buffers (
 INSERT INTO tmp_block_buffers
 SELECT gid, blockid10, ST_Multi(ST_Buffer(geom,50)) FROM neighborhood_census_blocks;
 CREATE INDEX tidx_neighborhood_blockgeoms ON tmp_block_buffers USING GIST (geom);
-ANALYZE tmp_block_buffers;
+VACUUM ANALYZE tmp_block_buffers;
 
 -- insert blocks and roads
 INSERT INTO generated.neighborhood_census_block_roads (
@@ -49,4 +49,4 @@ AND     (
 
 CREATE INDEX IF NOT EXISTS idx_neighborhood_censblkrds
 ON generated.neighborhood_census_block_roads (blockid10,road_id);
-ANALYZE generated.neighborhood_census_block_roads;
+VACUUM ANALYZE generated.neighborhood_census_block_roads;

--- a/pfb-analysis/connectivity/census_blocks.sql
+++ b/pfb-analysis/connectivity/census_blocks.sql
@@ -17,4 +17,4 @@ ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_high_stress 
 
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_geom ON neighborhood_census_blocks USING GIST (geom);
-ANALYZE neighborhood_census_blocks;
+VACUUM ANALYZE neighborhood_census_blocks;

--- a/pfb-analysis/connectivity/connected_census_blocks.sql
+++ b/pfb-analysis/connectivity/connected_census_blocks.sql
@@ -40,7 +40,7 @@ GROUP BY source_block.blockid10, target_block.blockid10
 
 -- block pair index
 CREATE UNIQUE INDEX idx_neighborhood_blockpairs ON neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
-ANALYZE neighborhood_connected_census_blocks;
+VACUUM ANALYZE neighborhood_connected_census_blocks;
 
 -- low stress
 UPDATE  neighborhood_connected_census_blocks
@@ -79,4 +79,4 @@ AND     (
 -- stress index
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_hstress ON neighborhood_connected_census_blocks (high_stress);
-ANALYZE neighborhood_connected_census_blocks;
+VACUUM ANALYZE neighborhood_connected_census_blocks;

--- a/pfb-analysis/connectivity/reachable_roads_high_stress_calc.sql
+++ b/pfb-analysis/connectivity/reachable_roads_high_stress_calc.sql
@@ -1,7 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
--- maximum network distsance: 10560 ft
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=11000 -f connected_census_blocks.sql
 ----------------------------------------
 INSERT INTO generated.neighborhood_reachable_roads_high_stress (
     base_road,
@@ -21,7 +22,7 @@ FROM    neighborhood_ways r1,
                     link_cost AS cost
             FROM    neighborhood_ways_net_link',
             v1.vert_id,
-            10560,
+            :nb_boundary_buffer,
             directed := true
         ) sheds
 WHERE r1.road_id % :thread_num = :thread_no

--- a/pfb-analysis/connectivity/reachable_roads_high_stress_cleanup.sql
+++ b/pfb-analysis/connectivity/reachable_roads_high_stress_cleanup.sql
@@ -1,3 +1,3 @@
 CREATE UNIQUE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road, target_road);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
-ANALYZE generated.neighborhood_reachable_roads_high_stress;
+VACUUM ANALYZE generated.neighborhood_reachable_roads_high_stress;

--- a/pfb-analysis/connectivity/reachable_roads_high_stress_prep.sql
+++ b/pfb-analysis/connectivity/reachable_roads_high_stress_prep.sql
@@ -1,7 +1,6 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
--- maximum network distsance: 10560 ft
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_high_stress;
 

--- a/pfb-analysis/connectivity/reachable_roads_low_stress_calc.sql
+++ b/pfb-analysis/connectivity/reachable_roads_low_stress_calc.sql
@@ -1,7 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
--- maximum network distsance: 10560 ft
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=11000 -f connected_census_blocks.sql
 ----------------------------------------
 INSERT INTO generated.neighborhood_reachable_roads_low_stress (
     base_road,
@@ -22,7 +23,7 @@ FROM    neighborhood_ways r1,
             FROM    neighborhood_ways_net_link
             WHERE   link_stress = 1',
             v1.vert_id,
-            10560,
+            :nb_boundary_buffer,
             directed := true
         ) sheds
 WHERE r1.road_id % :thread_num = :thread_no

--- a/pfb-analysis/connectivity/reachable_roads_low_stress_cleanup.sql
+++ b/pfb-analysis/connectivity/reachable_roads_low_stress_cleanup.sql
@@ -1,7 +1,6 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
--- maximum network distsance: 10560 ft
 ----------------------------------------
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);

--- a/pfb-analysis/connectivity/reachable_roads_low_stress_cleanup.sql
+++ b/pfb-analysis/connectivity/reachable_roads_low_stress_cleanup.sql
@@ -4,4 +4,4 @@
 ----------------------------------------
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);
-ANALYZE generated.neighborhood_reachable_roads_low_stress (base_road,target_road);
+VACUUM ANALYZE generated.neighborhood_reachable_roads_low_stress (base_road,target_road);

--- a/pfb-analysis/connectivity/reachable_roads_low_stress_prep.sql
+++ b/pfb-analysis/connectivity/reachable_roads_low_stress_prep.sql
@@ -1,7 +1,6 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
--- maximum network distsance: 10560 ft
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_low_stress;
 

--- a/pfb-analysis/scripts/run_connectivity.sh
+++ b/pfb-analysis/scripts/run_connectivity.sh
@@ -34,14 +34,14 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f ../connectivity/reachable_roads_high_stress_prep.sql
 
 /usr/bin/time -v parallel<<EOF
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=3 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=4 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=5 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=6 -f ../connectivity/reachable_roads_high_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=3 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=4 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=5 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=6 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_high_stress_calc.sql
 EOF
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f ../connectivity/reachable_roads_high_stress_cleanup.sql
@@ -50,14 +50,14 @@ EOF
   -f ../connectivity/reachable_roads_low_stress_prep.sql
 
 /usr/bin/time -v parallel<<EOF
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=3 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=4 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=5 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=6 -f ../connectivity/reachable_roads_low_stress_calc.sql
-psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=3 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=4 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=5 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=6 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" -f ../connectivity/reachable_roads_low_stress_calc.sql
 EOF
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -7,15 +7,32 @@ NB_POSTGRESQL_USER=gis
 NB_POSTGRESQL_PASSWORD=gis
 
 # Set defaults for overridable configuration params
-PFB_WORK_MEM="${PFB_WORK_MEM:-2048MB}"
 PFB_CHECKPOINT_COMPLETION="${PFB_CHECKPOINT_COMPLETION:-0.8}"
+# Disable to improve performance, if disabled, data loss occurs on server crash (ok for analysis)
+PFB_FSYNC="${PFB_FSYNC:-off}"
+# Only one process at a time, can be higher, set to 1/4 of available system memory
+PFB_MAINTENANCE_WORK_MEM="${PFB_MAINTENANCE_WORK_MEM:-1024MB}"
+# WAL is not useful for us, so keep small to limit disk usage
 PFB_MAX_WAL_SIZE="${PFB_MAX_WAL_SIZE:-256MB}"
+# Set to ~1/4 of available system memory
+PFB_SHARED_BUFFERS="${PFB_SHARED_BUFFERS:-1024MB}"
+# Disable to improve performance, _slightly_ safer than fsync=off
+PFB_SYNCHRONOUS_COMMIT="${PFB_SYNCHRONOUS_COMMIT:-off}"
+# Limits disk usage of query temp tables, set to ~1/2 of available disk space in KB, default 10GB
+PFB_TEMP_FILE_LIMIT="${PFB_TEMP_FILE_LIMIT:-10485760}"
+# This is per operation, so can't be massive. For analysis, 1/8 of available system memory
+PFB_WORK_MEM="${PFB_WORK_MEM:-512MB}"
 
 # Set configuration parameters
 su postgres bash -c psql <<EOF
-ALTER SYSTEM SET work_mem TO '${PFB_WORK_MEM}';
 ALTER SYSTEM SET checkpoint_completion_target TO ${PFB_CHECKPOINT_COMPLETION};
+ALTER SYSTEM SET fsync TO ${PFB_FSYNC};
+ALTER SYSTEM SET maintenance_work_mem TO '${PFB_MAINTENANCE_WORK_MEM}';
 ALTER SYSTEM SET max_wal_size TO '${PFB_MAX_WAL_SIZE}';
+ALTER SYSTEM SET shared_buffers TO '${PFB_SHARED_BUFFERS}';
+ALTER SYSTEM SET synchronous_commit TO ${PFB_SYNCHRONOUS_COMMIT};
+ALTER SYSTEM SET temp_file_limit TO ${PFB_TEMP_FILE_LIMIT};
+ALTER SYSTEM SET work_mem TO '${PFB_WORK_MEM}';
 EOF
 
 # set up database

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -6,10 +6,11 @@ NB_POSTGRESQL_DB=pfb
 NB_POSTGRESQL_USER=gis
 NB_POSTGRESQL_PASSWORD=gis
 
+PFB_AUTOVACUUM="${PFB_AUTOVACUUM:-off}"
 # Set defaults for overridable configuration params
 PFB_CHECKPOINT_COMPLETION="${PFB_CHECKPOINT_COMPLETION:-0.8}"
 # Disable to improve performance, if disabled, data loss occurs on server crash (ok for analysis)
-PFB_FSYNC="${PFB_FSYNC:-off}"
+PFB_FSYNC="${PFB_FSYNC:-on}"
 # Only one process at a time, can be higher, set to 1/4 of available system memory
 PFB_MAINTENANCE_WORK_MEM="${PFB_MAINTENANCE_WORK_MEM:-1024MB}"
 # WAL is not useful for us, so keep small to limit disk usage
@@ -20,11 +21,14 @@ PFB_SHARED_BUFFERS="${PFB_SHARED_BUFFERS:-1024MB}"
 PFB_SYNCHRONOUS_COMMIT="${PFB_SYNCHRONOUS_COMMIT:-off}"
 # Limits disk usage of query temp tables, set to ~1/2 of available disk space in KB, default 10GB
 PFB_TEMP_FILE_LIMIT="${PFB_TEMP_FILE_LIMIT:-10485760}"
+# Setting to at least a few MB can improve write performance on a server with many commits at once
+PFB_WAL_BUFFERS="${PFB_WAL_BUFFERS:-8192}"
 # This is per operation, so can't be massive. For analysis, 1/8 of available system memory
 PFB_WORK_MEM="${PFB_WORK_MEM:-512MB}"
 
 # Set configuration parameters
 su postgres bash -c psql <<EOF
+ALTER SYSTEM SET autovacuum TO ${PFB_AUTOVACUUM};
 ALTER SYSTEM SET checkpoint_completion_target TO ${PFB_CHECKPOINT_COMPLETION};
 ALTER SYSTEM SET fsync TO ${PFB_FSYNC};
 ALTER SYSTEM SET maintenance_work_mem TO '${PFB_MAINTENANCE_WORK_MEM}';
@@ -32,6 +36,7 @@ ALTER SYSTEM SET max_wal_size TO '${PFB_MAX_WAL_SIZE}';
 ALTER SYSTEM SET shared_buffers TO '${PFB_SHARED_BUFFERS}';
 ALTER SYSTEM SET synchronous_commit TO ${PFB_SYNCHRONOUS_COMMIT};
 ALTER SYSTEM SET temp_file_limit TO ${PFB_TEMP_FILE_LIMIT};
+ALTER SYSTEM SET wal_buffers TO ${PFB_WAL_BUFFERS};
 ALTER SYSTEM SET work_mem TO '${PFB_WORK_MEM}';
 EOF
 

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -9,7 +9,7 @@ NB_POSTGRESQL_PASSWORD=gis
 # Set defaults for overridable configuration params
 PFB_WORK_MEM="${PFB_WORK_MEM:-2048MB}"
 PFB_CHECKPOINT_COMPLETION="${PFB_CHECKPOINT_COMPLETION:-0.8}"
-PFB_MAX_WAL_SIZE="${PFB_MAX_WAL_SIZE:-2GB}"
+PFB_MAX_WAL_SIZE="${PFB_MAX_WAL_SIZE:-256MB}"
 
 # Set configuration parameters
 su postgres bash -c psql <<EOF


### PR DESCRIPTION
## Overview

Here we have a grab bag of fixes that hopefully resolve some of the inconsistencies of running large analyses in the virtualized docker container. This issue was mostly a result of bugfixes that fixed up the parameterization of the buffer distance in connected_census_blocks, along with further tweaks to postgresql settings that constrain database resources as are appropriate for the VM by default.

I was able to successfully run Germantown. Also Boulder, with a reduced boundary bufffer of 1000m and the normal 2mi buffer (3600m). The 3600m Boulder analysis ran in 1hr30m, which may be a bit slower than before (we have docs that state 2mi Boulder ran in 1h10m), but it no longer crashes by running out of mem/disk when attempting to calculate connected_census_blocks.sql. Before I parameterized buffer distance in https://github.com/azavea/pfb-network-connectivity/commit/1c19e635d6c03d63ccca075dc34981c9231e5605 a Boulder run with a buffer of 11000m successfully ran in 8hr (!). But it ran without crashing.

_EDIT_: 3600m Cambridge just ran, but hit the artificially imposed `temp_file_limit=10G` limit while calculating `connected_census_blocks`, which prevented the analysis from crashing, but key metrics are missing in `overall_scores`. I'm not sure there's a way around this issue currently, given the resource constraints of the VM. It's likely we'll need to come up with separate performance improvements there, which is blocked out as a separate task in #115  

### Notes

The change to docker devicemapper basesize will also need to happen somehow in AWS, opened a separate issue to investigate that: #118

The destruction of the VM as described in 'Testing' is not strictly necessary. However, without it you'll need to tweak the postgresql settings added in this PR appropriately, and run smaller jobs.

Fixes issue identified here: https://github.com/azavea/pfb-network-connectivity/pull/116#discussion_r103973428

## Demo

Boulder 3600m results:
```
id |  category  |                  score_name                   |   score    |                                              notes
----+------------+-----------------------------------------------+------------+--------------------------------------------------------------------------------------------------
  1 | Population | Median population accessible by low stress    |  5342.0000 | Total population accessible by low stress expressed as the median of all census blocks in the   +
    |            |                                               |            |             neighborhood
  2 | Population | Median population accessible by high stress   | 48921.0000 | Total population accessible by high stress expressed as the median of all census blocks in the  +
    |            |                                               |            |             neighborhood
  3 | Population | Median ratio of access to population          |     0.1030 | Ratio of population accessible by low stress to population accessible overall, expressed as     +
    |            |                                               |            |             the median of all census blocks in the                                              +
    |            |                                               |            |             neighborhood
  4 | Population | 70th percentile ratio of access to population |     0.1961 | Ratio of population accessible by low stress to population accessible overall, expressed as     +
    |            |                                               |            |             the 70th percentile of all census blocks in the                                     +
    |            |                                               |            |             neighborhood
  5 | Population | Average ratio of access to population         |     0.1372 | Ratio of population accessible by low stress to population accessible overall, expressed as     +
    |            |                                               |            |             the average of all census blocks in the                                             +
    |            |                                               |            |             neighborhood
  6 | Employment | Median employment accessible by low stress    |  3603.0000 | Total jobs accessible by low stress expressed as the median of all census blocks in the         +
    |            |                                               |            |             neighborhood
  7 | Employment | Median employment accessible by high stress   | 49604.0000 | Total jobs accessible by high stress expressed as the median of all census blocks in the        +
    |            |                                               |            |             neighborhood
  8 | Employment | Median ratio of access to employment          |     0.0730 | Ratio of employment accessible by low stress to employment accessible overall, expressed as     +
    |            |                                               |            |             the median of all census blocks in the                                              +
    |            |                                               |            |             neighborhood
  9 | Employment | 70th percentile ratio of access to employment |     0.1371 | Ratio of employment accessible by low stress to employment accessible overall, expressed as     +
    |            |                                               |            |             the 70th percentile of all census blocks in the                                     +
    |            |                                               |            |             neighborhood
 10 | Employment | Average ratio of access to employment         |     0.1144 | Ratio of employment accessible by low stress to employment accessible overall, expressed as     +
    |            |                                               |            |             the average of all census blocks in the                                             +
    |            |                                               |            |             neighborhood
 11 | Schools    | Average low stress school access              |     2.2588 | Number of schools accessible by low stress expressed as an average of all census blocks in the  +
    |            |                                               |            |             neighborhood
 12 | Schools    | Average high stress school access             |    17.9393 | Number of schools accessible by high stress expressed as an average of all census blocks in the +
    |            |                                               |            |             neighborhood
 13 | Schools    | Average school low stress population shed     |  5332.8276 | Population with low stress access to schools in the neighborhood expressed as an average of all +
    |            |                                               |            |             schools in the neighborhood
 14 | Schools    | Average school high stress population shed    | 39677.5517 | Population with high stress access to schools in the neighborhood expressed as an average of all+
    |            |                                               |            |             schools in the neighborhood
 15 | Schools    | Average school population shed ratio          |     0.1301 | Ratio of population with low stress access to schools to population with high stress access     +
    |            |                                               |            |             in the neighborhood expressed as an average of all                                  +
    |            |                                               |            |             schools in the neighborhood
```

## Testing

The change to the docker storage options requires that the VM be destroyed and reprovisioned, so do that first with `vagrant destroy && ./scripts/setup`.

Then rebuild the pfb-analysis container following current README instructions.

Once the container is built, you should be able to run any of the successful analysis jobs noted above.

If you want to run a long running job, but not block farther development, build the analysis container with a different tag, and then run the analysis using a different tag (substituting in `docker run` as appropriate). Once the container is built, you can safely switch off this branch.
