### PR TITLE
Overall scores in census blocks

### DIFF
--- a/src/analysis/connectivity/access_overall.sql
+++ b/src/analysis/connectivity/access_overall.sql
@@ -1,0 +1,181 @@
+----------------------------------------
+-- variables:
+--   :total=100
+--   :people=20
+--   :opportunity=25
+--   :core_services=30
+--   :recreation=10
+--   :transit=15
+----------------------------------------
+UPDATE  neighborhood_census_blocks
+SET     overall_score = :total *
+            (
+                :people * COALESCE(pop_score,0)
+                + :opportunity *
+                    CASE
+                    WHEN    COALESCE(schools_high_stress,0)
+                            + COALESCE(colleges_high_stress,0)
+                            + COALESCE(universities_high_stress,0)
+                            = 0 THEN 0
+                    ELSE    (
+                                (
+                                    0.4 * COALESCE(emp_score,0)
+                                    + 0.4 * COALESCE(schools_score,0)
+                                    + 0.1 * COALESCE(colleges_score,0)
+                                    + 0.1 * COALESCE(universities_score,0)
+                                ) /
+                                (
+                                    0.4
+                                    +   CASE
+                                        WHEN schools_high_stress > 0
+                                            THEN 0.4
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN colleges_high_stress > 0
+                                            THEN 0.1
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN universities_high_stress > 0
+                                            THEN 0.1
+                                        ELSE 0
+                                        END
+                                )
+                            )
+                    END
+                + :core_services *
+                    CASE
+                    WHEN    COALESCE(doctors_high_stress,0)
+                            + COALESCE(dentists_high_stress,0)
+                            + COALESCE(hospitals_high_stress,0)
+                            + COALESCE(pharmacies_high_stress,0)
+                            + COALESCE(retail_high_stress,0)
+                            + COALESCE(supermarkets_high_stress,0)
+                            + COALESCE(social_services_high_stress,0)
+                            = 0 THEN 0
+                    ELSE    (
+                                (
+                                    0.2 * COALESCE(doctors_score,0)
+                                    + 0.1 * COALESCE(dentists_score,0)
+                                    + 0.2 * COALESCE(hospitals_score,0)
+                                    + 0.1 * COALESCE(pharmacies_score,0)
+                                    + 0.1 * COALESCE(retail_score,0)
+                                    + 0.2 * COALESCE(supermarkets_score,0)
+                                    + 0.1 * COALESCE(social_services_score,0)
+                                ) /
+                                (
+                                    CASE
+                                    WHEN doctors_high_stress > 0
+                                        THEN 0.2
+                                    ELSE 0
+                                    END
+                                    +   CASE
+                                        WHEN dentists_high_stress > 0
+                                            THEN 0.1
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN hospitals_high_stress > 0
+                                            THEN 0.2
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN hospitals_high_stress > 0
+                                            THEN 0.2
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN pharmacies_high_stress > 0
+                                            THEN 0.1
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN retail_high_stress > 0
+                                            THEN 0.1
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN supermarkets_high_stress > 0
+                                            THEN 0.2
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN social_services_high_stress > 0
+                                            THEN 0.1
+                                        ELSE 0
+                                        END
+                                )
+                            )
+                    END
+                + :recreation *
+                    CASE
+                    WHEN    COALESCE(parks_high_stress,0)
+                            + COALESCE(trails_high_stress,0)
+                            + COALESCE(community_centers_high_stress,0)
+                            = 0 THEN 0
+                    ELSE    (
+                                (
+                                    0.5 * COALESCE(parks_score,0)
+                                    + 0.3 * COALESCE(trails_score,0)
+                                    + 0.2 * COALESCE(community_centers_score,0)
+                                ) /
+                                (
+                                    CASE
+                                    WHEN parks_high_stress > 0
+                                        THEN 0.5
+                                    ELSE 0
+                                    END
+                                    +   CASE
+                                        WHEN trails_high_stress > 0
+                                            THEN 0.3
+                                        ELSE 0
+                                        END
+                                    +   CASE
+                                        WHEN community_centers_high_stress > 0
+                                            THEN 0.2
+                                        ELSE 0
+                                        END
+                                )
+                            )
+                    END
+                + :transit * COALESCE(transit_score,0)
+            ) /
+            (
+                :people
+                +   CASE
+                    WHEN COALESCE(schools_high_stress,0)
+                            + COALESCE(colleges_high_stress,0)
+                            + COALESCE(universities_high_stress,0)
+                            = 0 THEN 0
+                    ELSE :opportunity
+                    END
+                +   CASE
+                    WHEN COALESCE(doctors_high_stress,0)
+                            + COALESCE(dentists_high_stress,0)
+                            + COALESCE(hospitals_high_stress,0)
+                            + COALESCE(pharmacies_high_stress,0)
+                            + COALESCE(retail_high_stress,0)
+                            + COALESCE(supermarkets_high_stress,0)
+                            + COALESCE(social_services_high_stress,0)
+                            = 0 THEN 0
+                    ELSE :core_services
+                    END
+                +   CASE
+                    WHEN COALESCE(parks_high_stress,0)
+                            + COALESCE(trails_high_stress,0)
+                            + COALESCE(community_centers_high_stress,0)
+                            = 0 THEN 0
+                    ELSE :recreation
+                    END
+                +   CASE
+                    WHEN COALESCE(transit_high_stress,0) = 0
+                        THEN 0
+                    ELSE :transit
+                    END
+            )
+WHERE   EXISTS (
+            SELECT  1
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(b.geom,neighborhood_census_blocks.geom)
+        );

