### PR TITLE
Fixup management container image url

### DIFF
--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -179,7 +179,7 @@ data "template_file" "pfb_app_management_ecs_task" {
   template = "${file("task-definitions/management.json")}"
 
   vars {
-    management_url             = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb:${var.git_commit}"
+    management_url             = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pfb-app:${var.git_commit}"
     django_env                 = "${var.django_env}"
     django_secret_key          = "${var.django_secret_key}"
     rds_host                   = "${module.database.hostname}"


### PR DESCRIPTION
## Overview

Fixes container image URL for the management task definition.

Addresses the issue in your PR where you're unable to properly run management commands due to an invalid container image tag.


### Notes

Didn't deploy, this is untested, but the name now matches the one used for the app task, and there are no other instances of the string `management_url` in the terraform code.
