### PR TITLE
Better error handling for both batch jobs

### DIFF
--- a/src/analysis/scripts/entrypoint.sh
+++ b/src/analysis/scripts/entrypoint.sh
@@ -40,7 +40,12 @@ do
     ((counter++))
 done
 
-if /opt/pfb/analysis/scripts/run_analysis.sh; then
+set +e
+/opt/pfb/analysis/scripts/run_analysis.sh
+PFB_EXIT_STATUS=$?
+set -e
+
+if [ $PFB_EXIT_STATUS -eq  0 ]; then
     update_status "EXPORTED" "Finished analysis"
 else
     update_status "ERROR" "Failed" "See job logs for more details."
@@ -50,7 +55,8 @@ fi
 # so it enables keeping a docker container alive after processing by running it with `-t`
 bash
 
-
 # shutdown postgres
 su postgres -c "/usr/lib/postgresql/9.6/bin/pg_ctl stop"
 wait
+
+exit $PFB_EXIT_STATUS

--- a/src/tilemaker/entrypoint.sh
+++ b/src/tilemaker/entrypoint.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-TL_SHAPEFILE_NAME="${TL_SHAPEFILE_NAME:-neighborhood_ways}"
-TL_MIN_ZOOM="${TL_MIN_ZOOM:-8}"
-TL_MAX_ZOOM="${TL_MAX_ZOOM:-17}"
+export TL_SHAPEFILE_NAME="${TL_SHAPEFILE_NAME:-neighborhood_ways}"
+export TL_MIN_ZOOM="${TL_MIN_ZOOM:-8}"
+export TL_MAX_ZOOM="${TL_MAX_ZOOM:-17}"
 
 if [ -z "${PFB_JOB_ID}" ]; then
     echo "Error: PFB_JOB_ID is required"
