### PR TITLE
Drop broken refs in osmconvert when clipping via bbox

### DIFF
--- a/src/analysis/import/import_osm.sh
+++ b/src/analysis/import/import_osm.sh
@@ -66,6 +66,7 @@ OSM_TEMPDIR=`mktemp -d`
 if [[ -f ${1} ]]; then
   update_status "IMPORTING" "Clipping provided OSM file"
   osmconvert "${1}" \
+    --drop-broken-refs \
     -b="${BBOX_SW_LNG}","${BBOX_SW_LAT}","${BBOX_NE_LNG}","${BBOX_NE_LAT}" \
     -o="${OSM_TEMPDIR}/converted.osm"
   OSM_DATA_FILE="${OSM_TEMPDIR}/converted.osm"


### PR DESCRIPTION
## Overview

See #216 and discussion in the linked osm2pgrouting issue for a detailed writeup.

This simply updates osmconvert to be called with the appropriate flag to avoid leaving broken node refs in the converted OSM data.


## Testing Instructions

After rebuilding the analysis container in the VM with `docker-compose build analysis`, run a job that makes use of a Mapzen Metro Extract. Example:
```
PFB_OSM_FILE_URL=https://s3.amazonaws.com/metro-extracts.mapzen.com/philadelphia_pennsylvania.osm.bz2 AWS_PROFILE=pfb ./scripts/run-local-analysis https://s3.amazonaws.com/test-pfb-inputs/germantown/gtown_westside.zip pa 42
```

Verify that while running the job, no lines like this:
```
Reference nd=4719271035 has no corresponding Node Entry (Maybe Node entry after Reference?)
```
are in the job output.

Closes #216 
