### PR TITLE
Add boundary population category to neighborhood_overall_scores

### DIFF
--- a/src/analysis/connectivity/overall_scores.sql
+++ b/src/analysis/connectivity/overall_scores.sql
@@ -365,17 +365,3 @@ SELECT  'population_total',
                     )
         ),
         'Total population of boundary';
-
--- population category
-INSERT INTO generated.neighborhood_overall_scores (
-    score_id, score_original, human_explanation
-)
-SELECT  'population_category',
-        CASE
-        WHEN score_original > 500000 THEN 1
-        WHEN score_original > 100000 THEN 2
-        ELSE 3
-        END,
-        'City category (1=large, 2=medium, 3=small)'
-FROM    neighborhood_overall_scores
-WHERE   score_id = 'population_total'

--- a/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
+++ b/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
@@ -178,5 +178,14 @@
       "category": "",
       "description": "On average, this is how people score for overall access."
     }
+  },
+  {
+    "model": "pfb_analysis.AnalysisScoreMetadata",
+    "pk": "population_total",
+    "fields": {
+      "label": "Total Population",
+      "category": "",
+      "description": "Total population of this area."
+    }
   }
 ]


### PR DESCRIPTION
## Overview

Adds two new entries to neighborhood_overall_scores. One is the total population of the boundary area (summary of pop10 attribute in census blocks). The second is a categorization of the city:

- 1=large
- 2=medium
- 3=small

Current breaks are set at >= 500,000 (large city) and >= 100,000 (medium city).

The score_id is `population_total` for the population and `population_category` for the category.

## Testing Instructions

1. Run analysis
2. Check for new scores
