### PR TITLE
Use S3 for analysis files

### DIFF
--- a/pfb-analysis/Dockerfile
+++ b/pfb-analysis/Dockerfile
@@ -34,6 +34,7 @@ RUN set -xe && \
         postgresql-$PG_MAJOR-pgrouting \
         python-gdal \
         unzip \
+        zip \
         postgis" && \
     apt-get update && apt-get install -y ${BUILD_DEPS} ${DEPS} --no-install-recommends && \
     mkdir /tmp/build/ && cd /tmp/build && \

--- a/pfb-analysis/Dockerfile
+++ b/pfb-analysis/Dockerfile
@@ -48,6 +48,12 @@ RUN set -xe && \
     cd /tmp/ && rm -rf /tmp/build/ /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove ${BUILD_DEPS}
 
+RUN set -xe && \
+    wget -q "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" && \
+    unzip awscli-bundle.zip && \
+    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+    rm -r ./awscli-bundle*
+
 COPY scripts/setup_database.sh /docker-entrypoint-initdb.d/setup_database.sh
 COPY ./ /pfb/
 

--- a/pfb-analysis/import/import_jobs.sh
+++ b/pfb-analysis/import/import_jobs.sh
@@ -87,7 +87,7 @@ then
     then
         usage
     else
-        NB_STATE_ABBREV="${1}"
+        NB_STATE_ABBREV="${1,,}"  # force to lower case to match the jobs file download paths
 
         import_job_data "${NB_STATE_ABBREV}" "main"
         import_job_data "${NB_STATE_ABBREV}" "aux"

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -46,12 +46,13 @@ export NB_OUTPUT_SRID="$(./scripts/detect_utm_zone.py $PFB_SHPFILE)"
 
 ./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS $PFB_OSM_FILE
 ./scripts/run_connectivity.sh
-./scripts/export_connectivity.sh $NB_OUTPUT_DIR
 
 # print scores (TODO: replace with export script)
 psql -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" <<EOF
 SELECT * FROM neighborhood_overall_scores;
 EOF
+
+./scripts/export_connectivity.sh $NB_OUTPUT_DIR $PFB_NEIGHBORHOOD_NAME
 
 # This will exit immediately when there's no pseudo-TTY but provide a shell if there is,
 # so it enables keeping a docker container alive after processing by running it with `-t`

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -38,6 +38,20 @@ do
     ((counter++))
 done
 
+PFB_TEMPDIR=`mktemp -d`
+
+# If given a URL for the shapefile, dowload and unzip it. Overrides PFB_SHPFILE.
+if [ "${PFB_SHPFILE_URL}" ]
+then
+    echo "Downloading shapefile"
+    pushd "${PFB_TEMPDIR}"
+    wget "${PFB_SHPFILE_URL}" -O boundary.zip
+    unzip boundary.zip
+    PFB_SHPFILE="${PFB_TEMPDIR}"/$(ls *.shp)  # Assumes there's exactly one .shp file
+    echo "Boundary shapefile is ${PFB_SHPFILE}"
+    popd
+fi
+
 # run job
 cd /pfb
 
@@ -52,11 +66,14 @@ psql -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" <<EOF
 SELECT * FROM neighborhood_overall_scores;
 EOF
 
+NB_OUTPUT_DIR="${NB_OUTPUT_DIR:-$PFB_TEMPDIR}"
 ./scripts/export_connectivity.sh $NB_OUTPUT_DIR $PFB_NEIGHBORHOOD_NAME
 
 # This will exit immediately when there's no pseudo-TTY but provide a shell if there is,
 # so it enables keeping a docker container alive after processing by running it with `-t`
 bash
+
+rm -rf "${PFB_TEMPDIR}"
 
 # shutdown postgres
 su postgres -c "/usr/lib/postgresql/9.6/bin/pg_ctl stop"

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -67,7 +67,7 @@ SELECT * FROM neighborhood_overall_scores;
 EOF
 
 NB_OUTPUT_DIR="${NB_OUTPUT_DIR:-$PFB_TEMPDIR}"