--- a/src/analysis/connectivity/access_overall.sql
+++ b/src/analysis/connectivity/access_overall.sql
@@ -50,7 +50,6 @@ SET     overall_score = :total *
                             + COALESCE(dentists_high_stress,0)
                             + COALESCE(hospitals_high_stress,0)
                             + COALESCE(pharmacies_high_stress,0)
-                            + COALESCE(retail_high_stress,0)
                             + COALESCE(supermarkets_high_stress,0)
                             + COALESCE(social_services_high_stress,0)
                             = 0 THEN 0
@@ -60,8 +59,7 @@ SET     overall_score = :total *
                                     + 0.1 * COALESCE(dentists_score,0)
                                     + 0.2 * COALESCE(hospitals_score,0)
                                     + 0.1 * COALESCE(pharmacies_score,0)
-                                    + 0.1 * COALESCE(retail_score,0)
-                                    + 0.2 * COALESCE(supermarkets_score,0)
+                                    + 0.3 * COALESCE(supermarkets_score,0)
                                     + 0.1 * COALESCE(social_services_score,0)
                                 ) /
                                 (
@@ -81,23 +79,13 @@ SET     overall_score = :total *
                                         ELSE 0
                                         END
                                     +   CASE
-                                        WHEN hospitals_high_stress > 0
-                                            THEN 0.2
-                                        ELSE 0
-                                        END
-                                    +   CASE
                                         WHEN pharmacies_high_stress > 0
                                             THEN 0.1
                                         ELSE 0
                                         END
                                     +   CASE
-                                        WHEN retail_high_stress > 0
-                                            THEN 0.1
-                                        ELSE 0
-                                        END
-                                    +   CASE
                                         WHEN supermarkets_high_stress > 0
-                                            THEN 0.2
+                                            THEN 0.3
                                         ELSE 0
                                         END
                                     +   CASE
@@ -108,6 +96,7 @@ SET     overall_score = :total *
                                 )
                             )
                     END
+                + :retail * COALESCE(retail_score,0)
                 + :recreation *
                     CASE
                     WHEN    COALESCE(parks_high_stress,0)
@@ -155,11 +144,14 @@ SET     overall_score = :total *
                             + COALESCE(dentists_high_stress,0)
                             + COALESCE(hospitals_high_stress,0)
                             + COALESCE(pharmacies_high_stress,0)
-                            + COALESCE(retail_high_stress,0)
                             + COALESCE(supermarkets_high_stress,0)
                             + COALESCE(social_services_high_stress,0)
                             = 0 THEN 0
                     ELSE :core_services
+                    END
+                +   CASE
+                    WHEN COALESCE(retail_high_stress,0) = 0 THEN 0
+                    ELSE :retail
                     END
                 +   CASE
                     WHEN COALESCE(parks_high_stress,0)

--- a/src/analysis/connectivity/census_blocks.sql
+++ b/src/analysis/connectivity/census_blocks.sql
@@ -59,6 +59,7 @@ ALTER TABLE neighborhood_census_blocks DROP COLUMN IF EXISTS community_centers_s
 ALTER TABLE neighborhood_census_blocks DROP COLUMN IF EXISTS transit_low_stress;
 ALTER TABLE neighborhood_census_blocks DROP COLUMN IF EXISTS transit_high_stress;
 ALTER TABLE neighborhood_census_blocks DROP COLUMN IF EXISTS transit_score;
+ALTER TABLE neighborhood_census_blocks DROP COLUMN IF EXISTS overall_score;
 
 ALTER TABLE neighborhood_census_blocks ADD COLUMN road_ids INTEGER[];
 ALTER TABLE neighborhood_census_blocks ADD COLUMN pop_low_stress INT;
