### PR TITLE
Feature/awf/analysis catch errors

### DIFF
--- a/src/analysis/scripts/entrypoint.sh
+++ b/src/analysis/scripts/entrypoint.sh
@@ -40,65 +40,16 @@ do
     ((counter++))
 done
 
-PFB_TEMPDIR=`mktemp -d`
-
-# If given a URL for the shapefile, dowload and unzip it. Overrides PFB_SHPFILE.
-if [ "${PFB_SHPFILE_URL}" ]
-then
-    update_status "IMPORTING" "Downloading shapefile"
-    pushd "${PFB_TEMPDIR}"
-    wget -nv "${PFB_SHPFILE_URL}" -O boundary.zip
-    unzip boundary.zip
-    PFB_SHPFILE="${PFB_TEMPDIR}"/$(ls *.shp)  # Assumes there's exactly one .shp file
-    echo "Boundary shapefile is ${PFB_SHPFILE}"
-    popd
+if /opt/pfb/analysis/scripts/run_analysis.sh; then
+    update_status "COMPLETE" "Finished"
+else
+    update_status "ERROR" "Failed" "See job logs for more details."
 fi
-
-# If given a URL for the OSM file, dowload and unzip it. Overrides PFB_OSM_FILE.
-if [ "${PFB_OSM_FILE_URL}" ]
-then
-    update_status "IMPORTING" "Downloading OSM file"
-    pushd "${PFB_TEMPDIR}"
-    wget -nv "${PFB_OSM_FILE_URL}"
-
-    PFB_OSM_FILE_ZIPPED="${PFB_TEMPDIR}"/$(ls *.osm.* || true)
-    echo "Zipped OSM file is ${PFB_OSM_FILE_ZIPPED}"
-    case "${PFB_OSM_FILE_ZIPPED}" in
-        *.bz2)     bunzip2 "${PFB_OSM_FILE_ZIPPED}" ;;
-        *.gz)      gunzip "${PFB_OSM_FILE_ZIPPED}" ;;
-        *.zip)     unzip "${PFB_OSM_FILE_ZIPPED}" ;;
-        *)         echo "Unrecognized zip format, skipping..." ;;
-    esac
-
-    PFB_OSM_FILE="${PFB_TEMPDIR}"/$(ls *.osm)  # Assumes there's exactly one .osm file
-    echo "OSM file is ${PFB_OSM_FILE}"
-    popd
-fi
-
-# run job
-cd /opt/pfb/analysis
-
-# determine coordinate reference system based on input shapefile UTM zone
-export NB_OUTPUT_SRID="$(./scripts/detect_utm_zone.py $PFB_SHPFILE)"
-
-./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS $PFB_OSM_FILE
-./scripts/run_connectivity.sh
-
-# print scores (TODO: replace with export script)
-psql -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" <<EOF
-SELECT * FROM neighborhood_overall_scores;
-EOF
-
-NB_OUTPUT_DIR="${NB_OUTPUT_DIR:-$PFB_TEMPDIR}"
-./scripts/export_connectivity.sh $NB_OUTPUT_DIR $PFB_JOB_ID
 
 # This will exit immediately when there's no pseudo-TTY but provide a shell if there is,
 # so it enables keeping a docker container alive after processing by running it with `-t`
 bash
 
-rm -rf "${PFB_TEMPDIR}"
-
-update_status "COMPLETE" "Finished"
 
 # shutdown postgres
 su postgres -c "/usr/lib/postgresql/9.6/bin/pg_ctl stop"

