### PR TITLE
Production deployment

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -30,6 +30,7 @@ You will be prompted to enter your AWS credentials, along with a default region.
 If you're deploying new application code, first set the commit to deploy, then build and push containers:
 ```bash
 vagrant@vagrant-ubuntu-trusty-64:~$ export GIT_COMMIT="<short-commit-to-deploy>"
+vagrant@vagrant-ubuntu-trusty-64:~$ export ENVIRONMENT="staging|production"
 vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_AWS_ECR_ENDPOINT="<aws-account-id>.dkr.ecr.us-east-1.amazonaws.com"
 vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/cibuild && ./scripts/cipublish
 ```

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -38,7 +38,7 @@ vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/cibuild && ./scripts/cipublish
 Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_SETTINGS_BUCKET="staging-pfb-config-us-east-1"
+vagrant@vagrant-ubuntu-trusty-64:~$ export PFB_SETTINGS_BUCKET="${ENVIRONMENT}-pfb-config-us-east-1"
 vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra plan
 ```
 

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "batch_manage_jobs" {
 # Custom policies
 #
 resource "aws_iam_policy" "batch_manage_jobs" {
-  name   = "BatchManageJobs"
+  name   = "${var.environment}BatchManageJobs"
   policy = "${data.aws_iam_policy_document.batch_manage_jobs.json}"
 }
 

--- a/scripts/infra
+++ b/scripts/infra
@@ -43,11 +43,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 #       an orphaned job definition that never gets used.
                 docker-compose build
 
+                ENVIRONMENT="${ENVIRONMENT:-staging}"
                 BATCH_ANALYSIS_JOB_NAME_REVISION=$(docker-compose run --rm \
-                    update-job-defs pfb-analysis-run-job.json \
+                    update-job-defs \
+                    --environment "${ENVIRONMENT}" \
+                    pfb-analysis-run-job.json \
                     "${PFB_AWS_ECR_ENDPOINT}/pfb-analysis:${GIT_COMMIT}")
                 BATCH_TILEMAKER_JOB_NAME_REVISION=$(docker-compose run --rm \
-                    update-job-defs pfb-tilemaker-run-job.json \
+                    update-job-defs \
+                    --environment "${ENVIRONMENT}" \
+                    pfb-tilemaker-run-job.json \
                     "${PFB_AWS_ECR_ENDPOINT}/pfb-tilemaker:${GIT_COMMIT}")
                 popd
 


### PR DESCRIPTION
## Overview

Provides the necessary updates to end up with a successful production environment on AWS.

Commit https://github.com/azavea/pfb-network-connectivity/commit/d32e6a5ebe056702ed119e220a473f6fdd840cfd is live on the production stack.

### Demo

![screen shot 2017-04-13 at 09 49 00](https://cloud.githubusercontent.com/assets/1818302/25007440/85979b7e-202e-11e7-9b36-a927f82cd924.png)

### Notes

Got error:
```
* aws_ecs_service.pfb_app_http: InvalidParameterException: The target group with targetGroupArn arn:aws:elasticloadbalancing:us-east-1:950872791630:targetg$
oup/tf-tg-6defea6dd9c9c22ca88749d107/54fbe71805823763 does not have an associated load balancer.
        status code: 400, request id: 32e019c6-2041-11e7-9b66-c5845ed8449f "ProductionHTTPAppServer"
```
while launching stack but I believe that was fallout from the previous error where the IAM Role BatchManageJobs failed to create because it already existed. After fixing the IAM role error, deleting the pfb_app_http ECS task and re-applying, the stack launched successfully.

Will be opening a separate PR to remove the `batch_analysis_compute_environment_arn` tfvar as a followup. It is only passed into Django, which does not use it. 

Do we want to setup the Jenkinsfile to automatically push new commits to `master` to the production environment? Probably. That can be a separate PR as well.


## Testing Instructions

Navigate to https://pfb.azavea.com. Password in fileshare. Should be able access the same features as staging.

NOTE: The batch container instance is currently disabled, so jobs can be created, but they will not run.

@azavea/operations can you take a look?

Connects #192 
