### PR TITLE
Create analysis job view

### DIFF
--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
@@ -1,0 +1,46 @@
+/**
+ * @ngdoc controller
+ * @name pfb.analysisJobs.create.controller:AnalysisJobCreateController
+ *
+ * @description
+ * Controller for creating/running an analysis job
+ *
+ */
+(function() {
+    'use strict';
+
+    /** @ngInject */
+    function AnalysisJobCreateController($state, $filter, toastr, AnalysisJob, Neighborhood) {
+        var ctl = this;
+
+        function initialize() {
+            ctl.neighborhoods = Neighborhood.all();
+            ctl.neighborhoods.$promise.then(function(data) {
+                ctl.neighborhoods = data;
+            });
+        }
+
+        initialize();
+
+        ctl.create = function() {
+            var submitToast = toastr.info('Submitting analysis job. Please wait...',
+                                          {autoDismiss: false});
+
+            var job = new AnalysisJob({
+                neighborhood: ctl.neighborhood.uuid,
+                osm_extract_url: ctl.osmUrl
+            });
+            job.$save().then(function() {
+                toastr.clear(submitToast);
+                toastr.success('Successfully submitted analysis job');
+                $state.go('analysis-jobs.list');
+            }).catch(function(error) {
+                toastr.clear(submitToast);
+                toastr.error('Error submitting analysis job: ' + error);
+            });
+        };
+    }
+    angular
+        .module('pfb.analysisJobs.create')
+        .controller('AnalysisJobCreateController', AnalysisJobCreateController);
+})();

--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
@@ -14,9 +14,8 @@
         var ctl = this;
 
         function initialize() {
-            ctl.neighborhoods = Neighborhood.all();
-            ctl.neighborhoods.$promise.then(function(data) {
-                ctl.neighborhoods = data;
+            ctl.neighborhoods = Neighborhood.all().$promise.then(function(data) {
+                ctl.neighborhoods = data.results;
             });
         }
 

--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.html
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.html
@@ -1,0 +1,36 @@
+<pfb-navbar></pfb-navbar>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-md-push-1">
+      <h1>Run Analysis</h1>
+      <form name="analysisJobCreateForm" novalidate ng-submit="analysisJobCreate.create()">
+        <div class="row">
+          <div class="col-sm-4">
+            <div class="form-group">
+              <label for="role">Neighborhood</label>
+              <select ng-model="analysisJobCreate.neighborhood"
+                      ng-options="neighborhood as neighborhood.label for neighborhood
+                      in analysisJobCreate.neighborhoods track by neighborhood.uuid"
+                      class="form-control" id="neighborhood" type="text" required>
+              </select>
+            </div>
+          </div>
+          <div class="col-sm-4">
+            <div class="form-group">
+              <label for="label">OSM extract URL (optional)</label>
+              <input ng-model="analysisJobCreate.osmUrl"
+                     class="form-control" id="osmUrl" type="url">
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-12">
+            <button type="submit" ng-disabled="analysisJobCreateForm.$invalid"
+                    class="btn-primary btn">Submit Analysis Job</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/angularjs/src/app/analysis-jobs/create/module.js
+++ b/src/angularjs/src/app/analysis-jobs/create/module.js
@@ -1,0 +1,4 @@
+(function () {
+    'use strict';
+    angular.module('pfb.analysisJobs.create', []);
+ })();

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -3,17 +3,18 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 col-md-push-1">
+      <button ng-if="navbar.isAdminUser"
+        ui-sref="analysis-jobs.create" class="btn btn-primary pull-right">
+        Run Analysis
+      </button>
       <h1 class="no-margin-top">Analysis Jobs</h1>
       <table class="table">
         <thead pfb-analysis-job-filter filters="analysisJobList.filters"></thead>
         <tbody>
           <tr ng-repeat="analysisJob in analysisJobList.analysisJobs">
-            <td>
-              {{analysisJob.uuid | limitTo: 5}}
-            </td>
-            <td>{{analysisJob.status | displayStatus}}
-            </td>
-            <td>{{analysisJob.neighborhood}}</td>
+            <td>{{analysisJob.uuid | limitTo: 5}}</td>
+            <td>{{analysisJob.status | displayStatus}}</td>
+            <td>{{analysisJob.neighborhood_label}}</td>
             <td>{{analysisJob.batch_job_id}}</td>
             <td>{{analysisJob.createdAt | date:'yyyy-MM-dd HH:mm:ss'}}</td>
             <td>

--- a/src/angularjs/src/app/analysis-jobs/module.js
+++ b/src/angularjs/src/app/analysis-jobs/module.js
@@ -2,5 +2,7 @@
     'use strict';
 
     angular.module('pfb.analysisJobs',
-                   ['pfb.analysisJobs.constants', 'pfb.analysisJobs.list']);
+                   ['pfb.analysisJobs.constants',
+                    'pfb.analysisJobs.list',
+                    'pfb.analysisJobs.create']);
 })();

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
@@ -8,7 +8,7 @@
      * Controller for the analysis job filtering table header
      */
     /** @ngInject */
