### PR TITLE
Don't try to export features with empty geometry

### DIFF
--- a/src/analysis/scripts/export_connectivity.sh
+++ b/src/analysis/scripts/export_connectivity.sh
@@ -80,7 +80,7 @@ function ec_export_table_geojson() {
   EXPORT_TABLENAME="${2}"
 
   FILENAME="${OUTPUT_DIR}/${EXPORT_TABLENAME}.geojson"
-  ogr2ogr -f GeoJSON "${FILENAME}" \
+  ogr2ogr -f GeoJSON "${FILENAME}" -skipfailures \
           -t_srs EPSG:4326 \
           "PG:host=${NB_POSTGRESQL_HOST} dbname=${NB_POSTGRESQL_DB} user=${NB_POSTGRESQL_USER}" \
           -sql "select * from ${EXPORT_TABLENAME}"
@@ -95,7 +95,7 @@ function ec_export_destination_geojson() {
   # Our version of ogr2ogr isn't new enough to specify the geom column :(
   #   Instead, ogr2ogr states it takes the "last" geom column, so we manually specify
   #   it here to ensure we always take the one we want
-  ogr2ogr -f GeoJSON "${FILENAME}" \
+  ogr2ogr -f GeoJSON "${FILENAME}" -skipfailures \
           -t_srs EPSG:4326 \
           "PG:host=${NB_POSTGRESQL_HOST} dbname=${NB_POSTGRESQL_DB} user=${NB_POSTGRESQL_USER}" \
           -sql "select *, geom_pt from ${EXPORT_TABLENAME}"


### PR DESCRIPTION
## Overview

Protects against empty geometry, which makes `ogr2ogr`, and hence the export script, crash.

### Demo

A little hard to pick out between the "More than one geometry column" warnings, but here's the command that gets run by `export_connectivity.sh` failing then succeeding in its "before" and "after" forms.

![image](https://cloud.githubusercontent.com/assets/6598836/25150925/a74f2c2e-2451-11e7-829c-7f727002393d.png)


### Notes

- I looked into downloading the `pgdata` for jobs off the batch worker.

Per [this answer](https://unix.stackexchange.com/a/327100) referencing [this line of the `scp` code](https://github.com/openssh/libopenssh/blob/master/ssh/scp.c#L375), scp doesn't support agent forwarding.  The strategy I did get working ([from here](https://serverfault.com/a/37664)) was opening one connection to the bastion that forwards the ssh port on the batch instance to another port, which you can then use to establish scp connections.
```
ssh -A -L 5022:<batch instance IP>:22 ec2-user@bastion.staging.pfb.azavea.com
scp -P 5022 ec2-user@localhost:<remote_path> <local_path>
```
The problem with that is that the remote files are owned by `root`, and `ec2-user` can't read them.  Which can be addressed either by tarring them up first, e.g. `ssh -p 5022 ec2-user@localhost "sudo tar czf /media/nvme0n1/pgdata/JOB_ID.tar.gz /media/nvme0n1/pgdata/JOB_ID"` then downloading that (it's created readable by other users) or by running a remote sudo command to change the permissions of the directory (which doesn't seem ideal, but then again the analysis is finished so it won't really be interfering with anything).

I think uploading to S3 and downloading from there makes the most sense.  The "tar then download" strategy, in particular, seems not ideal because it uses disk space, disk I/O, and CPU on the worker instance.  Anything will use at least some resources, but copying to S3 from EC2 is very fast, and once that's done you no longer have to rely on the EC2 instance.

- Speaking of which, it turned out none of this was actually relevant to my debugging of this issue because the batch worker instance was replaced yesterday so the working files from the actual analysis run are gone.  Only took about half an hour locally, though.

- The non-pharmacy is getting inserted at https://github.com/azavea/pfb-network-connectivity/blob/develop/src/analysis/connectivity/destinations/pharmacies.sql#L23.  This issue could also be addressed there, but I'm not that clear on what that's doing and why (it pulls a bunch of multipolygons with no attributes at the line mentioned, then adds point geometries for those and also pulls a bunch of points), so I went for the more obvious fix.

## Testing Instructions

I don't know how to reproduce this except with Glendale.  I could try to extract my database, since the one on staging is gone.

Resolves #295.