@@ -19,36 +19,18 @@ function update_status() {
 
 update_status "TILING" "Exporting tiles"
 
-PFB_TEMPDIR=`mktemp -d`
-cd $PFB_TEMPDIR
+set +e
+/opt/pfb/tilemaker/scripts/run_tilemaker.sh
+PFB_EXIT_STATUS=$?
+set -e
 
-# Download and unzip shapefile
-aws s3 cp "s3://${AWS_STORAGE_BUCKET_NAME}/${PFB_S3_RESULTS_PATH}/${TL_SHAPEFILE_NAME}.zip" ./
-unzip "${TL_SHAPEFILE_NAME}.zip"
-
-mkdir -p /data
-# Reproject. Could convert to GeoJSON as well, but shapefile is smaller and the tile conversion
-# can handle it just as well.
-ogr2ogr -overwrite -t_srs EPSG:4326 -f "ESRI Shapefile" "/data/" \
-    "${PFB_TEMPDIR}/${TL_SHAPEFILE_NAME}.shp"
-
-# Get bounds. ogrinfo can handle big files, but doesn't provide tons of output flexibility, so
-# parse out the answer from the blob of text it returns.
-TL_BOUNDS=$(ogrinfo -so -al "/data/${TL_SHAPEFILE_NAME}.shp" \
-    | grep Extent | sed -E 's/.*\((.*), (.*)\) - \((.*), (.*)\).*/\1 \2 \3 \4/')
-
-# Make tiles and upload them to S3.
-# 'tl' only has totally-quiet or very-verbose (every tile) output options, so this filters
-# the output to show the first line then every 1000th line thereafter.
-/usr/bin/time -f "\nTIMING: %C\nTIMING:\t%E elapsed %Kkb mem\n" \
-tl copy --min-zoom "${TL_MIN_ZOOM}" --max-zoom "${TL_MAX_ZOOM}" \
-    --bounds "${TL_BOUNDS}" \
-    "mapnik:///opt/pfb/tilemaker/styles/${TL_SHAPEFILE_NAME}_style.xml" \
-    "s3://${AWS_STORAGE_BUCKET_NAME}/${PFB_S3_TILES_PATH}/{z}/{x}/{y}.png" \
-    | awk 'NR == 1 || NR % 1000 == 0'
-
-update_status "COMPLETE" "Finished exporting tiles"
-
+if [ $PFB_EXIT_STATUS -eq  0 ]; then
+    update_status "COMPLETE" "Finished exporting tiles"
+else
+    update_status "ERROR" "Failed" "See job logs for more details."
+fi
 
 # Drop to a shell if run interactively
 bash
+
+exit $PFB_EXIT_STATUS

--- a/src/tilemaker/scripts/run_tilemaker.sh
+++ b/src/tilemaker/scripts/run_tilemaker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Downloads a shapefile and converts it to raster tiles that it writes to S3
+# Requires the following vars to be defined in the environment:
+# - AWS_STORAGE_BUCKET_NAME
+# - PFB_S3_RESULTS_PATH
+# - TL_SHAPEFILE_NAME
+# - TL_MIN_ZOOM
+# - TL_MAX_ZOOM
+
+set -e
+
+PFB_TEMPDIR=`mktemp -d`
+cd $PFB_TEMPDIR
+
+# Download and unzip shapefile
+aws s3 cp "s3://${AWS_STORAGE_BUCKET_NAME}/${PFB_S3_RESULTS_PATH}/${TL_SHAPEFILE_NAME}.zip" ./
+unzip "${TL_SHAPEFILE_NAME}.zip"
+
+mkdir -p /data
+# Reproject. Could convert to GeoJSON as well, but shapefile is smaller and the tile conversion
+# can handle it just as well.
+ogr2ogr -overwrite -t_srs EPSG:4326 -f "ESRI Shapefile" "/data/" \
+    "${PFB_TEMPDIR}/${TL_SHAPEFILE_NAME}.shp"
+
+# Get bounds. ogrinfo can handle big files, but doesn't provide tons of output flexibility, so
+# parse out the answer from the blob of text it returns.
+TL_BOUNDS=$(ogrinfo -so -al "/data/${TL_SHAPEFILE_NAME}.shp" \
+    | grep Extent | sed -E 's/.*\((.*), (.*)\) - \((.*), (.*)\).*/\1 \2 \3 \4/')
+
+# Make tiles and upload them to S3.
+# 'tl' only has totally-quiet or very-verbose (every tile) output options, so this filters
+# the output to show the first line then every 1000th line thereafter.
+/usr/bin/time -f "\nTIMING: %C\nTIMING:\t%E elapsed %Kkb mem\n" \
+tl copy --min-zoom "${TL_MIN_ZOOM}" --max-zoom "${TL_MAX_ZOOM}" \
+    --bounds "${TL_BOUNDS}" \
+    "mapnik:///opt/pfb/tilemaker/styles/${TL_SHAPEFILE_NAME}_style.xml" \
+    "s3://${AWS_STORAGE_BUCKET_NAME}/${PFB_S3_TILES_PATH}/{z}/{x}/{y}.png" \
+    | awk 'NR == 1 || NR % 1000 == 0'


### PR DESCRIPTION


## Overview

Properly catches and returns exit code of the main script in the entrypoint scripts. This allows Batch to properly detect exit codes and kill downstream jobs in the DAG


### Demo

![screen shot 2017-04-17 at 16 16 04](https://cloud.githubusercontent.com/assets/1818302/25103742/ac540a12-238b-11e7-8e5e-ae467784fdd8.png)
![screen shot 2017-04-17 at 16 16 25](https://cloud.githubusercontent.com/assets/1818302/25103743/ac548884-238b-11e7-933b-03a32c8f3779.png)

### Notes

Using the `set +e ... set -e` strategy seemed like the most clean way to go about this. If `-e` is left set, then there is no way to DRY the error handling as the script immediately exits without getting a chance to save the error code as demonstrated by this sample script (play with adding/deleting the `set -e` line):
```bash
#!/bin/bash

set -e

function fail() {
    return 1
}

fail
ERR=$?

# If instead we do 'if fail; then' then we have to duplicate the ERR=$? 
# in each branch, which is lame
if [ $ERR -eq 0 ]; then
    echo "Success: $ERR"
else
    echo "Failure: $ERR"
fi
```
Then again my bash-fu is pretty mediocre and I might have missed a better way (TM).

## Testing Instructions

 * Not really possible to test locally, but this branch is deployed on staging until another deployment happens, so if you get to it fast you could kick off a bad job by setting 'OSM Extract URL' on the AnalysisJob to an invalid URL (http://doesnotexist.localhost worked well for me)

Closes #272 