-    function AnalysisJobFilterController($scope, $http, AuthService, AnalysisJobStatuses) {
+    function AnalysisJobFilterController($scope, Neighborhood, AuthService, AnalysisJobStatuses) {
         var ctl = this;
         initialize();
 
@@ -20,7 +20,7 @@
         }
 
         function loadOptions() {
-            $http.get('/api/neighborhoods/').success(function(data) {
+            Neighborhood.all().$promise.then(function(data) {
                 ctl.neighborhoods = data.results;
             });
 

--- a/src/angularjs/src/app/components/neighborhoods.service.js
+++ b/src/angularjs/src/app/components/neighborhoods.service.js
@@ -14,6 +14,13 @@
             'query': {
                 method: 'GET',
                 isArray: false
+            },
+            'all': {
+                method: 'GET',
+                isArray: false,
+                params: {
+                    limit: 10000
+                }
             }
         });
     }

--- a/src/angularjs/src/app/components/neighborhoods.service.js
+++ b/src/angularjs/src/app/components/neighborhoods.service.js
@@ -19,7 +19,7 @@
                 method: 'GET',
                 isArray: false,
                 params: {
-                    limit: 10000
+                    limit: 'all'
                 }
             }
         });

--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -89,6 +89,12 @@
                 controllerAs: 'analysisJobList',
                 templateUrl: 'app/analysis-jobs/list/analysis-jobs-list.html'
             })
+            .state('analysis-jobs.create', {
+                url: 'create/',
+                controller: 'AnalysisJobCreateController',
+                controllerAs: 'analysisJobCreate',
+                templateUrl: 'app/analysis-jobs/create/analysis-jobs-create.html'
+            })
             .state('neighborhoods', {
                 abstract: true,
                 url: '/neighborhoods/?limit&offset',

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -9,6 +9,8 @@ class AnalysisJobSerializer(PFBModelSerializer):
     running_time = serializers.SerializerMethodField()
     start_time = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
+    neighborhood_label = serializers.SerializerMethodField()
+    neighborhood = serializers.PrimaryKeyRelatedField(queryset=Neighborhood.objects.all())
 
     def get_running_time(self, obj):
         return obj.running_time
@@ -18,6 +20,9 @@ class AnalysisJobSerializer(PFBModelSerializer):
 
     def get_status(self, obj):
         return obj.status
+
+    def get_neighborhood_label(self, obj):
+        return obj.neighborhood.label
 
     class Meta:
         model = AnalysisJob

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from pfb_analysis.models import AnalysisJob, Neighborhood
 from pfb_analysis.serializers import AnalysisJobSerializer, NeighborhoodSerializer
+from pfb_network_connectivity.pagination import OptionalLimitOffsetPagination
 from pfb_network_connectivity.filters import (OrgAutoFilterBackend,
                                               SelfUserAutoFilterBackend,
                                               AnalysisJobStatusFilterSet)
@@ -37,6 +38,7 @@ class NeighborhoodViewSet(ModelViewSet):
 
     queryset = Neighborhood.objects.all()
     serializer_class = NeighborhoodSerializer
+    pagination_class = OptionalLimitOffsetPagination
     permission_classes = (IsAdminOrgAndAdminCreateEditOnly,)
     filter_fields = ('organization', 'name', 'label', 'state_abbrev')
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -23,7 +23,8 @@ class AnalysisJobViewSet(ModelViewSet):
     permission_classes = (RestrictedCreate,)
     filter_class = AnalysisJobStatusFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
-    ordering_fields = ('created_at',)
+    ordering_fields = ('created_at', 'modified_at')
+    ordering = ('-created_at',)
 
     def perform_create(self, serializer):
         """ Start analysis jobs as soon as created """

--- a/src/django/pfb_network_connectivity/pagination.py
+++ b/src/django/pfb_network_connectivity/pagination.py
@@ -1,0 +1,24 @@
+from rest_framework.pagination import LimitOffsetPagination, _get_count
+
+
+class OptionalLimitOffsetPagination(LimitOffsetPagination):
+    """
+    Allow client to request all by setting limit parameter to 'all'
+
+    Inspired by https://github.com/azavea/ashlar/blob/develop/ashlar/pagination.py
+    """
+    def paginate_queryset(self, queryset, request, view=None):
+        self.limit = self.get_limit(request)
+        # set the limit to one more than the queryset count
+        if self.limit == 'all':
+            self.limit = _get_count(queryset) + 1
+        return super(OptionalLimitOffsetPagination, self).paginate_queryset(queryset, request, view)
+
+    def get_limit(self, request):
+        # If the limit is already set as an integer (e.g. because we're in the
+        # super.paginate_queryset call), just return it
+        if type(getattr(self, 'limit', None)) == int:
+            return self.limit
+        if self.limit_query_param and request.query_params.get(self.limit_query_param) == 'all':
+            return 'all'
+        return super(OptionalLimitOffsetPagination, self).get_limit(request)


### PR DESCRIPTION
## Overview

Adds a "Run Analysis" view to the management app, for kicking off analysis jobs.

### Demo

![image](https://cloud.githubusercontent.com/assets/6598836/24297842/83c38a92-107a-11e7-838b-148cea2eea10.png)

![image](https://cloud.githubusercontent.com/assets/6598836/24297819/71907768-107a-11e7-948f-8ebb07c208ed.png)

### Notes

- I added an `all` route to the neighborhoods endpoint because the droplist in this view and in the filter on the list view shouldn't be paginated.  Neighborhoods aren't very big, so I didn't bother to limit the fields returned, but we could if it seems laggy at all.
- I added a `neighborhood_label` SerializerMethodField to AnalysisJob so that we can show the label in the list.  Including the whole neighborhood with the job is pretty easy for GET requests but makes saving a bit more complicated, and I think label and ID (which is already there, in the `neighborhood` field) are all we're likely to need.

## Testing Instructions

With the AngularJS app running, go to http://localhost:9301/#/analysis-jobs/ and click 'Run Analysis'.  Pick a neighborhood and submit the job and it should put you back on the list view with your new job at the top, with status "Created".  Your Django container will have logged the command you can use to run that analysis job locally, so copy that and run it if you want to see the status change.

Resolves #141.