### PR TITLE
Manually mount i3 instance family ephemeral storage

### DIFF
--- a/deployment/terraform/cloud-config/ecs-batch-user-data.yml
+++ b/deployment/terraform/cloud-config/ecs-batch-user-data.yml
@@ -3,19 +3,14 @@
 packages:
     - awslogs
 
-fs_setup:
-  - label: nvme0n1
-    filesystem: ext4
-    extra_opts: ["-E", "nodiscard"]
-    device: /dev/nvme0n1
-    partition: auto
-
-mounts:
-  - [ /dev/nvme0n1, null ]
-  - [ /dev/nvme0n1, "/media/nvme0n1", "ext4", "defaults,nobootwait,discard", "0", "2" ]
-
 runcmd:
   - curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
+  # Manually mount i3 family ephemeral storage, see:
+  # https://bugs.launchpad.net/cloud-init/+bug/1672833
+  - mkfs.ext4 -E nodiscard /dev/nvme0n1
+  - mkdir -p /media/nvme0n1
+  - echo -e "/dev/nvme0n1\t/media/nvme0n1\text4\tdefaults,nofail,discard\t0\t2" >> /etc/fstab
+  - mount -a
 
 write_files:
   - path: /etc/ecs/ecs.config


### PR DESCRIPTION
## Overview

The fs_setup cloud-config directive was not properly mounting the i3 instance family ephemeral storage, discovered when our docker volume mount point mounted directly on the 8Gb root volume and a job ran out of disk space.

See https://bugs.launchpad.net/cloud-init/+bug/1672833 for a detailed breakdown of why this solution is necessary

## Demo

Mounted disks after boot:

![screen shot 2017-03-14 at 15 12 15](https://cloud.githubusercontent.com/assets/1818302/23918382/1d31944e-08c9-11e7-8e7b-33d9d65cadf8.png)

From /var/log/cloud-init-output.log:

![screen shot 2017-03-14 at 15 16 45](https://cloud.githubusercontent.com/assets/1818302/23918422/4436208c-08c9-11e7-8ecf-dd8600157978.png)

## Testing

Nothing really to test, with this configuration applied via `./scripts/infra plan && ./scripts/infra apply` the ephemeral device is properly mounted at the expected location as evidenced in the screenshots above.

Connects #163 