--- a/src/analysis/scripts/run_analysis.sh
+++ b/src/analysis/scripts/run_analysis.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+export NB_POSTGRESQL_DB=pfb
+export NB_POSTGRESQL_USER=gis
+export NB_POSTGRESQL_PASSWORD=gis
+
+source "$(dirname $0)"/utils.sh
+
+PFB_TEMPDIR=`mktemp -d`
+
+# If given a URL for the shapefile, dowload and unzip it. Overrides PFB_SHPFILE.
+if [ "${PFB_SHPFILE_URL}" ]
+then
+    update_status "IMPORTING" "Downloading shapefile"
+    pushd "${PFB_TEMPDIR}"
+    wget -nv "${PFB_SHPFILE_URL}" -O boundary.zip
+    unzip boundary.zip
+    PFB_SHPFILE="${PFB_TEMPDIR}"/$(ls *.shp)  # Assumes there's exactly one .shp file
+    echo "Boundary shapefile is ${PFB_SHPFILE}"
+    popd
+fi
+
+# If given a URL for the OSM file, dowload and unzip it. Overrides PFB_OSM_FILE.
+if [ "${PFB_OSM_FILE_URL}" ]
+then
+    update_status "IMPORTING" "Downloading OSM file"
+    pushd "${PFB_TEMPDIR}"
+    wget -nv "${PFB_OSM_FILE_URL}"
+
+    PFB_OSM_FILE_ZIPPED="${PFB_TEMPDIR}"/$(ls *.osm.* || true)
+    echo "Zipped OSM file is ${PFB_OSM_FILE_ZIPPED}"
+    case "${PFB_OSM_FILE_ZIPPED}" in
+        *.bz2)     bunzip2 "${PFB_OSM_FILE_ZIPPED}" ;;
+        *.gz)      gunzip "${PFB_OSM_FILE_ZIPPED}" ;;
+        *.zip)     unzip "${PFB_OSM_FILE_ZIPPED}" ;;
+        *)         echo "Unrecognized zip format, skipping..." ;;
+    esac
+
+    PFB_OSM_FILE="${PFB_TEMPDIR}"/$(ls *.osm)  # Assumes there's exactly one .osm file
+    echo "OSM file is ${PFB_OSM_FILE}"
+    popd
+fi
+
+# run job
+pushd /opt/pfb/analysis
+
+# determine coordinate reference system based on input shapefile UTM zone
+export NB_OUTPUT_SRID="$(./scripts/detect_utm_zone.py $PFB_SHPFILE)"
+
+./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS $PFB_OSM_FILE
+./scripts/run_connectivity.sh
+
+# print scores (TODO: replace with export script)
+psql -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" <<EOF
+SELECT * FROM neighborhood_overall_scores;
+EOF
+
+NB_OUTPUT_DIR="${NB_OUTPUT_DIR:-$PFB_TEMPDIR}"
+./scripts/export_connectivity.sh $NB_OUTPUT_DIR $PFB_JOB_ID
+
+rm -rf "${PFB_TEMPDIR}"
+
+popd

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -198,23 +198,9 @@ class AnalysisJob(PFBModel):
 
     @property
     def status(self):
-        """ Return current status for this job
-
-        Uses AnalysisJobStatusUpdate but checks the batch job for situations that status
-        updates don't cover.
-        """
-        # If there's no job ID that means it's brand new
-        if self.batch_job_id is None:
-            return self.Status.CREATED
-
-        if self.batch_job_status == JobState.FAILED:
-            return self.Status.ERROR
-        try:
-            # If the job hasn't failed and has sent any status updates, use the latest
-            return self.status_updates.last().status
-        except AttributeError:
-            # Not failed but no status updates means it must be in the queue
-            return self.Status.QUEUED
+        """ Return current status for this job """
+        latest_update = self.status_updates.last()
+        return latest_update.status if latest_update else self.Status.CREATED
 
     @property
     def batch_job_status(self):

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -317,8 +317,8 @@ class AnalysisJob(PFBModel):
             self.batch_job_id = response['jobId']
             self.save()
             AnalysisJobStatusUpdate.objects.create(job=self,
-                                                   status=self.Status.CREATED,
-                                                   step='CREATED')
+                                                   status=self.Status.QUEUED,
+                                                   step=self.Status.QUEUED)
         except (botocore.exceptions.BotoCoreError, KeyError):
             logger.exception('Error starting AnalysisJob {}'.format(self.uuid))
 


### PR DESCRIPTION
## Overview

Moves the code in entrypoint.sh related to running the analysis to a separate script, so that we can catch all errors that happen while that script is executing, and push the appropriate status to the Django app when a job completes (or fails)

Also greatly simplifies `AnalysisJob.status` and removes the HTTP call that property makes via the AWS Batch boto library.

## Testing

**Running:**
```
PFB_OSM_FILE_URL=https://s3.amazonaws.com/test-pfb-inputs/germantown/gtown_westside.osm.zip AWS_PROFILE=pfb ./scripts/run-local-analysis https://s3.amazonaws.com/test-pfb-inputs/germantown/gtown_westside.zip pa 42
```
Outputs:
![screen shot 2017-03-22 at 14 38 37](https://cloud.githubusercontent.com/assets/1818302/24215856/87d625f6-0f10-11e7-9c68-f5e2ada05305.png)


**Running (a failure):**
```
PFB_OSM_FILE_URL=https://s3.amazonaws.com/test-pfb-inputs/this/does/not/exist.zip AWS_PROFILE=pfb ./scripts/run-local-analysis https://s3.amazonaws.com/test-pfb-inputs/germantown/gtown_westside.zip pa 42
```
Outputs:
![screen shot 2017-03-22 at 14 31 44](https://cloud.githubusercontent.com/assets/1818302/24215872/92746e96-0f10-11e7-9cb0-1d6ebd6e7d0d.png)


Connects #189  