### PR TITLE
Feature/awf/analysis new overall scores

### DIFF
--- a/src/analysis/scripts/export_connectivity.sh
+++ b/src/analysis/scripts/export_connectivity.sh
@@ -159,8 +159,7 @@ then
         # Export neighborhood_overall_scores as CSV
         ec_export_table_csv "${OUTPUT_DIR}" "neighborhood_overall_scores"
         # Send overall_scores to Django app
-        # TODO: Fixup after merging #222
-        # update_overall_scores "${OUTPUT_DIR}/neighborhood_score_inputs.csv"
+        update_overall_scores "${OUTPUT_DIR}/neighborhood_overall_scores.csv"
 
         if [ -v AWS_STORAGE_BUCKET_NAME ]
         then

--- a/src/analysis/scripts/run_analysis.sh
+++ b/src/analysis/scripts/run_analysis.sh
@@ -52,9 +52,9 @@ export NB_OUTPUT_SRID="$(./scripts/detect_utm_zone.py $PFB_SHPFILE)"
 ./scripts/import.sh $PFB_SHPFILE $PFB_STATE $PFB_STATE_FIPS $PFB_OSM_FILE
 ./scripts/run_connectivity.sh
 
-# print scores (TODO: replace with export script)
+# print scores
 psql -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" <<EOF
-SELECT * FROM neighborhood_score_inputs;
+SELECT * FROM neighborhood_overall_scores;
 EOF
 
 NB_OUTPUT_DIR="${NB_OUTPUT_DIR:-$PFB_TEMPDIR}"

--- a/src/analysis/scripts/utils.sh
+++ b/src/analysis/scripts/utils.sh
@@ -11,7 +11,7 @@ function update_overall_scores() {
     # Usage:
     #    update_overall_scores OVERALL_SCORES_CSV
 
-    /opt/pfb/django/manage.py load_overall_scores "${PFB_JOB_ID}" "$@"
+    /opt/pfb/django/manage.py load_overall_scores --skip-columns human_explanation "${PFB_JOB_ID}" "$@"
 }
 
 function set_job_attr() {

--- a/src/django/pfb_analysis/management/commands/set_job_attr.py
+++ b/src/django/pfb_analysis/management/commands/set_job_attr.py
@@ -18,7 +18,9 @@ class Command(BaseCommand):
         Invalid job ID warns, any other error raises """
         try:
             qs = AnalysisJob.objects.filter(pk=options['job_id'])
-        except (AnalysisJob.DoesNotExist):
+            # Force qs evaluation to catch invalid job_id errors
+            qs.exists()
+        except (ValueError, AnalysisJob.DoesNotExist):
             print ("WARNING: Tried to update attribute '{attr}' "
                    "for invalid job {job_id}.".format(**options))
         else:

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -298,7 +298,10 @@ else:
 PFB_ANALYSIS_DESTINATIONS = [
     'colleges',
     'community_centers',
-    'medical',
+    'doctors',
+    'dentists',
+    'hospitals',
+    'pharmacies',
     'parks',
     'retail',
     'schools',


### PR DESCRIPTION
## Overview

Fixes up django app fallout from #222 by updating the management command to properly import the necessary overall_scores values from the analysis

### Demo

![screen shot 2017-03-30 at 11 37 14](https://cloud.githubusercontent.com/assets/1818302/24512679/41e9d9c4-153d-11e7-8736-048469afb3d4.png)


### Notes

- Fixes bug in set_job_attr where the qs wasn't evaluated until the second exception block if an invalid job id was provided.
- Updates list of destinations files to export in Django settings.py
- 

## Testing Instructions

Run analysis job locally, hit results endpoint like in screenshot once complete.
