### PR TITLE
Include neighborhood object in job api results

### DIFF
--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -24,7 +24,8 @@
         <tbody>
           <tr ng-repeat="(k, v) in analysisJobDetail.job">
             <td>{{ k }}</td>
-            <td>{{ v }}</td>
+            <td ng-if="k === 'neighborhood'">{{ v.label }}</td>
+            <td ng-if="k !== 'neighborhood'">{{ v }}</td>
           </tr>
         </tbody>
       </table>

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -14,7 +14,7 @@
           <tr ng-repeat="analysisJob in analysisJobList.analysisJobs">
             <td><a ui-sref="analysis-jobs.detail({uuid: analysisJob.uuid})">{{analysisJob.uuid | limitTo: 5}}</a></td>
             <td>{{analysisJob.status | displayStatus}}</td>
-            <td>{{analysisJob.neighborhood_label}}</td>
+            <td>{{analysisJob.neighborhood.label}}</td>
             <td>{{analysisJob.batch_job_id}}</td>
             <td>{{analysisJob.createdAt | date:'yyyy-MM-dd HH:mm:ss'}}</td>
             <td>

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from rest_framework import serializers
 
 from pfb_analysis.models import AnalysisJob, Neighborhood
@@ -5,34 +7,52 @@ from pfb_network_connectivity.serializers import PFBModelSerializer
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 
-class AnalysisJobSerializer(PFBModelSerializer):
+class PrimaryKeyReferenceRelatedField(serializers.PrimaryKeyRelatedField):
+    """ A custom relational field for read-only objects
 
-    running_time = serializers.SerializerMethodField()
-    start_time = serializers.SerializerMethodField()
-    status = serializers.SerializerMethodField()
-    neighborhood_label = serializers.SerializerMethodField()
-    neighborhood = serializers.PrimaryKeyRelatedField(queryset=Neighborhood.objects.all())
-    overall_score = serializers.FloatField(read_only=True)
+    This field is for the specific case where:
+    1. We want to reference the model on create by its primary key
+    2. We want to print the full serialized representation of the object on to_representation,
+       using a serializer of our choice
 
-    def get_running_time(self, obj):
-        return obj.running_time
+    """
 
-    def get_start_time(self, obj):
-        return obj.start_time
+    def __init__(self, **kwargs):
+        """ Custom init to take an extra 'serializer' argument
 
-    def get_status(self, obj):
-        return obj.status
+        @param serializer A custom serializer instance, used to generate the object representation
+                          in to_representation()
 
-    def get_neighborhood_label(self, obj):
-        return obj.neighborhood.label
+        """
+        self.serializer = kwargs.pop('serializer')
+        super(PrimaryKeyReferenceRelatedField, self).__init__(**kwargs)
 
-    class Meta:
-        model = AnalysisJob
-        exclude = ('created_at', 'modified_at', 'created_by', 'modified_by', 'overall_scores',
-                   'analysis_job_definition', 'tilemaker_job_definition',
-                   '_analysis_job_name', '_tilemaker_job_name',)
-        read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
-                            'batch_job_id', 'batch', 'census_block_count',)
+    def to_representation(self, value):
+        if self.allow_null is True and value.pk is None:
+            return None
+        try:
+            data = self.get_queryset().get(pk=value.pk)
+            serializer = self.serializer(data)
+            return serializer.data
+        except self.serializer.Meta.model.DoesNotExist:
+            self.fail('does_not_exist', pk_value=value.pk)
+        except (TypeError, ValueError):
+            self.fail('incorrect_type', data_type=type(value).__name__)
+
+    def get_choices(self, cutoff=None):
+        """ This is used to get the param value for the POST form in the DRF browsable API.
+        It normally uses `to_representation` to get the param value, but we want it to use `pk`.
+        """
+        queryset = self.get_queryset()
+        if queryset is None:
+            # Ensure that field.choices returns something sensible
+            # even when accessed with a read-only field.
+            return {}
+
+        if cutoff is not None:
+            queryset = queryset[:cutoff]
+
+        return OrderedDict([(item.pk, self.display_value(item)) for item in queryset])
 
 
 class NeighborhoodSerializer(PFBModelSerializer):
