### PR TITLE
Serve AngularJS site with nginx

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -26,7 +26,8 @@ You will be prompted to enter your AWS credentials, along with a default region.
 
 If you're deploying new application code, first set the commit to deploy, then build and push containers:
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ export GIT_COMMIT="<commit-to-deploy>"
+vagrant@vagrant-ubuntu-trusty-64:~$ export GIT_COMMIT="<short-commit-to-deploy>"
+vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="pfb"
 vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_AWS_ECR_ENDPOINT="<aws-account-id>.dkr.ecr.us-east-1.amazonaws.com"
 vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/cibuild && ./scripts/cipublish
 ```
@@ -35,7 +36,6 @@ Next, use the `infra` wrapper script to lookup the remote state of the infrastru
 
 ```bash
 vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_SETTINGS_BUCKET="staging-pfb-config-us-east-1"
-vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="pfb"
 vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra plan
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
       - "9200:443"
     links:
       - django
-    volumes:
-      - ./src/nginx/srv/dist:/srv/dist:ro
 
   django:
     image: pfb-app

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -24,14 +24,17 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Note: tests are run and the files are copied using the :latest images, which should be
-        # fine because CI first runs scripts/update, which builds all containers.
+        echo "Building container image"
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+                  -f "${DIR}/../docker-compose.yml" \
+                  -f "${DIR}/../docker-compose.test.yml" \
+                  build database django angularjs
 
         echo "Running tests"
         "${DIR}/test"
         echo "All tests pass!"
 
-        # Copy static angular site to nginx srv directory
+        # Copy static site from angularjs container to local nginx srv directory
         echo "Copying angular site to nginx"
         pushd "${DIR}/../src/nginx"
         docker run -i -v "${PWD}/srv/dist:/static-export/dist" pfb-angularjs \
@@ -39,11 +42,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                  /opt/pfb/angularjs/dist /static-export/
         popd
 
-        echo "Building container images"
+        echo "Building nginx image"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f "${DIR}/../docker-compose.yml" \
                   -f "${DIR}/../docker-compose.test.yml" \
-                  build
+                  build nginx
 
         echo "Building pfb-analysis container image"
         pushd pfb-analysis

--- a/scripts/update
+++ b/scripts/update
@@ -74,7 +74,7 @@ then
 
         # Build the current docker analysis container
         pushd pfb-analysis
-        docker build -t pfb .
+        docker build -t pfb-analysis .
         popd
 
         popd

--- a/scripts/update
+++ b/scripts/update
@@ -61,7 +61,7 @@ then
     else
         pushd ..
 
-        docker-compose build
+        docker-compose build database django angularjs
 
         run_database_migrations
 
@@ -71,6 +71,10 @@ then
                rsync -rlptDv --delete --exclude .gitkeep \
                  /opt/pfb/angularjs/dist /static-export/
         popd
+
+        # Build the nginx container after building angularjs and copying the files, so
+        # it includes them
+        docker-compose build nginx
 
         # Build the current docker analysis container
         pushd pfb-analysis

--- a/src/nginx/etc/nginx/conf.d/default.conf
+++ b/src/nginx/etc/nginx/conf.d/default.conf
@@ -37,13 +37,13 @@ server {
     }
 
     # Health check & app version
-    # location ~ ^/(health-check|version)/$ {
-    #     proxy_set_header Host $http_host;
-    #     proxy_set_header X-Forwarded-For $remote_addr;
-    #     proxy_redirect off;
-    #
-    #     proxy_pass http://django-upstream;
-    # }
+    location ~ ^/(healthcheck|version)/$ {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://django-upstream;
+    }
 
     # Static Assets
     location / {


### PR DESCRIPTION
Connects #95.

Most of the steps for that issue were done in PR #86, but it wasn't actually working.  I believe that's because of the `volumes:` mapping, which only makes sense in development but was probably mapping a nonexistent directory over top of the one inside the container.  At least that's the theory.  Anyway, using that volume mapping only makes sense in local development but isn't necessary or particularly useful, so this just removes it.

Also:
- I also made some changes to `scripts/update` and `scripts/cibuild` to ensure that the static files built by the AngularJS site are up to date and where they're supposed to be when they get copied into the nginx container's directory, and that the nginx container doesn't get built until that has happened.
- And a small tweak to the deployment README for a couple things that tripped me up.
- Uncommented the healthcheck redirect in the nginx config so ECS will let the containers live

