### PR TITLE
Add API view for AnalysisJob results

### DIFF
--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -28,7 +28,7 @@ class AnalysisJobSerializer(PFBModelSerializer):
         model = AnalysisJob
         exclude = ('created_at', 'modified_at', 'created_by', 'modified_by', 'overall_scores',)
         read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
-                            'batch_job_id', 'batch',)
+                            'batch_job_id', 'batch', 'census_block_count',)
 
 
 class NeighborhoodSerializer(PFBModelSerializer):

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -51,8 +51,7 @@ class AnalysisJobViewSet(ModelViewSet):
 
         if job.status == AnalysisJob.Status.COMPLETE:
             results = OrderedDict([
-                # TODO: Add once #183 is merged
-                # ('census_blocks_count', None),
+                ('census_block_count', job.census_block_count),
                 ('census_blocks_url', job.census_blocks_url),
                 ('destinations_urls', job.destinations_urls),
                 ('overall_scores', job.overall_scores),

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from datetime import datetime
 
 import us
@@ -43,6 +44,23 @@ class AnalysisJobViewSet(ModelViewSet):
                           .format(request.user.email, datetime.utcnow()))
         serializer = AnalysisJobSerializer(job)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @detail_route(methods=['GET'])
+    def results(self, request, pk=None):
+        job = self.get_object()
+
+        if job.status == AnalysisJob.Status.COMPLETE:
+            results = OrderedDict([
+                # TODO: Add once #183 is merged
+                # ('census_blocks_count', None),
+                ('census_blocks_url', job.census_blocks_url),
+                ('destinations_urls', job.destinations_urls),
+                ('overall_scores', job.overall_scores),
+                ('ways_url', job.ways_url),
+            ])
+            return Response(results, status=status.HTTP_200_OK)
+        else:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
 
 
 class NeighborhoodViewSet(ModelViewSet):

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -292,3 +292,19 @@ elif PFB_AWS_BATCH_JOB_DEFINITION_NAME:
 else:
     raise ImproperlyConfigured('env.PFB_AWS_BATCH_JOB_DEFINITION_NAME_REVISION or ' +
                                'env.PFB_AWS_BATCH_JOB_DEFINITION_NAME is required.')
+
+# Analysis results settings
+# A list of destinations types, created by the analysis, to be made available for download
+PFB_ANALYSIS_DESTINATIONS = [
+    'colleges',
+    'community_centers',
+    'medical',
+    'parks',
+    'retail',
+    'schools',
+    'social_services',
+    'supermarkets',
+    'universities',
+]
+# Length of time in seconds that S3 pre-signed urls are valid for
+PFB_ANALYSIS_PRESIGNED_URL_EXPIRES = 3600


### PR DESCRIPTION
## Overview

Adds an API view to give the user access to all available results from a single AnalysisJob.

Accessible at `/api/analysis_jobs/:jobId/results/`. If AnalysisJob.status != COMPLETE, then the endpoint returns 404 Not Found.


### Demo

![screen shot 2017-03-27 at 09 37 46](https://cloud.githubusercontent.com/assets/1818302/24359121/6171c5ae-12d1-11e7-81c1-cea09b93bcbb.png)
![screen shot 2017-03-27 at 09 38 13](https://cloud.githubusercontent.com/assets/1818302/24359122/6175e990-12d1-11e7-9c10-7a3eb2a15142.png)

## Notes

Will wait to merge until I can add the number of census blocks in the analysis to this endpoint, which is being added separately in #183 

## Testing Instructions

Run a local job to completion via the AnalysisJob.run() method. Then query the results endpoint mentioned above, and you should be able to view the overall scores and download the related results files.

Closes #211 
