### PR TITLE
Provide PFB_AWS_ECR_ENDPOINT to infra

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,13 @@ node {
       stage('infra') {
         // Use `git` to get the primary repository's current commmit SHA and
         // set it as the value of the `GIT_COMMIT` environment variable.
-        wrap([$class: 'AnsiColorBuildWrapper']) {
-          sh './scripts/infra plan'
-          sh './scripts/infra apply'
+        withCredentials([[$class: 'StringBinding',
+                          credentialsId: 'PFB_AWS_ECR_ENDPOINT',
+                          variable: 'PFB_AWS_ECR_ENDPOINT']]) {
+          wrap([$class: 'AnsiColorBuildWrapper']) {
+            sh './scripts/infra plan'
+            sh './scripts/infra apply'
+          }
         }
       }
     }


### PR DESCRIPTION
## Overview

Missed a use of `PFB_AWS_ECR_ENDPOINT in `./scripts/infra`. This adds those credentials to the appropriate step in the Jenkinsfile.

See http://urbanappsci.internal.azavea.com/job/azavea/job/pfb-network-connectivity/job/develop/32/ for a successful run against develop with this change applied.
