### PR TITLE
Add API view to cancel AnalysisJobs

### DIFF
--- a/src/django/pfb_analysis/management/commands/update_status.py
+++ b/src/django/pfb_analysis/management/commands/update_status.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from pfb_analysis.models import AnalysisJobStatusUpdate, AnalysisJob
+from pfb_analysis.models import AnalysisJob
 
 
 class Command(BaseCommand):
@@ -17,10 +17,7 @@ class Command(BaseCommand):
         try:
             job = AnalysisJob.objects.get(pk=options['job_id'])
         except (AnalysisJob.DoesNotExist, ValueError, KeyError):
-            print ('WARNING: Tried to update status for invalid job {job_id} '
-                   '(to {status} {step})'.format(**options))
+            print('WARNING: Tried to update status for invalid job {job_id} '
+                  '(to {status} {step})'.format(**options))
         else:
-            AnalysisJobStatusUpdate.objects.create(job=job,
-                                                   status=options['status'],
-                                                   step=options['step'],
-                                                   message=options['message'])
+            job.update_status(options['status'], step=options['step'], message=options['message'])

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -343,10 +343,7 @@ class AnalysisJob(PFBModel):
 
     def update_status(self, status, step='', message=''):
         if self.status != self.Status.CANCELLED:
-            AnalysisJobStatusUpdate.objects.create(job=self,
-                                                   status=status,
-                                                   step=step,
-                                                   message=message)
+            self.status_updates.create(job=self, status=status, step=step, message=message)
 
 
 class AnalysisJobStatusUpdate(models.Model):

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -270,7 +270,8 @@ class AnalysisJob(PFBModel):
         if self.status in self.Status.ACTIVE_STATUSES and self.batch_job_id is not None:
             client = boto3.client('batch')
             client.terminate_job(jobId=self.batch_job_id, reason=reason)
-        AnalysisJobStatusUpdate.objects.create(job=self, status=self.Status.CANCELLED, step='')
+        if self.status != self.Status.CANCELLED:
+            AnalysisJobStatusUpdate.objects.create(job=self, status=self.Status.CANCELLED, step='')
 
     def run(self):
         """ Run the analysis job, configuring ENV appropriately """

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+
 import us
 
 from django.utils.text import slugify
 
+from rest_framework import status
+from rest_framework.decorators import detail_route
 from rest_framework.filters import DjangoFilterBackend, OrderingFilter
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
@@ -29,6 +33,14 @@ class AnalysisJobViewSet(ModelViewSet):
         """ Start analysis jobs as soon as created """
         instance = serializer.save()
         instance.run()
+
+    @detail_route(methods=['post'])
+    def cancel(self, request, pk=None):
+        job = self.get_object()
+        job.cancel(reason='AnalysisJob terminated via API by {} at {}'
+                          .format(request.user.email, datetime.utcnow()))
+        serializer = AnalysisJobSerializer(job)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class NeighborhoodViewSet(ModelViewSet):


### PR DESCRIPTION
## Overview

Adds API view to cancel in progress AnalysisJobs

### Demo

<img width="1261" alt="screen shot 2017-03-24 at 15 21 40" src="https://cloud.githubusercontent.com/assets/1818302/24310430/52ecdeec-10a6-11e7-98fb-277e12be9812.png">

### Notes

I chose to do no error handling of exceptions fired by the AnalysisJob.cancel method. Theoretically, we could handle errors that happen within the boto calls, but the only HTTP status to return that _maybe_ makes more sense than the default 500 error is 503. And I'm not sure its worth it at this point to account for that.

## Testing Instructions

Get a token from http://localhost:9200/#/users/edit/:userid/ by clicking the 'refresh token' button.

Trigger a new analysis job via API views, curl, postman, etc. Note the new job's ID.

POST http://localhost:9200/api/analysis_jobs/:jobid/cancel/ via curl, postman, etc. The response should be the analysis job object, with `status: 'CANCELLED'`.


Closes #213 
