### PR TITLE
Feature/awf/fix reset password redirect

### DIFF
--- a/src/angularjs/src/app/components/organizations.service.js
+++ b/src/angularjs/src/app/components/organizations.service.js
@@ -23,7 +23,6 @@
 
         module.orgTypes = {
             ADMIN: 'Administrator Organization',
-            LOCAL: 'Local Agency',
             SUBSCRIBER: 'Subscription'
         };
 

--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -21,13 +21,13 @@
                 templateUrl: 'app/help/help.html'
             })
             .state('request-password-reset', {
-                url: '/admin/password-reset-request/',
+                url: '/password-reset-request/',
                 controller: 'PasswordResetRequestController',
                 controllerAs: 'pw',
                 templateUrl: 'app/password-reset/request/password-reset-request.html'
             })
             .state('password-reset', {
-                url: '/admin/password-reset/?token',
+                url: '/password-reset/?token',
                 controller: 'PasswordResetController',
                 controllerAs: 'pw',
                 templateUrl: 'app/password-reset/reset/password-reset.html'


### PR DESCRIPTION
## Overview

Fixes broken links in email templates by reverting password reset angular views to the root url namespace. Figured this was better than updating the email links so that all of the login related URLs stay at the root.

## Testing Instructions

Ensure password reset works locally.

