### PR TITLE
Add filters for analysis job by neighborhood name

### DIFF
--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -59,4 +59,9 @@ class AnalysisJobFilterSet(filters.FilterSet):
 
     class Meta:
         model = AnalysisJob
-        fields = ['neighborhood', 'batch', 'status', 'latest']
+        fields = {'neighborhood': ['exact', 'in'],
+                  'neighborhood__name': ['exact', 'contains'],
+                  'neighborhood__label': ['exact', 'contains'],
+                  'batch': ['exact', 'in'],
+                  'status': ['exact', 'in'],
+                  'latest': ['exact', 'in']}

--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -63,5 +63,5 @@ class AnalysisJobFilterSet(filters.FilterSet):
                   'neighborhood__name': ['exact', 'contains'],
                   'neighborhood__label': ['exact', 'contains'],
                   'batch': ['exact', 'in'],
-                  'status': ['exact', 'in'],
-                  'latest': ['exact', 'in']}
+                  'status': ['exact'],
+                  'latest': ['exact']}


### PR DESCRIPTION
## Overview

Filter AnalysisJob API endpint by neighborhood name (slug) or label, either as exact match or substring.
Closes #243.

## Notes

Here's some relevant [django filter docs](https://django-filter.readthedocs.io/en/latest/ref/filters.html#).

## Testing Instructions

 * Create one or more analysis jobs
 * Should be able to query analysis jobs by neighborhood name (slug) or label
 * Should be able to query for exact match
 * Should be able to query for substring using `__contains` syntax, like: http://localhost:9200/api/analysis_jobs/?neighborhood__label__contains=somestring
