### PR TITLE
Update requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PFB Bicycle Network Connectivity
 ## Getting Started
 
 Requirements:
-- Vagrant 1.8+
+- Vagrant 1.8.3+
 - VirtualBox 4.3+
 - [AWS CLI](https://aws.amazon.com/cli/)
 


### PR DESCRIPTION
## Overview

We require Vagrant 1.8.3+ to make use of the ansible local provisioner

The `install_mode` option isn't available before this version
