### PR TITLE
Angular AnalysisJob detail view

### DIFF
--- a/src/analysis/scripts/export_connectivity.sh
+++ b/src/analysis/scripts/export_connectivity.sh
@@ -149,9 +149,11 @@ then
         # Export neighborhood ways as GeoJSON
         # TODO: Export this once we know we need it
 
-        # Export neighborhood_connected_census_blocks as SHP
-        # NOTE: disabled for now, because large and not that useful
-        # ec_export_table_shp "${OUTPUT_DIR}" "neighborhood_connected_census_blocks"
+        # Export neighborhood_connected_census_blocks as CSV
+        # -9 max compression, -m move file, -j junk paths in zipped archive, -q quiet
+        ec_export_table_csv "${OUTPUT_DIR}" "neighborhood_connected_census_blocks"
+        zip -jmq9 "${OUTPUT_DIR}/neighborhood_connected_census_blocks.csv.zip" \
+                  "${OUTPUT_DIR}/neighborhood_connected_census_blocks.csv"
 
         # Export neighborhood_score_inputs as CSV
         ec_export_table_csv "${OUTPUT_DIR}" "neighborhood_score_inputs"

--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.controller.js
@@ -1,0 +1,45 @@
+/**
+ * @ngdoc controller
+ * @name pfb.analysis-jobs.detail.controller:AnalysisJobDetailController
+ *
+ * @description
+ * Controller for showing details about an analysis job
+ *
+ */
+(function() {
+    'use strict';
+
+    /** @ngInject */
+    function AnalysisJobDetailController($stateParams, AnalysisJob) {
+        var ctl = this;
+
+        initialize();
+
+        function initialize() {
+            ctl.job = null;
+            ctl.cancel = cancel;
+            ctl.getAnalysisJob = getAnalysisJob;
+
+            getAnalysisJob($stateParams.uuid);
+        }
+
+        function cancel(jobId) {
+            AnalysisJob.cancel({uuid: jobId}).$promise.then(function() {
+                getAnalysisJob(jobId);
+            });
+        }
+
+        function getAnalysisJob(jobId) {
+            AnalysisJob.get({uuid: jobId}).$promise.then(function(data) {
+                ctl.job = data;
+            });
+            AnalysisJob.results({uuid: jobId}).$promise.then(function(data) {
+                ctl.results = data;
+            });
+        }
+    }
+
+    angular
+        .module('pfb.analysisJobs.detail')
+        .controller('AnalysisJobDetailController', AnalysisJobDetailController);
+})();

