### PR TITLE
Remove angularjs build container after rsync

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -37,7 +37,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Copy static site from angularjs container to local nginx srv directory
         echo "Copying angular site to nginx..."
         pushd "${DIR}/../src/nginx"
-        docker run -i -v "${PWD}/srv/dist:/static-export/dist" pfb-angularjs \
+        docker run --rm -i -v "${PWD}/srv/dist:/static-export/dist" pfb-angularjs \
                rsync -rlptDv --delete --exclude .gitkeep \
                  /opt/pfb/angularjs/dist /static-export/
         popd


### PR DESCRIPTION
## Overview

Not removing this was causing incremental disk space usage and a bunch of leftover exited containers on the CI server

@azavea/operations 