### PR TITLE
Feature/awf/fix aws disk mount part ii

### DIFF
--- a/deployment/terraform/cloud-config/ecs-batch-user-data.yml
+++ b/deployment/terraform/cloud-config/ecs-batch-user-data.yml
@@ -3,24 +3,18 @@
 packages:
     - awslogs
 
-runcmd:
-  - curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
+bootcmd:
   # Manually mount i3 family ephemeral storage, see:
   # https://bugs.launchpad.net/cloud-init/+bug/1672833
-  # Before mounting, we need to stop the docker daemon and ECS agent. If we don't, then those
-  # services don't see the changed file handles at the mount point and continue to write data
-  # to the root volume at the block device mount point
-  # NOTE: It may be possible for a job to get taken before we have a chance to stop these
-  #       services. Not sure what the behavior is in that case. If we start seeing that once
-  #       autoscaling is implemented we'll need to address it separately
-  - stop ecs
-  - service docker stop
+  # Mounting in bootcmd ensures that the drive is mounted before the docker daemon
+  #   and ECS agent start, which avoids orphaned file handles
   - mkfs.ext4 -E nodiscard /dev/nvme0n1
   - mkdir -p /media/nvme0n1
   - echo -e "/dev/nvme0n1\t/media/nvme0n1\text4\tdefaults,nofail,discard\t0\t2" >> /etc/fstab
   - mount -a
-  - service docker start
-  - start ecs
+
+runcmd:
+  - curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
 
 write_files:
   - path: /etc/ecs/ecs.config

--- a/deployment/terraform/cloud-config/ecs-batch-user-data.yml
+++ b/deployment/terraform/cloud-config/ecs-batch-user-data.yml
@@ -7,10 +7,20 @@ runcmd:
   - curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
   # Manually mount i3 family ephemeral storage, see:
   # https://bugs.launchpad.net/cloud-init/+bug/1672833
+  # Before mounting, we need to stop the docker daemon and ECS agent. If we don't, then those
+  # services don't see the changed file handles at the mount point and continue to write data
+  # to the root volume at the block device mount point
+  # NOTE: It may be possible for a job to get taken before we have a chance to stop these
+  #       services. Not sure what the behavior is in that case. If we start seeing that once
+  #       autoscaling is implemented we'll need to address it separately
+  - stop ecs
+  - service docker stop
   - mkfs.ext4 -E nodiscard /dev/nvme0n1
   - mkdir -p /media/nvme0n1
   - echo -e "/dev/nvme0n1\t/media/nvme0n1\text4\tdefaults,nofail,discard\t0\t2" >> /etc/fstab
   - mount -a
+  - service docker start
+  - start ecs
 
 write_files:
   - path: /etc/ecs/ecs.config


### PR DESCRIPTION
## Overview

When we mounted the ephemeral block device manually in runcmd in #162, we were mounting after the docker daemon and ECS agent started. This leads to leaked file descriptors at the mount point, where new jobs taken by the ECS agent were still writing data to the root device. 

Mounting the ephemeral block device in `bootcmd` ensures that the mount happens before those services are started.

## Notes

The root volume still fills up slowly as jobs are run, due to the size of the containers that run the job. AWS ECS has a parameter where we can more aggressively clean up containers/images after they've stopped. Added separate issue #170 to address this.

## Demo

![screen shot 2017-03-15 at 15 59 02](https://cloud.githubusercontent.com/assets/1818302/23968440/1b39acfa-0999-11e7-869c-11090a6cd211.png)

## Testing

This change is deployed on the staging server and I've started to run larger jobs to test the analysis.


Connects #169 