### PR TITLE
Add score and latest-updated sorting to AnalysisJob endpoint

### DIFF
--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -24,6 +24,7 @@ class AnalysisJobFilterSet(filters.FilterSet):
         if value:
             matches = [m.pk for m in queryset.all() if m.status == value]
             queryset = queryset.filter(pk__in=matches)
+
         return queryset
 
     def filter_latest(self, queryset, name, value):

--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -1,0 +1,40 @@
+import logging
+
+from rest_framework import filters
+import django_filters
+from django.db.models import Case, When, Q, Max, Value, BooleanField
+
+from .models import AnalysisJob
+
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisJobFilterSet(filters.FilterSet):
+    """ Filters for AnalysisJob:
+      - status, to handle job status being defined as a property and not as database field
+      - latest, to return only the most recent analysis job for each neighborhood
+    """
+
+    status = django_filters.ChoiceFilter(choices=AnalysisJob.Status.CHOICES,
+                                         method='filter_status')
+    latest = django_filters.BooleanFilter(method='filter_latest')
+
+    def filter_status(self, queryset, name, value):
+        if value:
+            matches = [m.pk for m in queryset.all() if m.status == value]
+            queryset = queryset.filter(pk__in=matches)
+        return queryset
+
+    def filter_latest(self, queryset, name, value):
+        if type(value) is bool:
+            queryset = queryset.annotate(is_latest=Case(
+                When(Q(created_at=Max('neighborhood__analysis_jobs__created_at')),
+                     then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField())).filter(is_latest=value)
+        return queryset
+
+    class Meta:
+        model = AnalysisJob
+        fields = ['neighborhood', 'batch', 'status', 'latest']

--- a/src/django/pfb_analysis/functions.py
+++ b/src/django/pfb_analysis/functions.py
@@ -1,0 +1,14 @@
+from django.db.models.expressions import Func
+
+
+class ObjectAtPath(Func):
+    """ Database function to extract an object or value from a JSONField """
+    function = '#>'
+    template = "%(expressions)s%(function)s'{%(path)s}'"
+    arity = 1
+
+    def __init__(self, expression, path, **extra):
+        # if path is a list, convert it to a comma separated string
+        if isinstance(path, (list, tuple)):
+            path = ','.join(path)
+        super(ObjectAtPath, self).__init__(expression, path=path, **extra)

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -26,6 +26,7 @@ import us
 from pfb_analysis.aws_batch import JobState
 from pfb_network_connectivity.models import PFBModel
 from users.models import Organization
+from .functions import ObjectAtPath
 
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,13 @@ class AnalysisBatch(PFBModel):
                 logger.exception('Cancelling job {} failed: {}'.format(job, e))
 
 
+class AnalysisJobManager(models.Manager):
+    def get_queryset(self):
+        qs = super(AnalysisJobManager, self).get_queryset()
+        return qs.annotate(overall_score=ObjectAtPath('overall_scores',
+                                                      ('overall_score', 'score_normalized')))
+
+
 class AnalysisJob(PFBModel):
 
     def __str__(self):
@@ -212,6 +220,8 @@ class AnalysisJob(PFBModel):
                                                 'http://a.com/foo.osm.bz2')
     overall_scores = JSONField(db_index=True, default=dict)
     census_block_count = models.PositiveIntegerField(blank=True, null=True)
+
+    objects = AnalysisJobManager()
 
     @property
     def status(self):

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -482,6 +482,12 @@ class AnalysisJobStatusUpdate(models.Model):
         #       these objects elsewhere in the model. Proceed with caution.
         ordering = ('timestamp',)
 
