### PR TITLE
Feature/awf/better analysis logging

### DIFF
--- a/deployment/aws-batch/job-definitions/pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/pfb-analysis-run-job.json
@@ -20,6 +20,9 @@
             "name": "PFB_MAINTENANCE_WORK_MEM",
             "value": "2048MB"
         }, {
+            "name": "PFB_MAX_WAL_SIZE",
+            "value": "4096MB"
+        }, {
             "name": "PFB_SHARED_BUFFERS",
             "value": "3072MB"
         }, {

--- a/pfb-analysis/import/import_jobs.sh
+++ b/pfb-analysis/import/import_jobs.sh
@@ -45,7 +45,7 @@ function import_job_data() {
         aws s3 cp "s3://${AWS_STORAGE_BUCKET_NAME}/data/${NB_JOB_FILENAME}.gz" "${JOB_DOWNLOAD}"
     else
         JOB_DOWNLOAD="${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz"
-        wget -O "${JOB_DOWNLOAD}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
+        wget -nv -O "${JOB_DOWNLOAD}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
     fi
     gunzip -c "${JOB_DOWNLOAD}" > "${NB_TEMPDIR}/${NB_JOB_FILENAME}"
 

--- a/pfb-analysis/import/import_osm.sh
+++ b/pfb-analysis/import/import_osm.sh
@@ -68,7 +68,7 @@ else
   OSM_API_URL="http://www.overpass-api.de/api/xapi?*[bbox=${BBOX_SW_LNG},${BBOX_SW_LAT},${BBOX_NE_LNG},${BBOX_NE_LAT}]"
   OSM_TEMPDIR=`mktemp -d`
   OSM_DATA_FILE="${OSM_TEMPDIR}/overpass.osm"
-  wget -O "${OSM_DATA_FILE}" "${OSM_API_URL}"
+  wget -nv -O "${OSM_DATA_FILE}" "${OSM_API_URL}"
 fi
 
 # import the osm with highways

--- a/pfb-analysis/scripts/entrypoint.sh
+++ b/pfb-analysis/scripts/entrypoint.sh
@@ -45,7 +45,7 @@ if [ "${PFB_SHPFILE_URL}" ]
 then
     echo "Downloading shapefile"
     pushd "${PFB_TEMPDIR}"
-    wget "${PFB_SHPFILE_URL}" -O boundary.zip
+    wget -nv "${PFB_SHPFILE_URL}" -O boundary.zip
     unzip boundary.zip
     PFB_SHPFILE="${PFB_TEMPDIR}"/$(ls *.shp)  # Assumes there's exactly one .shp file
     echo "Boundary shapefile is ${PFB_SHPFILE}"
@@ -57,7 +57,7 @@ if [ "${PFB_OSM_FILE_URL}" ]
 then
     echo "Downloading OSM file"
     pushd "${PFB_TEMPDIR}"
-    wget "${PFB_OSM_FILE_URL}" -O neighborhood_osm.zip
+    wget -nv "${PFB_OSM_FILE_URL}" -O neighborhood_osm.zip
     unzip neighborhood_osm.zip
     PFB_OSM_FILE="${PFB_TEMPDIR}"/$(ls *.osm)  # Assumes there's exactly one .osm file
     echo "OSM file is ${PFB_OSM_FILE}"

--- a/pfb-analysis/scripts/run_connectivity.sh
+++ b/pfb-analysis/scripts/run_connectivity.sh
@@ -23,19 +23,22 @@ MIN_PATH_BBOX="${MIN_PATH_BBOX:-3300}"                  # minimum corner-to-corn
 BLOCK_ROAD_BUFFER="${BLOCK_ROAD_BUFFER:-15}"            # buffer distance to find roads associated with a block
 BLOCK_ROAD_MIN_LENGTH="${BLOCK_ROAD_MIN_LENGTH:-30}"    # minimum length road must overlap with block buffer to be associated
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+# Limit custom output formatting for `time` command
+export TIME="\nTIMING: %C\nTIMING:\t%E elapsed %Kkb mem\n"
+
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f ../connectivity/build_network.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v block_road_buffer="${BLOCK_ROAD_BUFFER}" \
   -v block_road_min_length="${BLOCK_ROAD_MIN_LENGTH}" \
   -f ../connectivity/census_blocks.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f ../connectivity/reachable_roads_high_stress_prep.sql
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f ../connectivity/reachable_roads_high_stress_prep.sql
 
-/usr/bin/time -v parallel<<EOF
+/usr/bin/time parallel<<EOF
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_high_stress_calc.sql
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_high_stress_calc.sql
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_high_stress_calc.sql
@@ -46,12 +49,12 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_high_stress_calc.sql
 EOF
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f ../connectivity/reachable_roads_high_stress_cleanup.sql
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f ../connectivity/reachable_roads_high_stress_cleanup.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/reachable_roads_low_stress_prep.sql
 
-/usr/bin/time -v parallel<<EOF
+/usr/bin/time parallel<<EOF
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_low_stress_calc.sql
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_low_stress_calc.sql
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_low_stress_calc.sql
@@ -62,96 +65,96 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
 psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" -f ../connectivity/reachable_roads_low_stress_calc.sql
 EOF
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/reachable_roads_low_stress_cleanup.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_max_trip_distance="${NB_MAX_TRIP_DISTANCE}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f ../connectivity/connected_census_blocks.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_population.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/census_block_jobs.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_jobs.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v cluster_tolerance="${TOLERANCE_COLLEGES}" \
   -f ../connectivity/destinations/colleges.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v cluster_tolerance="${TOLERANCE_COMM_CTR}" \
   -f ../connectivity/destinations/community_centers.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v cluster_tolerance="${TOLERANCE_MEDICAL}" \
   -f ../connectivity/destinations/medical.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v cluster_tolerance="${TOLERANCE_PARKS}" \
   -f ../connectivity/destinations/parks.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v cluster_tolerance="${TOLERANCE_RETAIL}" \
   -f ../connectivity/destinations/retail.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f ../connectivity/destinations/schools.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f ../connectivity/destinations/social_services.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f ../connectivity/destinations/supermarkets.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -v cluster_tolerance="${TOLERANCE_UNIVERSITIES}" \
   -f ../connectivity/destinations/universities.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_colleges.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_community_centers.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_medical.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_parks.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_retail.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_schools.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_social_services.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_supermarkets.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v min_path_length="${MIN_PATH_LENGTH}" \
   -v min_bbox_length="${MIN_PATH_BBOX}" \
   -f ../connectivity/access_trails.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/access_universities.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/overall_scores.sql

--- a/pfb-analysis/scripts/setup_database.sh
+++ b/pfb-analysis/scripts/setup_database.sh
@@ -9,6 +9,9 @@ NB_POSTGRESQL_PASSWORD=gis
 PFB_AUTOVACUUM="${PFB_AUTOVACUUM:-off}"
 # Set defaults for overridable configuration params
 PFB_CHECKPOINT_COMPLETION="${PFB_CHECKPOINT_COMPLETION:-0.8}"
+# Since WAL size is deliberately small, suppress the checkpoint warnings
+# Default postgresql setting is 30, units are seconds
+PFB_CHECKPOINT_WARNING_INTERVAL="${PFB_CHECKPOINT_WARNING_INTERVAL:-0}"
 # Disable to improve performance, if disabled, data loss occurs on server crash (ok for analysis)
 PFB_FSYNC="${PFB_FSYNC:-on}"
 # Only one process at a time, can be higher, set to 1/4 of available system memory
@@ -30,6 +33,7 @@ PFB_WORK_MEM="${PFB_WORK_MEM:-512MB}"
 su postgres bash -c psql <<EOF
 ALTER SYSTEM SET autovacuum TO ${PFB_AUTOVACUUM};
 ALTER SYSTEM SET checkpoint_completion_target TO ${PFB_CHECKPOINT_COMPLETION};
+ALTER SYSTEM SET checkpoint_warning TO ${PFB_CHECKPOINT_WARNING_INTERVAL};
 ALTER SYSTEM SET fsync TO ${PFB_FSYNC};
 ALTER SYSTEM SET maintenance_work_mem TO '${PFB_MAINTENANCE_WORK_MEM}';
 ALTER SYSTEM SET max_wal_size TO '${PFB_MAX_WAL_SIZE}';


### PR DESCRIPTION
## Overview

The analysis job logs are very difficult to read in some cases. This makes a few improvements that should make reading job logs a bit easier.

- Use `wget -nv` (no verbose) to get summary info about the download, but don't report download progress
- Replace `/usr/bin/time -v` verbose output with a custom format string that only shows elapsed time and average memory usage.
- Add `AnalysisJob.logs_url` property which makes it easy to link to CloudWatch logs from the Django application

## Demo

![screen shot 2017-03-16 at 08 51 20](https://cloud.githubusercontent.com/assets/1818302/23997763/1954af76-0a29-11e7-87f6-5f8958677e4d.png)
![screen shot 2017-03-16 at 08 50 56](https://cloud.githubusercontent.com/assets/1818302/23997770/1e3af7e8-0a29-11e7-9103-91fc751d1d65.png)

## Testing

Rebuild analysis container, run Germantown job locally, inspect output.

Trigger a new job via Django. Wait for it to start running, then navigate to `job.logs_url`