@@ -109,6 +110,7 @@ ALTER TABLE neighborhood_census_blocks ADD COLUMN community_centers_score FLOAT;
 ALTER TABLE neighborhood_census_blocks ADD COLUMN transit_low_stress INT;
 ALTER TABLE neighborhood_census_blocks ADD COLUMN transit_high_stress INT;
 ALTER TABLE neighborhood_census_blocks ADD COLUMN transit_score FLOAT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN overall_score FLOAT;
 
 -- indexes
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);

--- a/src/analysis/connectivity/score_inputs.sql
+++ b/src/analysis/connectivity/score_inputs.sql
@@ -1692,7 +1692,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         'Average score of low stress access to retail',
         CASE    WHEN SUM(retail_high_stress) = 0 THEN 0
                 ELSE SUM(retail_low_stress) / SUM(retail_high_stress)
@@ -1713,7 +1713,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         'Median score of retail access',
         quantile(CASE WHEN retail_high_stress=0 THEN 0 ELSE retail_low_stress::FLOAT/retail_high_stress END,0.5),
         regexp_replace('Score of retail accessible by low stress
@@ -1734,7 +1734,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         '70th percentile score of retail access',
         quantile(CASE WHEN retail_high_stress=0 THEN 0 ELSE retail_low_stress::FLOAT/retail_high_stress END,0.7),
         regexp_replace('Score of retail accessible by low stress
@@ -1755,7 +1755,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         '30th percentile score of retail access',
         quantile(CASE WHEN retail_high_stress=0 THEN 0 ELSE retail_low_stress::FLOAT/retail_high_stress END,0.3),
         regexp_replace('Score of retail accessible by low stress
@@ -1776,7 +1776,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation, use_retail
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         'Average score of access to retail',
         SUM(pop10 * retail_score / tmp_pop.retail),
         regexp_replace('Average retail score for census blocks
@@ -1796,7 +1796,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         'Average retail bike shed access score',
         CASE    WHEN SUM(pop_high_stress) = 0 THEN 0
                 ELSE SUM(pop_low_stress)::FLOAT / SUM(pop_high_stress)
@@ -1819,7 +1819,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         'Median retail population shed score',
         quantile(CASE WHEN pop_high_stress=0 THEN 0 ELSE pop_low_stress::FLOAT/pop_high_stress END,0.5),
         regexp_replace('Score of population with low stress access to retail
@@ -1842,7 +1842,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         '70th percentile retail population shed score',
         quantile(CASE WHEN pop_high_stress=0 THEN 0 ELSE pop_low_stress::FLOAT/pop_high_stress END,0.7),
         regexp_replace('Score of population with low stress access to retail
@@ -1865,7 +1865,7 @@ WHERE   EXISTS (
 INSERT INTO generated.neighborhood_score_inputs (
     category, score_name, score, notes, human_explanation
 )
-SELECT  'Core Services',
+SELECT  'Retail',
         '30th percentile retail population shed score',
         quantile(CASE WHEN pop_high_stress=0 THEN 0 ELSE pop_low_stress::FLOAT/pop_high_stress END,0.3),
         regexp_replace('Score of population with low stress access to retail

--- a/src/analysis/scripts/run_connectivity.sh
+++ b/src/analysis/scripts/run_connectivity.sh
@@ -28,9 +28,10 @@ MIN_PATH_BBOX="${MIN_PATH_BBOX:-3300}"                  # minimum corner-to-corn
 BLOCK_ROAD_BUFFER="${BLOCK_ROAD_BUFFER:-15}"            # buffer distance to find roads associated with a block
 BLOCK_ROAD_MIN_LENGTH="${BLOCK_ROAD_MIN_LENGTH:-30}"    # minimum length road must overlap with block buffer to be associated
 SCORE_TOTAL="${SCORE_TOTAL:-100}"
-SCORE_PEOPLE="${SCORE_PEOPLE:-20}"
+SCORE_PEOPLE="${SCORE_PEOPLE:-15}"
 SCORE_OPPORTUNITY="${SCORE_OPPORTUNITY:-25}"
-SCORE_CORESVCS="${SCORE_CORESVCS:-30}"
+SCORE_CORESVCS="${SCORE_CORESVCS:-25}"
+SCORE_RETAIL="${SCORE_CORESVCS:-10}"
 SCORE_RECREATION="${SCORE_RECREATION:-10}"
 SCORE_TRANSIT="${SCORE_TRANSIT:-15}"
 
@@ -282,6 +283,7 @@ update_status "METRICS" "Access: colleges"
   -v people=${SCORE_PEOPLE} \
   -v opportunity=${SCORE_OPPORTUNITY} \
   -v core_services=${SCORE_CORESVCS} \
+  -v retail=${SCORE_RETAIL} \
   -v recreation=${SCORE_RECREATION} \
   -v transit=${SCORE_TRANSIT} \
   -f ../connectivity/access_overall.sql
@@ -295,6 +297,7 @@ update_status "METRICS" "Overall scores"
   -v people=${SCORE_PEOPLE} \
   -v opportunity=${SCORE_OPPORTUNITY} \
   -v core_services=${SCORE_CORESVCS} \
+  -v retail=${SCORE_RETAIL} \
   -v recreation=${SCORE_RECREATION} \
   -v transit=${SCORE_TRANSIT} \
   -f ../connectivity/overall_scores.sql

--- a/src/analysis/scripts/run_connectivity.sh
+++ b/src/analysis/scripts/run_connectivity.sh
@@ -27,6 +27,12 @@ MIN_PATH_LENGTH="${MIN_PATH_LENGTH:-4800}"              # minimum path length to
 MIN_PATH_BBOX="${MIN_PATH_BBOX:-3300}"                  # minimum corner-to-corner span of path bounding box to be considered for recreation access
 BLOCK_ROAD_BUFFER="${BLOCK_ROAD_BUFFER:-15}"            # buffer distance to find roads associated with a block
 BLOCK_ROAD_MIN_LENGTH="${BLOCK_ROAD_MIN_LENGTH:-30}"    # minimum length road must overlap with block buffer to be associated
+SCORE_TOTAL="${SCORE_TOTAL:-100}"
+SCORE_PEOPLE="${SCORE_PEOPLE:-20}"
+SCORE_OPPORTUNITY="${SCORE_OPPORTUNITY:-25}"
+SCORE_CORESVCS="${SCORE_CORESVCS:-30}"
+SCORE_RECREATION="${SCORE_RECREATION:-10}"
+SCORE_TRANSIT="${SCORE_TRANSIT:-15}"
 
 # Limit custom output formatting for `time` command
 export TIME="\nTIMING: %C\nTIMING:\t%E elapsed %Kkb mem\n"
@@ -272,14 +278,23 @@ update_status "METRICS" "Access: colleges"
   -f ../connectivity/access_universities.sql
 
 /usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -v total=${SCORE_TOTAL} \
+  -v people=${SCORE_PEOPLE} \
+  -v opportunity=${SCORE_OPPORTUNITY} \
+  -v core_services=${SCORE_CORESVCS} \
+  -v recreation=${SCORE_RECREATION} \
+  -v transit=${SCORE_TRANSIT} \
+  -f ../connectivity/access_overall.sql
+
+/usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f ../connectivity/score_inputs.sql
 
 update_status "METRICS" "Overall scores"
 /usr/bin/time psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
-  -v total=100 \
-  -v people=20 \
-  -v opportunity=25 \
-  -v core_services=30 \
-  -v recreation=10 \
-  -v transit=15 \
+  -v total=${SCORE_TOTAL} \
+  -v people=${SCORE_PEOPLE} \
+  -v opportunity=${SCORE_OPPORTUNITY} \
+  -v core_services=${SCORE_CORESVCS} \
+  -v recreation=${SCORE_RECREATION} \
+  -v transit=${SCORE_TRANSIT} \
   -f ../connectivity/overall_scores.sql

--- a/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
+++ b/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
@@ -5,7 +5,7 @@
     "fields": {
       "label": "People",
       "category": "",
-      "description": "Half of all census blocks in the neighborhood have a ratio of low stress to high stress access above this number, half have a lower ratio."
+      "description": "On average, this is how residents score for access to other people."
     }
   },
   {
@@ -14,7 +14,7 @@
     "fields": {
       "label": "Employment",
       "category": "Opportunity",
-      "description": "Half of all census blocks in the neighborhood have a ratio of low stress to high stress access above this number, half have a lower ratio."
+      "description": "On average, this is how residents score for access to jobs."
     }
   },
   {
@@ -23,7 +23,7 @@
     "fields": {
       "label": "K12 Education",
       "category": "Opportunity",
-      "description": "70% of schools in the neighborhood have low stress connections to a higher percentage of people within biking distance, 30% are connected to a lower percentage."
+      "description": "On average, this is how people score for access to K-12 schools."
     }
   },
   {
@@ -32,7 +32,7 @@
     "fields": {
       "label": "Tech/Vocational College",
       "category": "Opportunity",
-      "description": "Half of tech/vocational colleges in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one tech/vocational college exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to a technical or vocational college."
     }
   },
   {
@@ -41,7 +41,7 @@
     "fields": {
       "label": "Higher Education",
       "category": "Opportunity",
-      "description": "Half of universities in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one university exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to a university."
     }
   },
   {
@@ -50,7 +50,7 @@
     "fields": {
       "label": "Opportunity Total",
       "category": "Opportunity",
-      "description": ""
+      "description": "On average, this is how people score for access to employment and educational opportunities."
     }
   },
   {
@@ -59,7 +59,7 @@
     "fields": {
       "label": "Doctors",
       "category": "Core Services",
-      "description": "Half of doctors in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one doctors office exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to doctors."
     }
   },
   {
@@ -68,7 +68,7 @@
     "fields": {
       "label": "Dentists",
       "category": "Core Services",
-      "description": "Half of dentists in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one dentists office exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to dentists."
     }
   },
   {
@@ -77,7 +77,7 @@
     "fields": {
       "label": "Hospitals",
       "category": "Core Services",
-      "description": "Half of hospitals in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one hospital exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to a hospital."
     }
   },
   {
@@ -86,16 +86,7 @@
     "fields": {
       "label": "Pharmacies",
       "category": "Core Services",
-      "description": "Half of pharmacies in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one pharmacy exists this is the score for that one location)"
-    }
-  },
-  {
-    "model": "pfb_analysis.AnalysisScoreMetadata",
-    "pk": "core_services_retail",
-    "fields": {
-      "label": "Retail",
-      "category": "Core Services",
-      "description": "Half of retail clusters in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one retail exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to pharmacies."
     }
   },
   {
@@ -104,7 +95,7 @@
     "fields": {
       "label": "Grocery",
       "category": "Core Services",
-      "description": "Half of supermarkets in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one supermarkets exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to groceries."
     }
   },
   {
@@ -113,16 +104,25 @@
     "fields": {
       "label": "Social Services",
       "category": "Core Services",
-      "description": "Half of social services in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one social_services exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to social services."
     }
   },
   {
     "model": "pfb_analysis.AnalysisScoreMetadata",
     "pk": "core_services",
     "fields": {
-      "label": "Services Total",
+      "label": "Core Services Total",
       "category": "Core Services",
-      "description": ""
+      "description": "On average, this is how people score for access to Core Services."
+    }
+  },
+  {
+    "model": "pfb_analysis.AnalysisScoreMetadata",
+    "pk": "core_services_retail",
+    "fields": {
+      "label": "Retail",
+      "category": "Retail",
+      "description": "On average, this is how people score for access to retail shopping opportunities."
     }
   },
   {
@@ -131,7 +131,7 @@
     "fields": {
       "label": "Parks",
       "category": "Recreation",
-      "description": "Half of census blocks in this neighborhood have low stress access to a higher ratio of parks within biking distance, half have access to a lower ratio."
+      "description": "On average, this is how people score for access to parks."
     }
   },
   {
@@ -140,7 +140,7 @@
     "fields": {
       "label": "Trails",
       "category": "Recreation",
-      "description": "Half of census blocks in this neighborhood have low stress access to a higher ratio of trails within biking distance, half have access to a lower ratio."
+      "description": "On average, this is how people score for access to off-street trails and paths for recreational riding."
     }
   },
   {
@@ -149,7 +149,7 @@
     "fields": {
       "label": "Community Centers",
       "category": "Recreation",
-      "description": "Half of community centers in the neighborhood have low stress connections to a higher percentage of people within biking distance, half are connected to a lower percentage. (if only one community centers exists this is the score for that one location)"
+      "description": "On average, this is how people score for access to community centers."
     }
   },
   {
@@ -158,7 +158,7 @@
     "fields": {
       "label": "Recreation Total",
       "category": "Recreation",
-      "description": ""
+      "description": "On average, this is how people score for access to recreation opportunities."
     }
   },
   {
@@ -167,7 +167,7 @@
     "fields": {
       "label": "Transit",
       "category": "Transit",
-      "description": "Half of census blocks in this neighborhood have low stress access to a higher ratio of transit stations within biking distance, half have access to a lower ratio."
+      "description": "On average, this is how people score for access to major transit hubs."
     }
   },
   {
@@ -176,7 +176,7 @@
     "fields": {
       "label": "Overall Score",
       "category": "",
-      "description": ""
+      "description": "On average, this is how people score for overall access."
     }
   }
 ]


### PR DESCRIPTION
## Overview

Adds new field "overall_score" to neighborhood_census_blocks. This is the field we can use to generate tiles for viewing census block scores.