@@ -50,9 +70,44 @@ class NeighborhoodGeoJsonSerializer(GeoFeatureModelSerializer):
         model = Neighborhood
         id_field = 'uuid'
         geo_field = 'geom_pt'
-        exclude = ('created_at',
-                   'modified_at',
-                   'created_by',
-                   'modified_by',
-                   'geom',
-                   'boundary_file',)
+        fields = ('uuid', 'name', 'label', 'state_abbrev', 'organization', 'geom_pt')
+
+
+class NeighborhoodSummarySerializer(PFBModelSerializer):
+    """ Serializer for including neighborhood information in AnalysisJob results
+
+    All the fields are read-only. Any changes to neighborhoods should happen through the
+    neighborhoods endpoint, which uses the regular serializer.
+
+    """
+    class Meta:
+        model = Neighborhood
+        fields = ('uuid', 'name', 'label', 'state_abbrev', 'organization', 'geom_pt')
+        read_only_fields = fields
+
+
+class AnalysisJobSerializer(PFBModelSerializer):
+
+    running_time = serializers.SerializerMethodField()
+    start_time = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    neighborhood = PrimaryKeyReferenceRelatedField(queryset=Neighborhood.objects.all(),
+                                                   serializer=NeighborhoodSummarySerializer)
+    overall_score = serializers.FloatField(read_only=True)
+
+    def get_running_time(self, obj):
+        return obj.running_time
+
+    def get_start_time(self, obj):
+        return obj.start_time
+
+    def get_status(self, obj):
+        return obj.status
+
+    class Meta:
+        model = AnalysisJob
+        exclude = ('created_at', 'modified_at', 'created_by', 'modified_by', 'overall_scores',
+                   'analysis_job_definition', 'tilemaker_job_definition',
+                   '_analysis_job_name', '_tilemaker_job_name',)
+        read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
+                            'batch_job_id', 'batch', 'census_block_count',)

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -8,21 +8,19 @@ from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 
 class PrimaryKeyReferenceRelatedField(serializers.PrimaryKeyRelatedField):
-    """ A custom relational field for read-only objects
+    """A custom relational field for read-only objects.
 
     This field is for the specific case where:
     1. We want to reference the model on create by its primary key
     2. We want to print the full serialized representation of the object on to_representation,
        using a serializer of our choice
-
     """
 
     def __init__(self, **kwargs):
-        """ Custom init to take an extra 'serializer' argument
+        """Custom init to take an extra 'serializer' argument
 
         @param serializer A custom serializer instance, used to generate the object representation
                           in to_representation()
-
         """
         self.serializer = kwargs.pop('serializer')
         super(PrimaryKeyReferenceRelatedField, self).__init__(**kwargs)
@@ -40,7 +38,7 @@ class PrimaryKeyReferenceRelatedField(serializers.PrimaryKeyRelatedField):
             self.fail('incorrect_type', data_type=type(value).__name__)
 
     def get_choices(self, cutoff=None):
-        """ This is used to get the param value for the POST form in the DRF browsable API.
+        """This is used to get the param value for the POST form in the DRF browsable API.
         It normally uses `to_representation` to get the param value, but we want it to use `pk`.
         """
         queryset = self.get_queryset()
@@ -74,12 +72,12 @@ class NeighborhoodGeoJsonSerializer(GeoFeatureModelSerializer):
 
 
 class NeighborhoodSummarySerializer(PFBModelSerializer):
-    """ Serializer for including neighborhood information in AnalysisJob results
+    """Serializer for including neighborhood information in AnalysisJob results.
 
     All the fields are read-only. Any changes to neighborhoods should happen through the
     neighborhoods endpoint, which uses the regular serializer.
-
     """
