### PR TITLE
Add options for running development jobs

### DIFF
--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -179,7 +179,7 @@ data "template_file" "pfb_app_management_ecs_task" {
   template = "${file("task-definitions/management.json")}"
 
   vars {
-    management_url             = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb:${var.git_commit}"
+    management_url             = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb-app:${var.git_commit}"
     django_env                 = "${var.django_env}"
     django_secret_key          = "${var.django_secret_key}"
     rds_host                   = "${module.database.hostname}"

--- a/src/django/pfb_analysis/management/commands/run_analysis_job.py
+++ b/src/django/pfb_analysis/management/commands/run_analysis_job.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+from pfb_analysis.models import AnalysisJob, Neighborhood
+
+
+class Command(BaseCommand):
+    help = """ Create and run an AnalysisJob for the given neighborhood
+
+    The neighborhood name must match an existing Neighborhood for the user's organization.
+
+    """
+
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument('neighborhood')
+        parser.add_argument('--user', default='systems+pfb@azavea.com', type=str)
+
+    def handle(self, *args, **options):
+        UserModel = get_user_model()
+        user = UserModel.objects.get(email=options['user'])
+        neighborhood = Neighborhood.objects.get(name=options['neighborhood'],
+                                                organization=user.organization)
+        job = AnalysisJob.objects.create(neighborhood=neighborhood,
+                                         created_by=user,
+                                         modified_by=user)
+        job.run()
+        self.stdout.write('Started job {} for {}'.format(job.batch_job_id, neighborhood.name))

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -293,14 +293,23 @@ class AnalysisJob(PFBModel):
             logger.warn('Attempt to re-run job: {}. Skipping.'.format(self.uuid))
             return
 
-        client = boto3.client('batch')
-
         # Since we run django manage commands in the analysis container, it needs a copy of
         # all the environment variables that this app needs, most of which are conveniently
         # prefixed with 'PFB_'
         # Set these first so they can be overridden by job specific settings below
         environment = {key: val for (key, val) in os.environ.items()
                        if key.startswith('PFB_') and val is not None}
+        # For the ones without the 'PFB_' prefix, send the settings rather than the original
+        # environment variables because the environment variables might be None, which is not
+        # acceptable as a container override environment value, but the settings values will be set
+        # to whatever they default to in settings.
+        environment.update({
+            'DJANGO_ENV': settings.DJANGO_ENV,
+            'DJANGO_LOG_LEVEL': settings.DJANGO_LOG_LEVEL,
+            'AWS_DEFAULT_REGION': settings.AWS_REGION,
+        })
+
+        # Job-specific settings
         environment.update({
             'PGDATA': os.path.join('/pgdata', str(self.uuid)),
             'PFB_SHPFILE_URL': self.neighborhood.boundary_file.url,
@@ -308,18 +317,11 @@ class AnalysisJob(PFBModel):
             'PFB_STATE_FIPS': self.neighborhood.state.fips,
             'PFB_JOB_ID': str(self.uuid),
             'AWS_STORAGE_BUCKET_NAME': settings.AWS_STORAGE_BUCKET_NAME,
-
-            # For ENV variables that aren't prefixed with 'PFB_', send the settings rather
-            # than the original environment variables because the environment variables
-            # might be None, which is not acceptable as a container override environment
-            # value, but the settings values will be set to whatever they default to in settings.
-            'DJANGO_ENV': settings.DJANGO_ENV,
-            'DJANGO_LOG_LEVEL': settings.DJANGO_LOG_LEVEL,
-            'AWS_DEFAULT_REGION': settings.AWS_REGION,
         })
         if self.osm_extract_url:
             environment['PFB_OSM_FILE_URL'] = self.osm_extract_url
 
+        client = boto3.client('batch')
         container_overrides = {
             'environment': create_environment(**environment),
         }

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -321,6 +321,15 @@ class AnalysisJob(PFBModel):
         if self.osm_extract_url:
             environment['PFB_OSM_FILE_URL'] = self.osm_extract_url
 
+        # Workaround for not being able to run development jobs on the actual batch cluster:
+        # bail out with a helpful message
+        if settings.DJANGO_ENV == 'development':
+            logger.warn("Can't actually run development jobs on AWS. Try this:"
+                        "\nPFB_JOB_ID='{PFB_JOB_ID}' "
+                        "./scripts/run-local-analysis "
+                        "'{PFB_SHPFILE_URL}' {PFB_STATE} {PFB_STATE_FIPS}".format(**environment))
+            return
+
         client = boto3.client('batch')
         container_overrides = {
             'environment': create_environment(**environment),

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -199,7 +199,12 @@ logging.config.dictConfig({
         'django': {
             'handlers': ['console'],
             'level': DJANGO_LOG_LEVEL,
+        },
+        'pfb_analysis': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
         }
+
     }
 })
 


### PR DESCRIPTION
## Overview

Since we can't run local development jobs on the staging AWS Batch cluster after PR #179, provides two interim options:
- A management command to run a job from ECS "Run new task".  Requires that the neighborhood you want to run already exist.
- To make it easier to run the analysis locally, it prints the command that will do it, complete with job ID and shapefile URL.  The more complete version of this approach, where the django container actually connects to the host Docker daemon and starts the analysis job, seems like it would add a lot more work for not that much gain.  Indeed, opt-in (i.e. you have to copy the command and run it to make it go rather than having to cancel the run if you don't want it) seems like possibly the right choice for local development.

### Demo

Local, assuming you have a `germantown-philadelphia-pa` neighborhood:
![image](https://cloud.githubusercontent.com/assets/6598836/24212254/10f7d980-0f05-11e7-8d63-1e324bfc8bff.png)

On staging:
![image](https://cloud.githubusercontent.com/assets/6598836/24212880/1f2e8bfa-0f07-11e7-91cd-912dd5ca6e52.png)

Actually this is failing with "STOPPED (CannotPullContainerError: Error: image pfb:7a01b08)". Will investigate further.

### Notes

Pretty soon we should have front-end tools to create jobs and neighborhoods, so the process on staging should be pretty smooth.  But the problem of not having a full production-like environment for individual development remains.  The most complete approach--individual app and batch clusters for each developer--would be some work to set up and maintain, not to mention the potential for increased AWS costs.

## Testing Instructions

See Demo, but here are the commands for the local version:
In `shell_plus`:
```
user = PFBUser.objects.get(email='systems+pfb@azavea.com')
gtown = Neighborhood.objects.get(name='germantown-philadelphia-pa', organization=user.organization)
job = AnalysisJob.objects.create(neighborhood=gtown, created_by=user, modified_by=user)
job.run()
```
Then that will print a command that you can copy and run in the VM to run the analysis and save updates to the job.

Connects #199 