### PR TITLE
Switch to Batch Unmanaged Compute Environment

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -2,6 +2,8 @@
 
 Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
 
+**NOTE**: Before deploying an AWS stack for the first time, ensure you've created the necessary resources detailed in the [AWS Batch](#aws-batch) section of this README.
+
 ## Table of Contents
 
 * [AWS Credentials](#aws-credentials)
@@ -60,27 +62,12 @@ Once these are created, the automated deployment handles creation of the latest 
 Login to the AWS Console and navigate to [AWS Batch: Compute Environments](https://console.aws.amazon.com/batch/home?region=us-east-1#/compute-environments)
 
 Click the 'Create Environment' button, then edit the new form with the inputs below:
-- Compute environment type: 'managed'
-- Compute environment name: '<environment>-pfb-analysis-<on-demand|spot>-compute-environment'
+- Compute environment type: 'unmanaged'
+- Compute environment name: '<environment>-pfb-analysis-unmanaged-compute-environment'
 - Service role: AWSBatchServiceRole
 - Instance role: StagingContainerInstanceRole
 - EC2 key pair: your choice
 - Enable compute environment: [x]
-- Provisioning model:
-  - staging: 'on-demand' -- better fits fewer, should always be available for developers
-  - production: 'spot' -- better fits larger jobs with less stringent completion requirements
-- Allowed instance types:
-  - staging: 'm3.xlarge'
-  - production: 'm3.2xlarge'
-- Minimum vCPUs: 0
-- Desired vCPUs: 0
-- Maximum vCPUs: 256 (default is fine)
-- VPC ID: Choose the VPC that matches to the environment you're launching in
-  - e.g. VPC 'pfbStaging' for the staging environment
-- Subnets: Select all of the private subnets for the VPC you chose
-- Security groups: 'default'
-- EC2 tags:
-  - Key: 'environment', Value: '<staging|production>'
 Click 'Create' and wait for the compute environment to provision.
 
 Next, go to 'Job queues' -> 'Create queue' then edit the form with the inputs below:
@@ -88,7 +75,8 @@ Next, go to 'Job queues' -> 'Create queue' then edit the form with the inputs be
 - Priority: leave blank
 - Enable job queue: [x]
 - Select a compute environment: Choose the name of the environment you just created
-Lastly, click create.
+Click create. The job queue should be ready pretty much immediately.
 
-Congratulations, the necessary resources for your environment are ready!
+Once the unmanaged compute environment has a 'VALID' status, navigate to [EC2 Container Service](https://console.aws.amazon.com/ecs/home?region=us-east-1) and copy the full name of the newly created ECS Cluster into the `batch_ecs_cluster_name` tfvar for the appropriate environment.
 
+Congratulations, the necessary resources for your environment are ready. The ECS instance configuration and autoscaling group attached to the compute environment are managed by Terraform.

--- a/deployment/aws-batch/job-definitions/pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/pfb-analysis-run-job.json
@@ -5,7 +5,7 @@
     "containerProperties": {
         "image": "{image}",
         "vcpus": 2,
-        "memory": 4096,
+        "memory": 12288,
         "command": [
             "/pfb/scripts/entrypoint.sh"
         ],
@@ -16,7 +16,19 @@
                 "sourcePath": "/media/nvme0n1/pgdata"
             }
         }],
-        "environment": [],
+        "environment": [{
+            "name": "PFB_MAINTENANCE_WORK_MEM",
+            "value": "2048MB"
+        }, {
+            "name": "PFB_SHARED_BUFFERS",
+            "value": "3072MB"
+        }, {
+            "name": "PFB_TEMP_FILE_LIMIT",
+            "value": "104857600"
+        }, {
+            "name": "PFB_WORK_MEM",
+            "value": "1536MB"
+        }],
         "mountPoints": [{
             "sourceVolume": "pgdata",
             "containerPath": "/pgdata",

--- a/deployment/aws-batch/job-definitions/pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/pfb-analysis-run-job.json
@@ -4,15 +4,24 @@
     "parameters": {},
     "containerProperties": {
         "image": "{image}",
-        "vcpus": 4,
+        "vcpus": 2,
         "memory": 4096,
         "command": [
             "/pfb/scripts/entrypoint.sh"
         ],
         "jobRoleArn": "",
-        "volumes": [],
+        "volumes": [{
+            "name": "pgdata",
+            "host": {
+                "sourcePath": "/media/nvme0n1/pgdata"
+            }
+        }],
         "environment": [],
-        "mountPoints": [],
+        "mountPoints": [{
+            "sourceVolume": "pgdata",
+            "containerPath": "/pgdata",
+            "readOnly": false
+        }],
         "readonlyRootFilesystem": false,
         "privileged": true,
         "ulimits": [],

--- a/deployment/terraform/batch-container-service.tf
+++ b/deployment/terraform/batch-container-service.tf
@@ -1,0 +1,80 @@
+#
+# Security group resources
+#
+resource "aws_security_group" "batch_container_instance" {
+  vpc_id = "${module.vpc.id}"
+
+  tags {
+    Name        = "sgBatchContainerInstance"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# Autoscaling Resources
+#
+data "template_file" "batch_container_instance_cloud_config" {
+  template = "${file("cloud-config/ecs-batch-user-data.yml")}"
+
+  vars {
+    ecs_cluster_name = "${var.batch_ecs_cluster_name}"
+    environment      = "${var.environment}"
+  }
+}
+
+resource "aws_launch_configuration" "batch_container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  ebs_optimized = true
+  iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
+  image_id             = "${var.ecs_instance_ami_id}"
+  instance_type        = "${var.batch_container_instance_type}"
+  key_name             = "${var.aws_key_name}"
+  security_groups      = ["${aws_security_group.container_instance.id}"]
+
+  user_data = "${data.template_file.batch_container_instance_cloud_config.rendered}"
+}
+
+resource "aws_autoscaling_group" "batch_container_instance" {
+  name = "asg${var.environment}BatchContainerInstance"
+
+  launch_configuration      = "${aws_launch_configuration.batch_container_instance.name}"
+  health_check_type         = "EC2"
+  desired_capacity          = "${var.batch_container_instance_asg_desired_capacity}"
+  min_size                  = "${var.batch_container_instance_asg_min_size}"
+  max_size                  = "${var.batch_container_instance_asg_max_size}"
+
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+
+  vpc_zone_identifier = ["${module.vpc.private_subnet_ids}"]
+
+  tag {
+    key                 = "Name"
+    value               = "BatchContainerInstance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = "${var.project}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.environment}"
+    propagate_at_launch = true
+  }
+}

--- a/deployment/terraform/cloud-config/ecs-batch-user-data.yml
+++ b/deployment/terraform/cloud-config/ecs-batch-user-data.yml
@@ -1,0 +1,78 @@
+#cloud-config
+
+packages:
+    - awslogs
+
+fs_setup:
+  - label: nvme0n1
+    filesystem: ext4
+    extra_opts: ["-E", "nodiscard"]
+    device: /dev/nvme0n1
+    partition: auto
+
+mounts:
+  - [ /dev/nvme0n1, null ]
+  - [ /dev/nvme0n1, "/media/nvme0n1", "ext4", "defaults,nobootwait,discard", "0", "2" ]
+
+runcmd:
+  - curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
+
+write_files:
+  - path: /etc/ecs/ecs.config
+    permissions: 0644
+    owner: root:root
+    content: |
+      ECS_CLUSTER=${ecs_cluster_name}
+  - path: /etc/awslogs/awslogs.conf
+    permissions: 0644
+    owner: root:root
+    content: |
+      [general]
+      state_file = /var/lib/awslogs/agent-state
+
+      [/var/log/dmesg]
+      file = /var/log/dmesg
+      log_group_name = log${environment}BatchContainerInstance
+      log_stream_name = dmesg/{instance_id}
+
+      [/var/log/messages]
+      file = /var/log/messages
+      log_group_name = log${environment}BatchContainerInstance
+      log_stream_name = messages/{instance_id}
+      datetime_format = %b %d %H:%M:%S
+
+      [/var/log/docker]
+      file = /var/log/docker
+      log_group_name = log${environment}BatchContainerInstance
+      log_stream_name = docker/{instance_id}
+      datetime_format = %Y-%m-%dT%H:%M:%S.%f
+
+      [/var/log/ecs/ecs-init.log]
+      file = /var/log/ecs/ecs-init.log.*
+      log_group_name = log${environment}BatchContainerInstance
+      log_stream_name = ecs-init/{instance_id}
+      datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+      [/var/log/ecs/ecs-agent.log]
+      file = /var/log/ecs/ecs-agent.log.*
+      log_group_name = log${environment}BatchContainerInstance
+      log_stream_name = ecs-agent/{instance_id}
+      datetime_format = %Y-%m-%dT%H:%M:%SZ
+
+  - path: /etc/init/awslogs.conf
+    permissions: 0644
+    owner: root:root
+    content: |
+      description "Configure and start CloudWatch Logs agent on Amazon ECS container instance"
+      author "Amazon Web Services"
+      start on started ecs
+      script
+          exec 2>>/var/log/ecs/cloudwatch-logs-start.log
+          set -x
+          until curl -s http://localhost:51678/v1/metadata
+          do
+              sleep 1
+          done
+          service awslogs start
+          chkconfig awslogs on
+      end script

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -101,14 +101,22 @@ variable "rds_alarm_disk_queue_threshold" {}
 variable "rds_alarm_free_disk_threshold" {}
 variable "rds_alarm_free_memory_threshold" {}
 
-# Batch
-variable "batch_analysis_compute_environment_arn" {}
-variable "batch_analysis_job_queue_name" {}
-variable "batch_analysis_job_definition_name_revision" {} # format: 'name:revision'
+# Batch ECS Cluster
+variable "batch_ecs_cluster_name" {}
+variable "batch_container_instance_type" {
+  description = "Must be one of the instance types in the AWS EC2 'i3' family"
+}
+variable "batch_container_instance_asg_desired_capacity" {}
+variable "batch_container_instance_asg_min_size" {}
+variable "batch_container_instance_asg_max_size" {}
 
+# Django
 variable "django_env" {}
 variable "django_secret_key" {}
 variable "django_allowed_hosts" {}
+variable "batch_analysis_compute_environment_arn" {}
+variable "batch_analysis_job_queue_name" {}
+variable "batch_analysis_job_definition_name_revision" {} # format: 'name:revision'
 
 variable "papertrail_host" {}
 variable "papertrail_port" {}

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -114,6 +114,7 @@ class AnalysisJob(PFBModel):
         definition_name, revision = job_definition.split(':')
         job_name = '{}--{}--{}'.format(definition_name[:30], revision, str(self.uuid)[:8])
         environment = create_environment(
+            PGDATA=os.path.join('/pgdata', str(self.uuid)),
             PFB_SHPFILE_URL=self.neighborhood.boundary_file.url,
             PFB_STATE=self.neighborhood.state_abbrev,
             PFB_STATE_FIPS=self.neighborhood.state.fips,


### PR DESCRIPTION
## Overview

Our analysis jobs require large amounts of scratch space for the postgresql data dir. This required switching to unmanaged CE's so that we can mount the ephemeral storage space provided by the `i3` EC2 instance class. 

Remaining TODOs:
- [x] Update deployment/README#aws-batch section with info on setting up unmanaged compute environment
- [x] Figure out how to autoscale this ECS cluster. We should be able to scale on CPU...this may need to be left to a separate task.

## Demo

![screen shot 2017-03-08 at 15 25 08](https://cloud.githubusercontent.com/assets/1818302/23722755/9203a7a8-0414-11e7-8497-72a09abbed6e.png)


## Notes

Left some comments in the diff for things I'm unsure of how to handle.

The Jenkins build is currently disabled so that merges to develop do not delete the extra ECS stack that was deployed via this branch. Re-enable Jenkins before merging.

#118 is no longer necessary as we're mounting an external docker volume

## Testing

Pull down this branch, start your local Django instance, and then run the following commands:
```
user = PFBUser.objects.first()

# Option 1, if gtown doesn't exist in your local db already
from django.core.files import File
boundary_file = File(open('/data/gtown_westside.zip'))
org = Organization.objects.first()
gtown = Neighborhood.objects.create(name='gtown-westside', label='Germantown, PA', boundary_file=boundary_file, organization=org, state_abbrev='PA', created_by=user, modified_by=user)
# OR option 2 if it does
gtown = Neighborhood.objects.first()

job = AnalysisJob.objects.create(neighborhood=gtown, created_by=user, modified_by=user)
job.run()
```
Watch the AWS Batch console to ensure the job you started succeeds. The job should run definition `staging-pfb-analysis-run-job:42`.


Connects #118, Connects #129 