### PR TITLE
Fix join syntax in results URLs method

### DIFF
--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -452,7 +452,7 @@ class AnalysisJob(PFBModel):
         return '{}/tiles'.format(self.s3_results_path)
 
     def _s3_url_for_result_resource(self, filename):
-        key = '/'.join(self.s3_results_path, filename)
+        key = '/'.join((self.s3_results_path, filename))
         s3 = boto3.client('s3')
         return s3.generate_presigned_url(
             ClientMethod='get_object',


### PR DESCRIPTION
I converted results path from a hard-coded string in a few places to a
method on AnalysisJob, but got the syntax wrong when I changed
`_s3_url_for_result_resource` for the new setup.
