### PR TITLE
Add job logs url to AnalysisJob detail view in admin

### DIFF
--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -86,12 +86,16 @@ class NeighborhoodSummarySerializer(PFBModelSerializer):
 
 class AnalysisJobSerializer(PFBModelSerializer):
 
+    logs_url = serializers.SerializerMethodField()
     running_time = serializers.SerializerMethodField()
     start_time = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
     neighborhood = PrimaryKeyReferenceRelatedField(queryset=Neighborhood.objects.all(),
                                                    serializer=NeighborhoodSummarySerializer)
     overall_score = serializers.FloatField(read_only=True)
+
+    def get_logs_url(self, obj):
+        return obj.logs_url
 
     def get_running_time(self, obj):
         return obj.running_time


### PR DESCRIPTION
## Overview

Adds a link to the AWS logs for the job, making it easier to inspect failed jobs.

Again, not pretty, but its selectable and copy/pastable into a browser.

### Demo

<img width="1027" alt="screen shot 2017-04-17 at 12 59 10" src="https://cloud.githubusercontent.com/assets/1818302/25096373/eb769070-236d-11e7-9edb-6deb0ba3dc93.png">

## Testing Instructions

 * Create job via UI, ensure url exists once job is started

Closes #296 