+
     class Meta:
         model = Neighborhood
         fields = ('uuid', 'name', 'label', 'state_abbrev', 'organization', 'geom_pt')

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -70,6 +70,7 @@ class AnalysisJobViewSet(ModelViewSet):
 class NeighborhoodMixin(APIView):
     """Shared properties of the neighborhood viewsets."""
 
+    queryset = Neighborhood.objects.all()
     permission_classes = (IsAdminOrgAndAdminCreateEditOnly,)
     filter_fields = ('organization', 'name', 'label', 'state_abbrev')
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
@@ -78,7 +79,6 @@ class NeighborhoodMixin(APIView):
 class NeighborhoodViewSet(NeighborhoodMixin, ModelViewSet):
     """For listing or retrieving neighborhoods."""
 
-    queryset = Neighborhood.objects.all()
     serializer_class = NeighborhoodSerializer
     pagination_class = OptionalLimitOffsetPagination
     ordering_fields = ('created_at',)
@@ -92,7 +92,6 @@ class NeighborhoodViewSet(NeighborhoodMixin, ModelViewSet):
 class NeighborhoodGeoJsonViewSet(NeighborhoodMixin, ReadOnlyModelViewSet):
     """For retrieving neighborhood centroids as GeoJSON feature collection."""
 
-    queryset = Neighborhood.objects.all()
     serializer_class = NeighborhoodGeoJsonSerializer
     pagination_class = None
 


### PR DESCRIPTION
## Overview

Switches the analysis-jobs endpoint from including UUID and label as properties on the job to including `neighborhood` as an object, with those details plus state and point geometry inside.

Since DRF doesn't have easy automatic behavior for saving inlined related objects, I borrowed an idea from MUB and made neighborhood on the AnalysisJob serializer into a field that expects UUID for create/save operations but includes the serialized object when serializing for presentation.

### Demo

Example result:
```
        {
            "uuid": "acc421de-2832-4252-87e0-5f1c828452bb",
            "createdAt": "2017-04-07T01:12:12.827062Z",
            "modifiedAt": "2017-04-07T04:09:36.021285Z",
            "running_time": 11461,
            "start_time": "2017-04-07T01:16:32.001600Z",
            "status": "COMPLETE",
            "neighborhood": {
                "uuid": "08f827a6-c21a-4e45-959e-42cc509bb6fc",
                "name": "gtown-westside",
                "label": "Germantown, PA",
                "state_abbrev": "PA",
                "organization": "813f56de-1800-4b50-8515-a073eb32970d",
                "geom_pt": {
                    "type": "Point",
                    "coordinates": [
                        -75.17746130993164,
                        40.02685249307617
                    ]
                }
            },
            "overall_score": 23.0,
            "batch_job_id": "0981846f-f061-4910-820b-ad896f4220db",
            "osm_extract_url": null,
            "census_block_count": 2700,
            "batch": null
        },
```

### Notes

I made a new serializer for the partial neighborhood included with the analysis job (`NeighborhoodSummarySerializer`).  It's extremely similar to `NeighborhoodGeoJsonSerializer`, except that it specifies all the fields as read-only and it's not a Geo serializer so the point just goes in with other attributes rather than in a Feature/geometry/properties structure.  I figured since this endpoint isn't returning GeoJSON, there's no making the inlined neighborhood GeoJSON-like, but I could be persuaded to toss out `NeighborhoodSummarySerializer` and just use `NeighborhoodGeoJsonSerializer` if that seems better.

## Testing Instructions

- The `analysis_jobs` endpoint should work and include neighborhood information in the results.
- Creating a job in the front-end or the API should work as before, with `neighborhood: <uuid>` creating the association to the neighborhood.
- The Analysis Job detail admin view should show the neighborhood label.

Resolves #264.