--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -1,0 +1,75 @@
+<pfb-navbar></pfb-navbar>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-md-push-1">
+      <button class="btn btn-danger pull-right"
+              ng-click="analysisJobDetail.cancel(analysisJobDetail.job.uuid)">
+        <span class="glyphicon glyphicon-ban-circle"></span>
+        Cancel Job
+      </button>
+      <button class="btn btn-primary pull-right"
+              ng-click="analysisJobDetail.getAnalysisJob(analysisJobDetail.job.uuid)">
+        <span class="glyphicon glyphicon-refresh"></span>
+        Refresh
+      </button>
+
+      <h1 class="no-margin-top">
+        <a class="btn" ui-sref="analysis-jobs.list">
+          <span class="glyphicon glyphicon-chevron-left"></span>
+        </a>
+        Analysis Job
+      </h1>
+      <table class="table" ng-if="analysisJobDetail.job">
+        <tbody>
+          <tr ng-repeat="(k, v) in analysisJobDetail.job">
+            <td>{{ k }}</td>
+            <td>{{ v }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- Show results overall scores -->
+      <h2 ng-if="analysisJobDetail.results">Overall Scores</h2>
+      <table class="table" ng-if="analysisJobDetail.results">
+        <thead>
+          <tr>
+            <th>Score ID</th>
+            <th>Value</th>
+            <th>Normalized Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="(name, data) in analysisJobDetail.results.overall_scores">
+            <td>{{ name }}</td>
+            <td>{{ data.score_original }}</td>
+            <td>{{ data.score_normalized }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- Show results destinations tables -->
+      <h2 ng-if="analysisJobDetail.results">Data</h2>
+      <table class="table" ng-if="analysisJobDetail.results">
+          <tbody>
+              <tr>
+                  <td>Census Blocks</td>
+                  <td><a ng-href="{{ analysisJobDetail.results.census_blocks_url }}">ESRI Shapefile</a></td>
+              </tr>
+              <tr>
+                  <td>Overall Scores</td>
+                  <td><a ng-href="{{ analysisJobDetail.results.overall_scores_url }}">CSV</a></td>
+              </tr>
+              <tr>
+                  <td>Ways</td>
+                  <td><a ng-href="{{ analysisJobDetail.results.ways_url }}">ESRI Shapefile</a></td>
+              </tr>
+              <tr ng-repeat="(key, url) in analysisJobDetail.results.destinations_urls">
+                  <td>Destination: {{ key }}</td>
+                  <td><a ng-href="{{ url }}">GeoJSON</a></td>
+              </tr>
+          </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -57,6 +57,10 @@
                   <td><a ng-href="{{ analysisJobDetail.results.census_blocks_url }}">ESRI Shapefile</a></td>
               </tr>
               <tr>
+                  <td>Connected Census Blocks</td>
+                  <td><a ng-href="{{ analysisJobDetail.results.connected_census_blocks_url }}">Zipped CSV</a></td>
+              </tr>
+              <tr>
                   <td>Overall Scores</td>
                   <td><a ng-href="{{ analysisJobDetail.results.overall_scores_url }}">CSV</a></td>
               </tr>

--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -61,6 +61,10 @@
                   <td><a ng-href="{{ analysisJobDetail.results.overall_scores_url }}">CSV</a></td>
               </tr>
               <tr>
+                  <td>Score Inputs</td>
+                  <td><a ng-href="{{ analysisJobDetail.results.score_inputs_url }}">CSV</a></td>
+              </tr>
+              <tr>
                   <td>Ways</td>
                   <td><a ng-href="{{ analysisJobDetail.results.ways_url }}">ESRI Shapefile</a></td>
               </tr>

--- a/src/angularjs/src/app/analysis-jobs/detail/module.js
+++ b/src/angularjs/src/app/analysis-jobs/detail/module.js
@@ -1,0 +1,4 @@
+(function () {
+    'use strict';
+    angular.module('pfb.analysisJobs.detail', []);
+ })();

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -12,7 +12,7 @@
         <thead pfb-analysis-job-filter filters="analysisJobList.filters"></thead>
         <tbody>
           <tr ng-repeat="analysisJob in analysisJobList.analysisJobs">
-            <td>{{analysisJob.uuid | limitTo: 5}}</td>
+            <td><a ui-sref="analysis-jobs.detail({uuid: analysisJob.uuid})">{{analysisJob.uuid | limitTo: 5}}</a></td>
             <td>{{analysisJob.status | displayStatus}}</td>
             <td>{{analysisJob.neighborhood_label}}</td>
             <td>{{analysisJob.batch_job_id}}</td>

--- a/src/angularjs/src/app/analysis-jobs/module.js
+++ b/src/angularjs/src/app/analysis-jobs/module.js
@@ -4,5 +4,6 @@
     angular.module('pfb.analysisJobs',
                    ['pfb.analysisJobs.constants',
                     'pfb.analysisJobs.list',
-                    'pfb.analysisJobs.create']);
+                    'pfb.analysisJobs.create',
+                    'pfb.analysisJobs.detail']);
 })();

--- a/src/angularjs/src/app/components/analysis-jobs/analysis-jobs.service.js
+++ b/src/angularjs/src/app/components/analysis-jobs/analysis-jobs.service.js
@@ -15,6 +15,16 @@
             'query': {
                 method: 'GET',
                 isArray: false
+            },
+            'results': {
+                method: 'GET',
+                isArray: false,
+                url: '/api/analysis_jobs/:uuid/results/'
+            },
+            'cancel': {
+                method: 'POST',
+                isArray: false,
+                url: '/api/analysis_jobs/:uuid/cancel/'
             }
         });
     }

--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -95,6 +95,12 @@
                 controllerAs: 'analysisJobCreate',
                 templateUrl: 'app/analysis-jobs/create/analysis-jobs-create.html'
             })
