### PR TITLE
Move and modify 'Running the analysis' documentation

### DIFF
--- a/README.RUNNING.md
+++ b/README.RUNNING.md
@@ -1,0 +1,85 @@
+# Running the Analysis Locally
+
+### Setup
+
+All commands should be run inside the VM from the `/vagrant/` directory.
+
+The container is built by `scripts/update`, but can be rebuilt by running:
+```
+pushd pfb-analysis
+docker build -t pfb-analysis .
+popd
+```
+
+### Example
+
+To run the analysis for Boulder, CO:
+```
+./scripts/run-local-analysis https://s3.amazonaws.com/test-pfb-inputs/boulder/boulder.zip co 08
+```
+
+This will take up to an hour, so just let it work. Consider piping script output to a file and
+running in a screen/tmux session.
+
+#### Using local files
+
+The analysis can also gets its input data from local files.  To run the analysis using the
+same Boulder boundary and a pre-downloaded OSM file, download
+[the zipped shapefile](https://s3.amazonaws.com/test-pfb-inputs/boulder/boulder.zip)
+and extract it to `./data/`.
+Also download [the OSM file](https://s3.amazonaws.com/test-pfb-inputs/boulder/boulder-osm.zip)
+and extract it into `./data/`.
+
+Then run:
+```
+PFB_OSM_FILE=/data/boulder.osm ./scripts/run-local-analysis /data/boulder.shp co 08
+```
+
+### Analysis parameters
+
+See the usage message of `scripts/run-local-analysis` for options and defaults.
+
+`run-local-analysis` maps `/vagrant/data` in the VM to `/data/` within the container.
+
+| Variable | Purpose | Default value |
+| -------- | ------- | ------------- |
+| NB_INPUT_SRID | SRID of the input shapefile | 4326 |
+| NB_BOUNDARY_BUFFER | The distance beyond the edge of the boundary given by the shapefile to include in the imported geographic data. Also the maximum trip distance considered in the connectivity calculations. | 3600 |
+| PFB_OSM_FILE | An exported OSM file to use instead of downloading current OSM data during the analysis | |
+| PFB_OSM_FILE_URL | A URL from which a zipped .osm file can be downloaded. Overrides PFB_OSM_FILE. | none |
+| NB_OUTPUT_DIR | The path, within the analysis container, to write results to. The directory will be created (if possible) if it doesn't exist. | /data/output |
+| AWS_STORAGE_BUCKET_NAME | The S3 bucket to upload results to. Requires `AWS_PROFILE` be set. | {DEV_USER}-pfb-storage-us-east-1 |
+| AWS_PROFILE | The name of the AWS profile, configured in `~/.aws` to use for uploading to S3. | pfb |
+| PFB_JOB_ID | The job ID of the analysis job, which isn't really applicable when directly running a local analysis but which is required because it's used in the results upload path. | 'local-job' |
+
+
+### Running other neighborhoods
+
+The following input files are also available at https://s3.amazonaws.com/test-pfb-inputs/.
+
+- Cambridge, MA
+    - Shapefile: https://s3.amazonaws.com/test-pfb-inputs/cambridge/neighborhood_boundary_02138.zip
+    - OSM files: https://s3.amazonaws.com/test-pfb-inputs/cambridge/cambridge-osm.zip
+    - FIPS code: 25
+    - set `NB_INPUT_SRID=2249`
+- Lower Manhattan, NY
+    - Shapefile: https://s3.amazonaws.com/test-pfb-inputs/lowermanhattan/lowermanhattan.zip
+    - OSM file: https://s3.amazonaws.com/test-pfb-inputs/lowermanhattan/lowermanhattan-osm.zip
+    - FIPS code: 36
+    - A large network.  Analysis is lengthy and resource-intensive.
+- Center City Philadelphia, PA
+    - Shapefile: https://s3.amazonaws.com/test-pfb-inputs/philly/philly.zip
+    - OSM file: https://s3.amazonaws.com/test-pfb-inputs/philly/philly-osm.zip
+    - FIPS code: 42
+- Germantown, PA
+    - Shapefile: https://s3.amazonaws.com/test-pfb-inputs/germantown/gtown_westside.zip
+    - OSM file: https://s3.amazonaws.com/test-pfb-inputs/germantown/gtown_westside-osm.zip
+    - FIPS code: 42
+    - A small area for quick tests
+
+### Cleaning up old analysis runs
+
+Each analysis run takes up a significant amount of limited VM disk space. To clear old analysis volumes once finished with them, run:
+```
+./scripts/clean-analysis-volumes
+```

--- a/README.md
+++ b/README.md
@@ -83,65 +83,7 @@ systems+pfb@azavea.com / root
 
 ## Running the Analysis
 
-Copy the 'neighborhood_boundary_02138.zip' file on fileshare and unzip to `./data/neighborhood_boundary.shp`.
-
-In this example, we configure the analysis to be run for Cambridge MA.
-
-Run:
-```
-pushd pfb-analysis
-docker build -t pfb-analysis .
-popd
-
-docker run \
-    -e PFB_SHPFILE=/data/neighborhood_boundary.shp \
-    -e PFB_STATE=ma \
-    -e PFB_STATE_FIPS=25 \
-    -e NB_INPUT_SRID=2249 \
-    -e NB_BOUNDARY_BUFFER=3600 \
-    -v /vagrant/data/:/data/ \
-    pfb-analysis
-```
-
-This will take up to 1hr, so just let it work. Consider piping script output to a file and running in
-a screen/tmux session.
-
-#### Re-running the analysis
-
-If you want to run a different neighborhood, simply rerun the `docker run` command with the
-appropriate arguments, which are described below, in [Importing other neighborhoods](#importing-other-neighborhoods).
-
-#### Cleaning up old analysis runs
-
-Each analysis run takes up a significant amount of limited VM disk space. To clear old analysis volumes once finished with them, run:
-```
-./scripts/clean-analysis-volumes
-```
-
-
-## Importing other neighborhoods
-
-Running the analysis requires a neighborhood shapefile polygon to run the analysis against.
-
-To get started, place your neighborhood boundary shapefile, unzipped, in the project `./data` directory.
-
-You will also need to know the following:
-- State abbrev that your neighborhood is found in, e.g. 'ma' for Massachussetts
-- State FIPS code that your neighborhood is found in: https://www.census.gov/geo/reference/ansi_statetables.html
-- SRID of your neighborhood boundary file (input)
-- SRID you want to run the analysis in (output)
-
-Now run:
-```
-docker run \
-    -e PFB_SHPFILE=<path_to_boundary_shp> \
-    -e PFB_STATE=<state abbrev> \
-    -e PFB_STATE_FIPS=<state fips> \
-    -e NB_INPUT_SRID=<input srid> \
-    -e NB_BOUNDARY_BUFFER=<buffer distance in meters> \
-    -v /vagrant/data/:/data/ \
-    pfb-analysis
-```
+See [Running the Analysis Locally](README.RUNNING.md).
 
 
 ## Verifying the Analysis
@@ -170,8 +112,7 @@ docker-compose run verifier boulder.csv my_output_to_verify.csv
 
 If there are any differences in the outputs, a summary of the differences will be output to console.
 
-
-## Verified Output Parameters
+### Verified Output Parameters
 
 The analysis output in the `verified_output` directory was generated using the following input parameters and files:
 

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -52,6 +52,18 @@ then
     popd
 fi
 
+# If given a URL for the OSM file, dowload and unzip it. Overrides PFB_OSM_FILE.
+if [ "${PFB_OSM_FILE_URL}" ]
+then
+    echo "Downloading OSM file"
+    pushd "${PFB_TEMPDIR}"
+    wget "${PFB_OSM_FILE_URL}" -O neighborhood_osm.zip
+    unzip neighborhood_osm.zip
+    PFB_OSM_FILE="${PFB_TEMPDIR}"/$(ls *.osm)  # Assumes there's exactly one .osm file
+    echo "OSM file is ${PFB_OSM_FILE}"
+    popd
+fi
+
 # run job
 cd /pfb
 

--- a/scripts/run-local-analysis
+++ b/scripts/run-local-analysis
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname "${0}")
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") PFB_SHPFILE[_URL] PFB_STATE PFB_STATE_FIPS ['extra args']
+
+Run an analysis job in local development. Sets a bunch of the required
+arguments to useful defaults.
+
+The first argument can be either the path to a shapefile (within the container,
+/data/boulder.shp, assuming the default mapping of ./data to /data) or a URL from
+which to download the zipped shapefile. Anything that starts with 'http' will be
+treated as a URL.
+
+'extra args' should be a string that will be fed through to the `docker run` command, e.g. '-ti'
+
+Optional, set them in the environment to override:
+NB_INPUT_SRID (default: 4326)
+NB_BOUNDARY_BUFFER (in meters. default: 3600)
+PFB_OSM_FILE (default: none, downloaded by the analysis job)
+PFB_OSM_FILE_URL (expects a zipped .osm file, overrides PFB_OSM_FILE. default: none)
+NB_OUTPUT_DIR (default: /data/output)
+AWS_PROFILE (default: pfb)
+AWS_STORAGE_BUCKET_NAME (default: ${DEV_USER}-pfb-storage-us-east-1)
+PFB_JOB_ID (default: 'local-job')
+
+EXAMPLES:
+A boulder run with local shapefile and all defaults:
+   ./scripts/run-local-analysis /data/boulder.shp pa 42
+
+Override the buffer size and supply an OSM file:
+   PFB_OSM_FILE=/data/boulder.osm NB_BOUNDARY_BUFFER=1000 \\
+       ./scripts/run-local-analysis /data/boulder.shp pa 42
+"
+}
+
+
+if [ "${1:-}" = "--help" ] || [ -z "${3}" ]
+then
+    usage
+else
+    if [[ $1 =~ ^http ]]; then
+        PFB_SHPFILE_URL="${1}"
+    else
+        PFB_SHPFILE="${1}"
+    fi
+    PFB_STATE="${2}"
+    PFB_STATE_FIPS="${3}"
+    EXTRA_ARGS="${4}"
+
+    NB_INPUT_SRID="${NB_INPUT_SRID:-4326}"
+    NB_BOUNDARY_BUFFER="${NB_BOUNDARY_BUFFER:-3600}"
+    NB_OUTPUT_DIR="${NB_OUTPUT_DIR:-/data/output}"
+    PFB_JOB_ID="${PFB_JOB_ID:-local-job}"
+
+    docker run $EXTRA_ARGS \
+        -e PFB_SHPFILE_URL=$PFB_SHPFILE_URL \
+        -e PFB_SHPFILE=$PFB_SHPFILE \
+        -e PFB_OSM_FILE_URL=$PFB_OSM_FILE_URL \
+        -e PFB_OSM_FILE=$PFB_OSM_FILE \
+        -e PFB_STATE=$PFB_STATE -e PFB_STATE_FIPS=$PFB_STATE_FIPS \
+        -e NB_INPUT_SRID=$NB_INPUT_SRID \
+        -e NB_BOUNDARY_BUFFER=$NB_BOUNDARY_BUFFER \
+        -e NB_OUTPUT_DIR=$NB_OUTPUT_DIR \
+        -e PFB_JOB_ID=$PFB_JOB_ID \
+        -e AWS_PROFILE=pfb \
+        -e AWS_STORAGE_BUCKET_NAME="${DEV_USER}-pfb-storage-us-east-1" \
+        -v /vagrant/data/:/data/ \
+        -v /home/vagrant/.aws:/root/.aws \
+        pfb-analysis
+fi


### PR DESCRIPTION
Connects #120.

The details of running the analysis change frequently and the documentation is scattered.  This adds a script, `scripts/run-local-analysis` to encapsulate the defaults so we don't have to include so much boilerplate in all our examples that quickly goes out of date.

It also moves the "Running the analysis" section into its own README and changes it to use Boulder (mainly because Cambridge requires overriding the input SRID).

This should replace Issue #10 and make the command examples in various other issues (e.g. #128) no longer necessary.  It should also make it easier to keep the behavior and parameters of the analysis well documented.

~~There are multiple TODOs here, but I wanted to put something up to facilitate the conversation in connection with the discussion on PR #133 ([here](https://github.com/azavea/pfb-network-connectivity/pull/133#issuecomment-285088349)) about putting the example source files in a publicly-accessible place.~~