### PR TITLE
Feature/awf/analysis job running time

### DIFF
--- a/src/analysis/import/import_neighborhood.sh
+++ b/src/analysis/import/import_neighborhood.sh
@@ -102,6 +102,9 @@ then
                 AS boundary WHERE NOT ST_DWithin(blocks.geom, boundary.geom, \
                 ${NB_BOUNDARY_BUFFER});"
         echo "DONE: Finished removing blocks outside buffer"
+        echo "Census Blocks in analysis:"
+        psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+            -c "SELECT count(*) as total_census_blocks FROM neighborhood_census_blocks;"
 
         # Remove NB_TEMPDIR
         rm -rf "${NB_TEMPDIR}"

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -164,6 +164,7 @@ class AnalysisJob(PFBModel):
 
     @property
     def start_time(self):
+        """ Return start time of the job as a datetime object """
         first_update = self.status_updates.first()
         return first_update.timestamp if first_update else None
 

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -1,14 +1,29 @@
+from rest_framework import serializers
+
 from pfb_analysis.models import AnalysisJob, Neighborhood
 from pfb_network_connectivity.serializers import PFBModelSerializer
 
 
 class AnalysisJobSerializer(PFBModelSerializer):
 
+    running_time = serializers.SerializerMethodField()
+    start_time = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    def get_running_time(self, obj):
+        return obj.running_time
+
+    def get_start_time(self, obj):
+        return obj.start_time
+
+    def get_status(self, obj):
+        return obj.status
+
     class Meta:
         model = AnalysisJob
         exclude = ('created_at', 'modified_at', 'created_by', 'modified_by')
         read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
-                            'batch_job_id', 'status')
+                            'batch_job_id',)
 
 
 class NeighborhoodSerializer(PFBModelSerializer):

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -17,7 +17,7 @@ class AnalysisJobViewSet(ModelViewSet):
     queryset = AnalysisJob.objects.all()
     serializer_class = AnalysisJobSerializer
     permission_classes = (RestrictedCreate,)
-    filter_fields = ('status', 'neighborhood',)
+    filter_fields = ('neighborhood',)
     filter_backends = (DjangoFilterBackend, OrderingFilter,
                        OrgAutoFilterBackend, SelfUserAutoFilterBackend)
     ordering_fields = ('created_at',)


### PR DESCRIPTION
## Overview

Bah, apparently I never made a PR for this.

This adds the following properties to AnalysisJob:
- `running_time` 
- `start_time`

It also returns these properties in the API. 

Also fixes the issue with status no longer being a DB field, causing FilterSet issues. I fixed this in the simplest way possible by removing `status` filtering. If we want this back we'll need to explore other solutions later.

### Notes

Added a psql command in the analysis to print the number of census blocks in the analysis after import.

## Testing Instructions

Trigger a new AnalysisJob in the API, then view that job's detail view. You'll see the new properties, without errors.

Connects #182, #188 
