### PR TITLE
Offset segments to show both directions in neighborhood_ways tiles

### DIFF
--- a/src/tilemaker/styles/neighborhood_ways_style.xml
+++ b/src/tilemaker/styles/neighborhood_ways_style.xml
@@ -4,44 +4,142 @@
 
 <Parameters>
   <Parameter name="bounds">-180,-85.05112877980659,180,85.05112877980659</Parameter>
-  <Parameter name="center">0,0,2</Parameter>
+  <Parameter name="center">-75,40,11</Parameter>
   <Parameter name="format">png8</Parameter>
-  <Parameter name="minzoom">0</Parameter>
+  <Parameter name="minzoom">2</Parameter>
   <Parameter name="maxzoom">22</Parameter>
   <Parameter name="scale">1</Parameter>
   <Parameter name="metatile">2</Parameter>
-  <Parameter name="id"><![CDATA[pfb_export_json]]></Parameter>
-  <Parameter name="_updated">1490794336000</Parameter>
-  <Parameter name="name"><![CDATA[Neighborhood ways from GeoJSON]]></Parameter>
   <Parameter name="tilejson"><![CDATA[2.0.0]]></Parameter>
   <Parameter name="scheme"><![CDATA[xyz]]></Parameter>
 </Parameters>
 
-
-<Style name="neighborhood_ways" filter-mode="first">
+<Style name="neighborhood_waysFT" filter-mode="first">
   <Rule>
-    <Filter>([FT_SEG_STR] = 1) and ([FT_INT_STR] = 1)</Filter>
-    <LineSymbolizer stroke="#008000"/>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <Filter>([FT_SEG_STR] = 1)</Filter>
+    <LineSymbolizer offset="1" stroke="#008000"/>
   </Rule>
   <Rule>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <Filter>([FT_SEG_STR] = 1)</Filter>
+    <LineSymbolizer stroke="#008000" offset="0.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <Filter>([FT_SEG_STR] = 1)</Filter>
+    <LineSymbolizer stroke="#008000" offset="1.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
     <Filter>([FT_SEG_STR] &gt; 1)</Filter>
-    <LineSymbolizer stroke="#ff0000"/>
+    <LineSymbolizer offset="1" stroke="#ff0000"/>
   </Rule>
   <Rule>
-    <Filter>([FT_INT_STR] &gt; 1)</Filter>
-    <LineSymbolizer stroke="#ff0000"/>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <Filter>([FT_SEG_STR] &gt; 1)</Filter>
+    <LineSymbolizer stroke="#ff0000" offset="0.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <Filter>([FT_SEG_STR] &gt; 1)</Filter>
+    <LineSymbolizer stroke="#ff0000" offset="1.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <LineSymbolizer offset="1" stroke="#ffa500"/>
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <LineSymbolizer offset="0.5" stroke="#ffa500"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <LineSymbolizer offset="1.5" stroke="#ffa500"/>
   </Rule>
 </Style>
-<Layer name="neighborhood_ways" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
-    <StyleName>neighborhood_ways</StyleName>
-    <Datasource>
-       <Parameter name="file"><![CDATA[/data/neighborhood_ways.shp]]></Parameter>
-       <Parameter name="layer"><![CDATA[neighborhood_ways]]></Parameter>
-       <Parameter name="id"><![CDATA[neighborhood_ways]]></Parameter>
-       <Parameter name="project"><![CDATA[pfb_export]]></Parameter>
-       <Parameter name="srs"><![CDATA[]]></Parameter>
-       <Parameter name="type"><![CDATA[ogr]]></Parameter>
-    </Datasource>
-  </Layer>
+<Layer name="neighborhood_waysFT" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <StyleName>neighborhood_waysFT</StyleName>
+  <Datasource>
+    <Parameter name="file"><![CDATA[/data/neighborhood_ways.shp]]></Parameter>
+    <Parameter name="layer"><![CDATA[neighborhood_ways]]></Parameter>
+    <Parameter name="type"><![CDATA[ogr]]></Parameter>
+  </Datasource>
+</Layer>
+
+<Style name="neighborhood_waysTF" filter-mode="first">
+  <Rule>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <Filter>([TF_SEG_STR] &lt; 1)</Filter>
+    <LineSymbolizer offset="-1" stroke-opacity="0"/>
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <Filter>([TF_SEG_STR] &lt; 1)</Filter>
+    <LineSymbolizer stroke-opacity="0" offset="-0.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <Filter>([TF_SEG_STR] &lt; 1)</Filter>
+    <LineSymbolizer stroke-opacity="0" offset="-1.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <Filter>([TF_SEG_STR] = 1)</Filter>
+    <LineSymbolizer offset="-1" stroke="#008000"/>
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <Filter>([TF_SEG_STR] = 1)</Filter>
+    <LineSymbolizer stroke="#008000" offset="-0.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <Filter>([TF_SEG_STR] = 1)</Filter>
+    <LineSymbolizer stroke="#008000" offset="-1.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <Filter>([TF_SEG_STR] &gt; 1)</Filter>
+    <LineSymbolizer offset="-1" stroke="#ff0000"/>
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <Filter>([TF_SEG_STR] &gt; 1)</Filter>
+    <LineSymbolizer stroke="#ff0000" offset="-0.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <Filter>([TF_SEG_STR] &gt; 1)</Filter>
+    <LineSymbolizer stroke="#ff0000" offset="-1.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>750000</MaxScaleDenominator>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <LineSymbolizer offset="-1"/>
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>750000</MinScaleDenominator>
+    <LineSymbolizer offset="-0.5"/>
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <LineSymbolizer offset="-1.5"/>
+  </Rule>
+</Style>
+<Layer name="neighborhood_waysTF" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+  <StyleName>neighborhood_waysTF</StyleName>
+  <Datasource>
+    <Parameter name="file"><![CDATA[/data/neighborhood_ways.shp]]></Parameter>
+    <Parameter name="layer"><![CDATA[neighborhood_ways]]></Parameter>
+    <Parameter name="type"><![CDATA[ogr]]></Parameter>
+  </Datasource>
+</Layer>
 
 </Map>


### PR DESCRIPTION
## Overview

Updates the styling for the stress score tiles to
- only rely on the `SEG_STR` scores (formerly it also looked at `INT_STR`)
- display the `FT` and `TF` scores separately by offsetting them in opposite directions.

### Demo

![image](https://cloud.githubusercontent.com/assets/6598836/24965917/73c372ee-1f73-11e7-897f-f2b57d005ce0.png)

### Notes

- I also changed the tile generation command to produce some output, rather than none, as it was doing, or tens of thousands of lines, as it was doing before that.
- The sample above is from a York, PA, analysis, and seems to be missing some roads. I opened the exported neighborhood_ways shapefile in QGIS and confirmed that they're not there.

## Testing Instructions

Rebuild the `tilemaker` container and run it.  You can create a job locally and run the analysis then the tilemaker commands that get printed to the logs, or you could run tile generation for an already-finished analysis, along the lines of
```
AWS_STORAGE_BUCKET_NAME='<username>-pfb-storage-us-east-1' PFB_JOB_ID='<job_id>' PFB_S3_RESULTS_PATH='results/<job_id>' PFB_S3_TILES_PATH='results/<job_id>/tiles' docker-compose run tilemaker
```

Resolves #261.