+    def save(self, *args, **kwargs):
+        """ Override to update `modified_at` on the related AnalysisJob """
+        super(AnalysisJobStatusUpdate, self).save(*args, **kwargs)
+        # The modified_at field is auto_now=True, so just saving updates it
+        self.job.save()
+
 
 class AnalysisScoreMetadata(models.Model):
     """ Used to hold metadata for each of the scores saved in AnalysisJob.overall_scores

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -11,6 +11,7 @@ class AnalysisJobSerializer(PFBModelSerializer):
     status = serializers.SerializerMethodField()
     neighborhood_label = serializers.SerializerMethodField()
     neighborhood = serializers.PrimaryKeyRelatedField(queryset=Neighborhood.objects.all())
+    overall_score = serializers.FloatField(read_only=True)
 
     def get_running_time(self, obj):
         return obj.running_time

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import us
 
 from django.utils.text import slugify
+from django.db.models import Case, When, Q, Max, Value, BooleanField
 
 from rest_framework import status
 from rest_framework.decorators import detail_route
@@ -12,13 +13,13 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
 
-from pfb_analysis.models import AnalysisJob, Neighborhood
-from pfb_analysis.serializers import AnalysisJobSerializer, NeighborhoodSerializer
 from pfb_network_connectivity.pagination import OptionalLimitOffsetPagination
-from pfb_network_connectivity.filters import (OrgAutoFilterBackend,
-                                              SelfUserAutoFilterBackend,
-                                              AnalysisJobStatusFilterSet)
+from pfb_network_connectivity.filters import OrgAutoFilterBackend
 from pfb_network_connectivity.permissions import IsAdminOrgAndAdminCreateEditOnly, RestrictedCreate
+
+from .models import AnalysisJob, Neighborhood
+from .serializers import AnalysisJobSerializer, NeighborhoodSerializer
+from .filters import AnalysisJobFilterSet
 
 
 class AnalysisJobViewSet(ModelViewSet):
@@ -27,7 +28,7 @@ class AnalysisJobViewSet(ModelViewSet):
     queryset = AnalysisJob.objects.all()
     serializer_class = AnalysisJobSerializer
     permission_classes = (RestrictedCreate,)
-    filter_class = AnalysisJobStatusFilterSet
+    filter_class = AnalysisJobFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
     ordering_fields = ('created_at', 'modified_at')
     ordering = ('-created_at',)

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -19,14 +19,12 @@ from pfb_network_connectivity.permissions import IsAdminOrgAndAdminCreateEditOnl
 from .models import AnalysisJob, Neighborhood
 from .serializers import AnalysisJobSerializer, NeighborhoodSerializer
 from .filters import AnalysisJobFilterSet
-from .functions import ObjectAtPath
 
 
 class AnalysisJobViewSet(ModelViewSet):
     """For listing or retrieving analysis jobs."""
 
-    queryset = AnalysisJob.objects.all().annotate(
-        overall_score=ObjectAtPath('overall_scores', ('overall_score', 'score_normalized')))
+    queryset = AnalysisJob.objects.all()
     serializer_class = AnalysisJobSerializer
     permission_classes = (RestrictedCreate,)
     filter_class = AnalysisJobFilterSet

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import us
 
 from django.utils.text import slugify
-from django.db.models import Case, When, Q, Max, Value, BooleanField
 
 from rest_framework import status
 from rest_framework.decorators import detail_route
@@ -20,17 +19,19 @@ from pfb_network_connectivity.permissions import IsAdminOrgAndAdminCreateEditOnl
 from .models import AnalysisJob, Neighborhood
 from .serializers import AnalysisJobSerializer, NeighborhoodSerializer
 from .filters import AnalysisJobFilterSet
+from .functions import ObjectAtPath
 
 
 class AnalysisJobViewSet(ModelViewSet):
     """For listing or retrieving analysis jobs."""
 
-    queryset = AnalysisJob.objects.all()
+    queryset = AnalysisJob.objects.all().annotate(
+        overall_score=ObjectAtPath('overall_scores', ('overall_score', 'score_normalized')))
     serializer_class = AnalysisJobSerializer
     permission_classes = (RestrictedCreate,)
     filter_class = AnalysisJobFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
-    ordering_fields = ('created_at', 'modified_at')
+    ordering_fields = ('created_at', 'modified_at', 'overall_score', 'neighborhood__label')
     ordering = ('-created_at',)
 
     def perform_create(self, serializer):

--- a/src/django/pfb_network_connectivity/filters.py
+++ b/src/django/pfb_network_connectivity/filters.py
@@ -5,8 +5,7 @@ or role within an organization
 """
 import logging
 
-from rest_framework import filters, exceptions
-import django_filters
+from rest_framework import filters
 
 from pfb_network_connectivity.permissions import is_admin_org, is_admin
 from pfb_analysis.models import AnalysisJob
@@ -48,20 +47,3 @@ class SelfUserAutoFilterBackend(filters.BaseFilterBackend):
             return queryset
         else:
             return queryset.filter(uuid=request.user.uuid)
-
-
-class AnalysisJobStatusFilterSet(filters.FilterSet):
-    """ Filter to handle job status being defined as property and not as database field."""
-
-    status = django_filters.ChoiceFilter(choices=AnalysisJob.Status.CHOICES,
-                                         method='filter_status')
-
-    def filter_status(self, queryset, name, value):
-        if value:
-            matches = [m.pk for m in queryset.all() if m.status == value]
-            queryset = queryset.filter(pk__in=matches)
-        return queryset
-
-    class Meta:
-        model = AnalysisJob
-        fields = ['neighborhood', 'batch', 'status']


### PR DESCRIPTION
## Overview

Adds "overall score" and "latest updated" sorting and filtering to the AnalysisJobs endpoint.

### Demo

- Latest updated. Sorting by `created_at` already worked, but with the addition of `latest=True`, it now works as a "neighborhoods by last analysis run" endpoint: http://localhost:9200/api/analysis_jobs/?latest=True&ordering=-created_at
- Highest rated: http://localhost:9200/api/analysis_jobs/?latest=True&ordering=-overall_score
- Lowest rated: http://localhost:9200/api/analysis_jobs/?latest=True&ordering=overall_score
- Alphabetical by neighborhood: http://localhost:9200/api/analysis_jobs/?latest=True&ordering=neighborhood__label (note the double-underscore.  the `neighborhood_label` field in the results is a MethodField added by the serializer, so not sortable)

### Notes

~Issue #242 calls for "Last updated (job completion datetime)".  This implements it as job creation datetime.  I just started writing up a case for doing it by job creation, but then realized that would mean the scores for a neighborhood disappear as soon as a new job is started for it, which would not be great.  I made a run at pulling AnalysisJobStatusUpdate information into the query and didn't get there, but I'll have another go in issue #260.~

I pushed a new version that switches to doing the `latest` filtering in code and behaves thus:
- If there are successful jobs for a neighborhood, include only the one that finished most recently
- If there are none, include the one with the most recent status update
- If there are no status updates for any job for a neighborhood (i.e. only CREATED jobs), return the most recently modified job

Note also, if this gets applied after a status filter (which seems to be the case. I haven't found documentation, but it seems like it gets applied second regardless of parameter ordering), it will be based on the set of jobs it gets, so it'll follow the fallback logic and return the most recently updated of those jobs, even if there are other jobs for the same neighborhoods with different statuses that are newer.

## Testing Instructions

See the Demo section for example queries.  The new ordering options and the `latest=True` filter should work fine in conjunction with the previously-existing filters (e.g. by status) and ordering options.

Resolves #242, resolves #260.