-./scripts/export_connectivity.sh $NB_OUTPUT_DIR $PFB_NEIGHBORHOOD_NAME
+./scripts/export_connectivity.sh $NB_OUTPUT_DIR $PFB_JOB_ID
 
 # This will exit immediately when there's no pseudo-TTY but provide a shell if there is,
 # so it enables keeping a docker container alive after processing by running it with `-t`

--- a/pfb-analysis/scripts/export_connectivity.sh
+++ b/pfb-analysis/scripts/export_connectivity.sh
@@ -11,16 +11,15 @@ NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
 NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
 NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
 NB_POSTGRESQL_PORT="${NB_POSTGRESQL_PORT:-5432}"
-NB_OUTPUT_FILE_PREFIX="${NB_OUTPUT_FILE_PREFIX:-analysis_}"
-
-NB_OUTPUT_DIR="${1}"
 
 function ec_usage() {
     echo -n \
 "
-Usage: $(basename "$0") <output_directory>
+Usage: $(basename "$0") <output_directory> <file_prefix>
 
-Export data from a successful run of the PeopleForBike Network Analysis to a directory on disk.
+Export data from a successful run of the PeopleForBikes Network Analysis.
+Writes to <output_directory> and, if AWS_STORAGE_BUCKET_NAME is set,
+uploads to S3.
 
 <output_directory> must be an absolute path (pgsql COPY doesn't support relative paths)
 
@@ -32,21 +31,23 @@ This script exports the following tables:
 
 Optional ENV vars:
 
-NB_OUTPUT_FILE_PREFIX - Default: 'analysis_'
+AWS_STORAGE_BUCKET_NAME
+AWS_PROFILE (necessary for using S3 in local development)
 NB_POSTGRESQL_HOST - Default: 127.0.0.1
 NB_POSTGRESQL_DB - Default: pfb
 NB_POSTGRESQL_USER - Default: gis
 NB_POSTGRESQL_PASSWORD - Default: gis
-NB_POSTGRESQL_PORT - Default: 4326
+NB_POSTGRESQL_PORT - Default: 5432
 
 "
 }
 
 function ec_export_table_shp() {
     OUTPUT_DIR="$1"
-    EXPORT_TABLENAME="$2"
+    OUTPUT_FILE_PREFIX="${2}"
+    EXPORT_TABLENAME="$3"
 
-    FILENAME="${OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.shp"
+    FILENAME="${OUTPUT_DIR}/${OUTPUT_FILE_PREFIX}_${EXPORT_TABLENAME}.shp"
     pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
               -u "${NB_POSTGRESQL_USER}" \
               -p "${NB_POSTGRESQL_PORT}" \
@@ -58,36 +59,56 @@ function ec_export_table_shp() {
 
 function ec_export_table_csv() {
     OUTPUT_DIR="$1"
-    EXPORT_TABLENAME="$2"
+    OUTPUT_FILE_PREFIX="${2}"
+    EXPORT_TABLENAME="$3"
 
-    FILENAME="${OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.csv"
+    FILENAME="${OUTPUT_DIR}/${OUTPUT_FILE_PREFIX}_${EXPORT_TABLENAME}.csv"
     psql -h "${NB_POSTGRESQL_HOST}" \
          -U "${NB_POSTGRESQL_USER}" \
          -p "${NB_POSTGRESQL_PORT}" \
          -d "${NB_POSTGRESQL_DB}" \
-         -c "COPY ${EXPORT_TABLENAME} TO '${FILENAME}' WITH (FORMAT CSV, HEADER)"
+         -c "\COPY ${EXPORT_TABLENAME} TO '${FILENAME}' WITH (FORMAT CSV, HEADER)"
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    if [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]
+    if [ "${1}" = "--help" ]
     then
         ec_usage
+    elif [ -z "${1}" ] || [ -z "${2}" ]
+    then
+        ec_usage
+        exit 1
     else
         echo "Exporting analysis to ${NB_OUTPUT_DIR}"
         NB_OUTPUT_DIR="${1}"
+        NB_OUTPUT_FILE_PREFIX="${2}"
         mkdir -p "${NB_OUTPUT_DIR}"
 
         # Export neighborhood_ways as SHP
-        ec_export_table_shp "${NB_OUTPUT_DIR}" "neighborhood_ways"
+        ec_export_table_shp "${NB_OUTPUT_DIR}" "${NB_OUTPUT_FILE_PREFIX}" "neighborhood_ways"
 
         # Export neighborhood ways as GeoJSON
         # TODO: Add ogr2ogr and try again
 
         # Export neighborhood_connected_census_blocks as SHP
-        ec_export_table_shp "${NB_OUTPUT_DIR}" "neighborhood_connected_census_blocks"
+        ec_export_table_shp "${NB_OUTPUT_DIR}" "${NB_OUTPUT_FILE_PREFIX}" "neighborhood_connected_census_blocks"
 
         # Export neighborhood_overall_scores as CSV
-        ec_export_table_csv "${NB_OUTPUT_DIR}" "neighborhood_overall_scores"
+        ec_export_table_csv "${NB_OUTPUT_DIR}" "${NB_OUTPUT_FILE_PREFIX}" "neighborhood_overall_scores"
+
+        if [ -v AWS_STORAGE_BUCKET_NAME ]
+        then
+          pushd "${NB_OUTPUT_DIR}"
+          sync  # Probably superfluous, but the s3 command said "file changed while reading" once
+
+          OUTPUT_FILENAME="${NB_OUTPUT_FILE_PREFIX}.zip"
+          zip "${OUTPUT_FILENAME}" "${NB_OUTPUT_FILE_PREFIX}_"*
+          sync
+
+          aws s3 cp "${OUTPUT_FILENAME}" "s3://${AWS_STORAGE_BUCKET_NAME}/results/"
+
+          popd
+        fi
     fi
 fi

--- a/pfb-analysis/scripts/export_connectivity.sh
+++ b/pfb-analysis/scripts/export_connectivity.sh
@@ -15,24 +15,25 @@ NB_POSTGRESQL_PORT="${NB_POSTGRESQL_PORT:-5432}"
 function ec_usage() {
     echo -n \
 "
-Usage: $(basename "$0") <output_directory> <file_prefix>
+Usage: $(basename "$0") <local_directory> <job_id>
 
 Export data from a successful run of the PeopleForBikes Network Analysis.
-Writes to <output_directory> and, if AWS_STORAGE_BUCKET_NAME is set,
-uploads to S3.
+Writes to <local_directory> and, if AWS_STORAGE_BUCKET_NAME is set,
+uploads to S3 at {AWS_STORAGE_BUCKET_NAME}/{job_id}.
 
-<output_directory> must be an absolute path (pgsql COPY doesn't support relative paths)
+<local_directory> must be an absolute path (pgsql COPY doesn't support relative paths)
 
 This script exports the following tables:
  - neighborhood_ways as SHP
  - neighborhood_ways as GeoJSON (TODO)
- - neighborhood_connected_census_blocks as SHP
+ - neighborhood_connected_census_blocks as SHP (currently disabled)
  - neighborhood_overall_scores as CSV
 
 Optional ENV vars:
 
 AWS_STORAGE_BUCKET_NAME
 AWS_PROFILE (necessary for using S3 in local development)
+
 NB_POSTGRESQL_HOST - Default: 127.0.0.1
 NB_POSTGRESQL_DB - Default: pfb
 NB_POSTGRESQL_USER - Default: gis
@@ -44,10 +45,9 @@ NB_POSTGRESQL_PORT - Default: 5432
 
 function ec_export_table_shp() {
     OUTPUT_DIR="$1"
-    OUTPUT_FILE_PREFIX="${2}"
-    EXPORT_TABLENAME="$3"
+    EXPORT_TABLENAME="$2"
 
-    FILENAME="${OUTPUT_DIR}/${OUTPUT_FILE_PREFIX}_${EXPORT_TABLENAME}.shp"
+    FILENAME="${OUTPUT_DIR}/${EXPORT_TABLENAME}.shp"
     pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
               -u "${NB_POSTGRESQL_USER}" \
               -p "${NB_POSTGRESQL_PORT}" \
@@ -55,14 +55,17 @@ function ec_export_table_shp() {
               -f "${FILENAME}" \
               "${NB_POSTGRESQL_DB}" \
               "${EXPORT_TABLENAME}"
+    pushd "${OUTPUT_DIR}"
+    zip "${EXPORT_TABLENAME}.zip" "${EXPORT_TABLENAME}".*
+    rm "${EXPORT_TABLENAME}".[^z]*
+    popd
 }
 
 function ec_export_table_csv() {
     OUTPUT_DIR="$1"
-    OUTPUT_FILE_PREFIX="${2}"
-    EXPORT_TABLENAME="$3"
+    EXPORT_TABLENAME="$2"
 
-    FILENAME="${OUTPUT_DIR}/${OUTPUT_FILE_PREFIX}_${EXPORT_TABLENAME}.csv"
+    FILENAME="${OUTPUT_DIR}/${EXPORT_TABLENAME}.csv"
     psql -h "${NB_POSTGRESQL_HOST}" \
          -U "${NB_POSTGRESQL_USER}" \
          -p "${NB_POSTGRESQL_PORT}" \
@@ -80,35 +83,29 @@ then
         ec_usage
         exit 1
     else
-        echo "Exporting analysis to ${NB_OUTPUT_DIR}"
         NB_OUTPUT_DIR="${1}"
-        NB_OUTPUT_FILE_PREFIX="${2}"
-        mkdir -p "${NB_OUTPUT_DIR}"
+        JOB_ID="${2}"
+        OUTPUT_DIR="${NB_OUTPUT_DIR}/${JOB_ID}"
+        echo "Exporting analysis to ${OUTPUT_DIR}"
+        mkdir -p "${OUTPUT_DIR}"
 
         # Export neighborhood_ways as SHP
-        ec_export_table_shp "${NB_OUTPUT_DIR}" "${NB_OUTPUT_FILE_PREFIX}" "neighborhood_ways"
+        ec_export_table_shp "${OUTPUT_DIR}" "neighborhood_ways"
 
         # Export neighborhood ways as GeoJSON
         # TODO: Add ogr2ogr and try again
 
         # Export neighborhood_connected_census_blocks as SHP
-        ec_export_table_shp "${NB_OUTPUT_DIR}" "${NB_OUTPUT_FILE_PREFIX}" "neighborhood_connected_census_blocks"
+        # NOTE: disabled for now, because large and not that useful
+        # ec_export_table_shp "${OUTPUT_DIR}" "neighborhood_connected_census_blocks"
 
         # Export neighborhood_overall_scores as CSV
-        ec_export_table_csv "${NB_OUTPUT_DIR}" "${NB_OUTPUT_FILE_PREFIX}" "neighborhood_overall_scores"
+        ec_export_table_csv "${OUTPUT_DIR}" "neighborhood_overall_scores"
 
         if [ -v AWS_STORAGE_BUCKET_NAME ]
         then
-          pushd "${NB_OUTPUT_DIR}"
           sync  # Probably superfluous, but the s3 command said "file changed while reading" once
-
-          OUTPUT_FILENAME="${NB_OUTPUT_FILE_PREFIX}.zip"
-          zip "${OUTPUT_FILENAME}" "${NB_OUTPUT_FILE_PREFIX}_"*
-          sync
-
-          aws s3 cp "${OUTPUT_FILENAME}" "s3://${AWS_STORAGE_BUCKET_NAME}/results/"
-
-          popd
+          aws s3 cp --recursive "${OUTPUT_DIR}" "s3://${AWS_STORAGE_BUCKET_NAME}/results/${JOB_ID}"
         fi
     fi
 fi

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -106,9 +106,13 @@ class AnalysisJob(PFBModel):
         # so force truncate to that to keep jobs from failing
         definition_name, revision = job_definition.split(':')
         job_name = '{}--{}--{}'.format(definition_name[:30], revision, str(self.uuid)[:8])
-        environment = create_environment(PFB_SHPFILE=self.neighborhood.boundary_file.url,
-                                         PFB_STATE=self.neighborhood.state_abbrev,
-                                         PFB_STATE_FIPS=self.neighborhood.state.fips)
+        environment = create_environment(
+            PFB_SHPFILE_URL=self.neighborhood.boundary_file.url,
+            PFB_STATE=self.neighborhood.state_abbrev,
+            PFB_STATE_FIPS=self.neighborhood.state.fips,
+            PFB_JOB_ID=str(self.uuid),
+            AWS_STORAGE_BUCKET_NAME=settings.AWS_STORAGE_BUCKET_NAME,
+        )
         container_overrides = {
             'environment': environment,
         }


### PR DESCRIPTION
Adds S3 uploading and downloading.  Requires that `AWS_STORAGE_BUCKET_NAME` be set.  In development, `AWS_PROFILE` must also be set and the `.aws` directory must be mounted in the container.
The new bits:
- Given `PFB_SHPFILE_KEY`, downloads the boundary file from the given S3 key, unzips it, and sets the value of `PFB_SHPFILE`.  (If `PFB_SHPFILE` is also set, this will override it.)
- When finished, zips up the results and uploads to `{AWS_STORAGE_BUCKET_NAME}/results/{PFB_NEIGHBORHOOD_NAME}.zip`.  (`PFB_NEIGHBORHOOD_NAME` is now required by the export.)
- Adds an S3 clause to the "reuse big downloads" logic in `import_neighborhood.sh` and `import_jobs.sh`. They'll look first in the local `/data/` directory, then in `{AWS_STORAGE_BUCKET_NAME}/data/`, then do the download.

This doesn't do anything with OSM files so far.  Those aren't general like the state-level block and jobs information, so we'll need to add that to the `Neighborhood` or `AnalysisJob` model to make them uploadable/reusable.

Notes:
- The aws cli can be installed with pip or from a standalone bundle.  I started with the former, but after several issues with unstated dependencies and build errors, I went for the bundle instead.
- The first commit fixes the NB_INPUT_SRID bug in the same way that PR #119 does. Since I was changing the file, I wanted to be starting from the good version.  I didn't cherry-pick, but I tried to copy the diff so that it would merge/rebase cleanly.

**To Test**
Make a neighborhood.  In the django shell:
```
from django.core.files import File
boundary_file = File(open('/data/gtown_westside.zip'))
org = Organization.objects.first()
gtown = Neighborhood.objects.create(name='gtown-westside', label='Germantown, PA', boundary_file=boundary_file, organization=org, state_abbrev='PA')
```
gtown.boundary_file.file.obj.key will now return the key of the file just uploaded to S3, which should be `neighborhood_boundaries/gtown-westside/gtown_westside.zip`

Then run the analysis.  In `/vagrant/` inside the VM:
```
pushd pfb-analysis && docker build -t pfb-analysis . && popd && \
docker run -it -e PFB_SHPFILE_KEY='neighborhood_boundaries/gtown-westside/gtown_westside.zip' \
    -e PFB_NEIGHBORHOOD_NAME='gtown-westside' -e PFB_STATE=pa -e PFB_STATE_FIPS=42 \
    -e NB_BOUNDARY_BUFFER=50 \
    -v /vagrant/data/:/data/ -v /home/vagrant/.aws:/root/.aws \
    -e AWS_PROFILE=pfb -e AWS_STORAGE_BUCKET_NAME="${DEV_USER}-pfb-storage-us-east-1" \
    pfb-analysis
```
That will run the analysis and upload the results.  (Note the `-it`, which will make it drop you to a shell rather than exiting when finished.  Remove that if not wanted.)

Connects #89.