### PR TITLE
Create and associate new IAM instance profile with batch container instances

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -9,14 +9,11 @@ pfb_aws_batch_analysis_job_definition_name: "staging-pfb-analysis-run-job"
 pfb_aws_batch_tilemaker_job_queue_name: "name_of_batch_tilemaker_job_queue"
 pfb_aws_batch_tilemaker_job_definition_name: "staging-pfb-tilemaker-run-job"
 
-
-# application settings
-docker_compose_version: 1.8.0
-
 # azavea.docker
 # 1.12.* to match AWS ECS
 docker_version: 1.12.*
 docker_options: "--storage-opt dm.basesize=20G"
+docker_compose_version: 1.9.0
 
 # azavea.terraform
 terraform_version: 0.9.1

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,6 +1,6 @@
 - src: azavea.aws-cli
   version: 0.1.0
 - src: azavea.docker
-  version: 2.0.1
+  version: 3.0.0
 - src: azavea.terraform
   version: 0.3.1

--- a/deployment/terraform/batch-container-service.tf
+++ b/deployment/terraform/batch-container-service.tf
@@ -32,7 +32,7 @@ resource "aws_launch_configuration" "batch_container_instance" {
   }
 
   ebs_optimized        = true
-  iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
+  iam_instance_profile = "${aws_iam_instance_profile.batch_instance.name}"
   image_id             = "${var.ecs_instance_ami_id}"
   instance_type        = "${var.batch_container_instance_type}"
   key_name             = "${var.aws_key_name}"

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -6,6 +6,6 @@ terraform {
   backend "s3" {
     region  = "us-east-1"
     encrypt = "true"
-    lock	= "false"
+    lock    = "false"
   }
 }

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -32,9 +32,10 @@ data "aws_iam_policy_document" "ses_send_email" {
     effect = "Allow"
 
     resources = ["*"]
-    actions   = [
+
+    actions = [
       "ses:SendEmail",
-      "ses:SendRawEmail"
+      "ses:SendRawEmail",
     ]
   }
 }
@@ -89,7 +90,7 @@ resource "aws_iam_role_policy_attachment" "sqs_read_write" {
 }
 
 #
-# EC2 roles
+# App EC2 roles
 #
 resource "aws_iam_role" "container_instance_ec2" {
   name               = "${var.environment}ContainerInstanceProfile"
@@ -97,8 +98,8 @@ resource "aws_iam_role" "container_instance_ec2" {
 }
 
 resource "aws_iam_role_policy" "ec2_ses_send_email" {
-  name = "${var.environment}EC2SESSendEmail"
-  role = "${aws_iam_role.container_instance_ec2.id}"
+  name   = "${var.environment}EC2SESSendEmail"
+  role   = "${aws_iam_role.container_instance_ec2.id}"
   policy = "${data.aws_iam_policy_document.ses_send_email.json}"
 }
 
@@ -112,7 +113,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_logs_policy_container_inst
   policy_arn = "${var.aws_cloudwatch_logs_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "ec2_s3_policy" {
+resource "aws_iam_role_policy_attachment" "app_ec2_s3_policy" {
   role       = "${aws_iam_role.container_instance_ec2.name}"
   policy_arn = "${var.aws_s3_policy_arn}"
 }
@@ -125,4 +126,27 @@ resource "aws_iam_role_policy_attachment" "ecs_for_ec2_policy_container_instance
 resource "aws_iam_instance_profile" "container_instance" {
   name  = "${aws_iam_role.container_instance_ec2.name}"
   roles = ["${aws_iam_role.container_instance_ec2.name}"]
+}
+
+#
+# Batch EC2 roles
+#
+resource "aws_iam_role" "batch_instance_ec2" {
+  name               = "${var.environment}BatchInstanceProfile"
+  assume_role_policy = "${data.aws_iam_policy_document.container_instance_ec2_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_for_ec2_policy_batch_instance_role" {
+  role       = "${aws_iam_role.batch_instance_ec2.name}"
+  policy_arn = "${var.aws_ecs_for_ec2_service_role_policy_arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "batch_ec2_s3_policy" {
+  role       = "${aws_iam_role.batch_instance_ec2.name}"
+  policy_arn = "${var.aws_s3_policy_arn}"
+}
+
+resource "aws_iam_instance_profile" "batch_instance" {
+  name  = "${aws_iam_role.batch_instance_ec2.name}"
+  roles = ["${aws_iam_role.batch_instance_ec2.name}"]
 }


### PR DESCRIPTION
## Overview

Currently, the AWS Batch Container instances are using the `ecsStagingInstanceProfile`, which has permissions that unnecessary for Batch, including full Cloudwatch Logs access and SES access. This PR adds a separate Batch container instance profile to ensure that each service has the minimum amount of access that is necessary.

Additionally, this PR updates `deployment/ansible/group_vars/all.example` with values necessary for provisioning.


### Demo

Optional. Screenshots, `curl` examples, etc.


### Notes

The `BatchInstanceProfile` includes the permissions indicated in the [AWS Docs](http://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html), and also adds S3 access so that analysis jobs can store their results. 


## Testing Instructions

 * Provision the VM
 * run `GIT_COMMIT=682b1e1 scripts/infra plan` according to `README` instructions, ensure that only ECS task definitions need updating.
 * I ran an out-of-band Batch job through the console, visible [here](https://console.aws.amazon.com/batch/home?region=us-east-1#/jobs/queue/arn:aws:batch:us-east-1:950872791630:job-queue~2Fstaging-pfb-analysis-job-queue/state/SUCCEEDED/job/e03bfe12-2299-446a-811e-fe19e832a45d/queue/arn:aws:batch:us-east-1:950872791630:job-queue~2Fstaging-pfb-analysis-job-queue/state/SUCCEEDED). CloudWatch [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=local-job-2017-04-13-1415-tnation/e03bfe12-2299-446a-811e-fe19e832a45d/09f9ec02-4a55-4aaa-9308-927704be22e0) were also successfully created. Logs indicate that the job finished in an error state, but I believe that's because the it wasn't created through the application. Adding @CloudNiner to confirm.


Closes #147 
