### PR TITLE
Serve Django static files from nginx container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ deployment/ansible/*.retry
 data/*
 !data/.gitkeep
 
+# Static Directory
+src/nginx/srv/static/*
+!src/nginx/srv/static/.gitkeep
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/common.yml
+++ b/common.yml
@@ -21,5 +21,5 @@ services:
     volumes:
       - ./data:/data
       - ./src/django:/usr/src
-      - ./src/nginx/srv/dist:/static/
+      - ./src/nginx/srv/static:/static/
       - $HOME/.aws:/root/.aws:ro

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -35,12 +35,20 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         echo "All tests pass!"
 
         # Copy static site from angularjs container to local nginx srv directory
-        echo "Copying angular site to nginx"
+        echo "Copying angular site to nginx..."
         pushd "${DIR}/../src/nginx"
         docker run -i -v "${PWD}/srv/dist:/static-export/dist" pfb-angularjs \
                rsync -rlptDv --delete --exclude .gitkeep \
                  /opt/pfb/angularjs/dist /static-export/
         popd
+
+        echo "Running Django collectstatic..."
+        GIT_COMMIT="${GIT_COMMIT}" \
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.test.yml \
+            run --rm --no-deps --entrypoint "./manage.py" \
+            django collectstatic --noinput
 
         echo "Building nginx image"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -43,16 +43,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-nginx:${GIT_COMMIT}"
             docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-app:${GIT_COMMIT}"
             docker push "${PFB_AWS_ECR_ENDPOINT}/pfb-analysis:${GIT_COMMIT}"
-
-            echo "Uploading static files to S3..."
-            PFB_S3STORAGE_BUCKET="${PFB_S3STORAGE_BUCKET}" \
-            GIT_COMMIT="${GIT_COMMIT}" \
-            docker-compose \
-                -f docker-compose.yml \
-                -f docker-compose.test.yml \
-                run --rm --no-deps --entrypoint "./manage.py" \
-                django collectstatic --noinput
-            echo "Upload complete!"
         else
             echo "ERROR: No PFB_AWS_ECR_ENDPOINT variable defined."
             exit 1

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -171,7 +171,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
-STATIC_URL = '/'
+STATIC_URL = '/static/'
 STATIC_ROOT = '/static/'
 
 # Logging

--- a/src/nginx/Dockerfile
+++ b/src/nginx/Dockerfile
@@ -5,6 +5,10 @@ MAINTAINER Azavea
 RUN mkdir -p /srv/dist && \
     chown nginx:nginx -R /srv/dist/
 
+RUN mkdir -p /srv/static && \
+    chown nginx:nginx -R /srv/static/
+
 COPY srv/dist /srv/dist/
+COPY srv/static /srv/static/
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf

--- a/src/nginx/etc/nginx/conf.d/default.conf
+++ b/src/nginx/etc/nginx/conf.d/default.conf
@@ -45,7 +45,7 @@ server {
         proxy_pass http://django-upstream;
     }
 
-    # Static Assets
+    # Angular Admin App
     location / {
         root /srv/dist;
         index index.json index.html;
@@ -55,5 +55,14 @@ server {
         proxy_redirect off;
 
         try_files $uri $uri/ =404;
+    }
+
+    # Django static assets
+    location /static {
+        alias /srv/static;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
     }
 }


### PR DESCRIPTION
## Overview

Updates the Nginx/Django configuration to compile and serve static files from a separate directory in the nginx container. 

## Demo

![screen shot 2017-03-14 at 16 14 49](https://cloud.githubusercontent.com/assets/1818302/23920599/bc509c70-08d1-11e7-8c36-7243b2ebe95c.png)

## Testing

```
export GIT_COMMIT=9051463
./scripts/cibuild
docker-compose -f docker-compose.yml -f docker-compose.test.yml up nginx
```
Navigate to http://localhost:9200/api/ which will serve static files from nginx. To prove this is the case, you can `rm -rf src/nginx/srv/static/*` and then request the same URL.

The staging site will stop properly serving the static assets if another branch is merged to develop before this one.

Connects #87 