### PR TITLE
Tweak ECS agent image cleanup on batch stack

### DIFF
--- a/deployment/terraform/batch-container-service.tf
+++ b/deployment/terraform/batch-container-service.tf
@@ -18,8 +18,11 @@ data "template_file" "batch_container_instance_cloud_config" {
   template = "${file("cloud-config/ecs-batch-user-data.yml")}"
 
   vars {
-    ecs_cluster_name = "${var.batch_ecs_cluster_name}"
-    environment      = "${var.environment}"
+    ecs_cluster_name                        = "${var.batch_ecs_cluster_name}"
+    environment                             = "${var.environment}"
+    ecs_engine_task_cleanup_wait_duration   = "${var.batch_ecs_engine_task_cleanup_wait_duration}"
+    ecs_image_cleanup_interval              = "${var.batch_ecs_image_cleanup_interval}"
+    ecs_image_minimum_cleanup_age           = "${var.batch_ecs_image_minimum_cleanup_age}"
   }
 }
 

--- a/deployment/terraform/cloud-config/ecs-batch-user-data.yml
+++ b/deployment/terraform/cloud-config/ecs-batch-user-data.yml
@@ -22,6 +22,9 @@ write_files:
     owner: root:root
     content: |
       ECS_CLUSTER=${ecs_cluster_name}
+      ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=${ecs_engine_task_cleanup_wait_duration}
+      ECS_IMAGE_CLEANUP_INTERVAL=${ecs_image_cleanup_interval}
+      ECS_IMAGE_MINIMUM_CLEANUP_AGE=${ecs_image_minimum_cleanup_age}
   - path: /etc/awslogs/awslogs.conf
     permissions: 0644
     owner: root:root

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -109,6 +109,15 @@ variable "batch_container_instance_type" {
 variable "batch_container_instance_asg_desired_capacity" {}
 variable "batch_container_instance_asg_min_size" {}
 variable "batch_container_instance_asg_max_size" {}
+variable "batch_ecs_engine_task_cleanup_wait_duration" {
+  default = "5m"
+}
+variable "batch_ecs_image_cleanup_interval" {
+  default = "10m"
+}
+variable "batch_ecs_image_minimum_cleanup_age" {
+  default = "30m"
+}
 
 # Django
 variable "django_env" {}


### PR DESCRIPTION
## Overview

More aggressive removal of containers prevents us from filling up the root volume with stopped containers when many analysis jobs are run at once in a batch

### Demo

![screen shot 2017-03-22 at 21 25 38](https://cloud.githubusercontent.com/assets/1818302/24227810/5e59f744-0f46-11e7-9add-117412b194b2.png)

## Testing Instructions

Nothing really. Change is deployed on current staging batch container instance.

Connects #170 