+            .state('analysis-jobs.detail', {
+                url: ':uuid/',
+                controller: 'AnalysisJobDetailController',
+                controllerAs: 'analysisJobDetail',
+                templateUrl: 'app/analysis-jobs/detail/analysis-jobs-detail.html'
+            })
             .state('neighborhoods', {
                 abstract: true,
                 url: '/neighborhoods/?limit&offset',

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -249,6 +249,10 @@ class AnalysisJob(PFBModel):
         }
 
     @property
+    def overall_scores_url(self):
+        return self._s3_url_for_result_resource('neighborhood_overall_scores.csv')
+
+    @property
     def logs_url(self):
         url = ('https://console.aws.amazon.com/cloudwatch/home?region={aws_region}' +
                '#logStream:group=/aws/batch/job;prefix={batch_job_name}/{batch_job_id}' +

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -240,6 +240,10 @@ class AnalysisJob(PFBModel):
         return self._s3_url_for_result_resource('neighborhood_census_blocks.zip')
 
     @property
+    def connected_census_blocks_url(self):
+        return self._s3_url_for_result_resource('neighborhood_connected_census_blocks.csv.zip')
+
+    @property
     def destinations_urls(self):
         """ Return a dict of the available destinations files for this job """
         return {

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -253,6 +253,10 @@ class AnalysisJob(PFBModel):
         return self._s3_url_for_result_resource('neighborhood_overall_scores.csv')
 
     @property
+    def score_inputs_url(self):
+        return self._s3_url_for_result_resource('neighborhood_score_inputs.csv')
+
+    @property
     def logs_url(self):
         url = ('https://console.aws.amazon.com/cloudwatch/home?region={aws_region}' +
                '#logStream:group=/aws/batch/job;prefix={batch_job_name}/{batch_job_id}' +

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -53,6 +53,7 @@ class AnalysisJobViewSet(ModelViewSet):
             results = OrderedDict([
                 ('census_block_count', job.census_block_count),
                 ('census_blocks_url', job.census_blocks_url),
+                ('connected_census_blocks_url', job.connected_census_blocks_url),
                 ('destinations_urls', job.destinations_urls),
                 ('overall_scores', job.overall_scores),
                 ('overall_scores_url', job.overall_scores_url),

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -55,6 +55,7 @@ class AnalysisJobViewSet(ModelViewSet):
                 ('census_blocks_url', job.census_blocks_url),
                 ('destinations_urls', job.destinations_urls),
                 ('overall_scores', job.overall_scores),
+                ('overall_scores_url', job.overall_scores_url),
                 ('ways_url', job.ways_url),
             ])
             return Response(results, status=status.HTTP_200_OK)

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -56,6 +56,7 @@ class AnalysisJobViewSet(ModelViewSet):
                 ('destinations_urls', job.destinations_urls),
                 ('overall_scores', job.overall_scores),
                 ('overall_scores_url', job.overall_scores_url),
+                ('score_inputs_url', job.score_inputs_url),
                 ('ways_url', job.ways_url),
             ])
             return Response(results, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Overview

Adds a functional (but not super pretty) AnalysisJob detail view to the admin UI. 

User can see all properties of the AnalysisJob, can refresh the view to check for updates, and can cancel an in progress job. 

### Demo

![screen shot 2017-03-30 at 15 01 41](https://cloud.githubusercontent.com/assets/1818302/24521528/73e9eeb0-155a-11e7-9e1a-ce1025f79310.png)
![screen shot 2017-03-30 at 15 01 50](https://cloud.githubusercontent.com/assets/1818302/24521529/73eec318-155a-11e7-9ef3-be93a8b72881.png)


### Notes

Didn't get fancy with the cancel button. If a job is cancellable it'll cancel, otherwise silently do nothing. I think it's fine for now.

Same with dressing up the rows, or trying to neatly format text. Don't see value in it yet, easy to clean up later.

I included links in the data section to all files requested for download in #157, including a zipped connected_census_blocks.csv

## Testing Instructions

Start AnalysisJob from UI in development. Go to detail page. Cancel it, to prove that works. Start another job. Run it via console. Go to detail page for that job and click refresh while job is in progress to see it update. When job is complete the results will populate after clicking refresh.


Closes #208
