### PR TITLE
Codify SES Send Email permissions in Terraform

### DIFF
--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -27,12 +27,15 @@ data "aws_iam_policy_document" "container_instance_ecs_assume_role" {
   }
 }
 
-data "aws_iam_policy_document" "container_instance_ses_send_email" {
+data "aws_iam_policy_document" "ses_send_email" {
   statement {
     effect = "Allow"
 
     resources = ["*"]
-    actions   = ["ses:SendRawEmail"]
+    actions   = [
+      "ses:SendEmail",
+      "ses:SendRawEmail"
+    ]
   }
 }
 
@@ -80,12 +83,6 @@ resource "aws_iam_role_policy_attachment" "ecs_policy" {
   policy_arn = "${var.aws_ecs_service_role_policy_arn}"
 }
 
-resource "aws_iam_role_policy" "ses_send_email" {
-  name   = "SESSendEmail"
-  role   = "${aws_iam_role.container_instance_ecs.id}"
-  policy = "${data.aws_iam_policy_document.container_instance_ses_send_email.json}"
-}
-
 resource "aws_iam_role_policy_attachment" "sqs_read_write" {
   role       = "${aws_iam_role.container_instance_ecs.name}"
   policy_arn = "${var.aws_sqs_read_write_policy_arn}"
@@ -97,6 +94,12 @@ resource "aws_iam_role_policy_attachment" "sqs_read_write" {
 resource "aws_iam_role" "container_instance_ec2" {
   name               = "${var.environment}ContainerInstanceProfile"
   assume_role_policy = "${data.aws_iam_policy_document.container_instance_ec2_assume_role.json}"
+}
+
+resource "aws_iam_role_policy" "ec2_ses_send_email" {
+  name = "${var.environment}EC2SESSendEmail"
+  role = "${aws_iam_role.container_instance_ec2.id}"
+  policy = "${data.aws_iam_policy_document.ses_send_email.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "batch_manage_jobs_policy_container_instance_role" {


### PR DESCRIPTION
## Overview

Email permissions are needed by the EC2 instance to properly send user emails. These were quickfixed earlier on by adding the necessary permissions in the console. Now the same permissions are codified in Terraform


### Demo

<img width="993" alt="screen shot 2017-04-11 at 15 41 11" src="https://cloud.githubusercontent.com/assets/1818302/24927635/b70e86f2-1ecd-11e7-80b6-2a31ae5af85b.png">


### Notes

I _believe_ I made these changes in an acceptable way, as an inline policy for both ECS/EC2. Permission seems to be necessary on both. 


## Testing Instructions

Can checkout branch and run `./scripts/infra plan` to verify no permissions changes in the plan, the changes in the PR are live in the staging environment.

Closes  #238 
