### PR TITLE
Reusable map component with basic configuration

### DIFF
--- a/src/angularjs/.eslintrc
+++ b/src/angularjs/.eslintrc
@@ -10,6 +10,7 @@
     "module": true,
     "URI": true,
     "_": true,
+    "L": true,
     "inject": true
   },
   "rules": {

--- a/src/angularjs/bower.json
+++ b/src/angularjs/bower.json
@@ -16,6 +16,7 @@
     "angular-resource": "1.5.11",
     "angular-ui-router": "0.4.2",
     "angular-toastr": "2.1.1",
+    "leaflet": "1.0.3",
     "moment": "2.17.1",
     "animate.css": "3.5.2",
     "angular-bootstrap": "1.3.3",

--- a/src/angularjs/src/app/components/map/map.directive.js
+++ b/src/angularjs/src/app/components/map/map.directive.js
@@ -1,0 +1,72 @@
+(function() {
+
+    /* @ngInject */
+    function MapController($element) {
+        var ctl = this;
+        ctl.map = null;
+        ctl.mapHTMLElement = $element[0];
+        ctl.pfbMapOptions = ctl.pfbMapOptions || {};
+
+        ctl.$onChanges = function (changes) {
+            ctl.updateMapOptions(changes);
+        }
+
+        ctl.$postLink = function () {
+            ctl.map = L.map(ctl.mapHTMLElement, ctl.pfbMapOptions);
+            ctl.updateMapOptions({
+                pfbMapBounds: { currentValue: ctl.pfbMapBounds },
+                pfbMapCenter: { currentValue: ctl.pfbMapCenter },
+                pfbMapZoom: { currentValue: ctl.pfbMapZoom },
+                pfbMapBaselayer: { currentValue: ctl.pfbMapBaselayer }
+            });
+            ctl.pfbMapReady({map: ctl.map});
+        }
+
+        ctl.updateMapOptions = function (changes) {
+            if (ctl.map) {
+                if (changes.pfbMapBounds && changes.pfbMapBounds.currentValue) {
+                    ctl.map.fitBounds(changes.pfbMapBounds.currentValue);
+                }
+                if (changes.pfbMapCenter && changes.pfbMapCenter.currentValue) {
+                    ctl.map.panTo(changes.pfbMapCenter.currentValue, {animate: false});
+                }
+                if (changes.pfbMapZoom && changes.pfbMapZoom.currentValue) {
+                    ctl.map.setZoom(changes.pfbMapZoom.currentValue, {animate: false});
+                }
+
+                if (changes.pfbMapBaselayer && changes.pfbMapBaselayer.currentValue) {
+                    if (ctl.baselayer) {
+                        ctl.map.removeLayer(ctl.baselayer);
+                        ctl.baselayer = null;
+                    }
+                    ctl.baselayer = changes.pfbMapBaselayer.currentValue;
+                    ctl.map.addLayer(ctl.baselayer);
+                }
+            }
+        }
+    }
+
+    function PFBMapDirective() {
+        var module = {
+            restrict: 'A',
+            controller: 'PFBMapController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            scope: {
+                pfbMapBounds: '<',
+                pfbMapZoom: '<',
+                pfbMapCenter: '<',
+                pfbMapBaselayer: '<',
+                pfbMapOptions: '<',
+                pfbMapReady: '&'
+            }
+        };
+        return module;
+    }
+
+
+    angular.module('pfb.components.map')
+        .controller('PFBMapController', MapController)
+        .directive('pfbMap', PFBMapDirective);
+
+})();

--- a/src/angularjs/src/app/components/map/module.js
+++ b/src/angularjs/src/app/components/map/module.js
@@ -1,0 +1,6 @@
+
+(function() {
+    'use strict';
+
+    angular.module('pfb.components.map', []);
+})();

--- a/src/angularjs/src/app/components/module.js
+++ b/src/angularjs/src/app/components/module.js
@@ -4,5 +4,6 @@
     angular.module('pfb.components',
                    ['pfb.components.analysis-jobs',
                     'pfb.components.auth',
-                    'pfb.components.filters']);
+                    'pfb.components.filters',
+                    'pfb.components.map']);
 })();

--- a/src/angularjs/src/app/home/home.controller.js
+++ b/src/angularjs/src/app/home/home.controller.js
@@ -1,0 +1,35 @@
+/**
+ * @ngdoc controller
+ * @name pfb.home.home.controller:HomeController
+ *
+ * @description
+ * Controller handling interactions on index page
+ *
+ */
+(function() {
+    'use strict';
+
+    /** @ngInject */
+    function HomeController($log) {
+        var ctl = this;
+
+        ctl.$onInit = function () {
+            ctl.conusMapOptions = { scrollWheelZoom: false };
+            ctl.conusBounds = [[24.396308, -124.848974], [49.384358, -66.885444]];
+            ctl.baselayer = L.tileLayer(
+                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                });
+        };
+
+        ctl.onConusMapReady = function (map) {
+            $log.debug(map.getBounds());
+        };
+    }
+
+    angular
+        .module('pfb.home')
+        .controller('HomeController', HomeController);
+
+})();

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -17,11 +17,11 @@
             Leading Cities/Towns
         </h2>
         <div class="row stack-xs">
-            
-            <!-- I imagine no more than 8 in the leaderboard 
+
+            <!-- I imagine no more than 8 in the leaderboard
                      will suffice. Having more will make the page very long. -->
 
-            <!-- If you duplicate the .column-6 divs  
+            <!-- If you duplicate the .column-6 divs
                      and children the layout will adjust. -->
             <div class="column-6">
                 <div class="card">
@@ -87,7 +87,13 @@
             </div>
 
             <!-- keep the .map class. It's important for sizing. -->
-            <div class="map"></div>
+            <div class="map map-below"
+                pfb-map
+                pfb-map-bounds="home.conusBounds"
+                pfb-map-baselayer="home.baselayer"
+                pfb-map-options="home.conusMapOptions"
+                pfb-map-ready="home.onConusMapReady(map)">
+            </pfb-map>
         </div>
     </div>
 </section>
@@ -104,9 +110,9 @@
             <div class="column-6">
                 <div class="card alternate">
 
-                    <!-- This card image div is currently empty 
-                             because I dont know what the metric names 
-                             are. Images or icons might not make sense 
+                    <!-- This card image div is currently empty
+                             because I dont know what the metric names
+                             are. Images or icons might not make sense
                              to even show so we might remove. If we do
                              the layout will auto adjust. -->
                     <div class="card-image"></div>

--- a/src/angularjs/src/app/home/module.js
+++ b/src/angularjs/src/app/home/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('pfb.home', []);
+})();

--- a/src/angularjs/src/app/index.module.js
+++ b/src/angularjs/src/app/index.module.js
@@ -3,7 +3,7 @@
 
     angular
         .module('pfb', [
-            'angular-loading-bar',  'pfb.login', 'pfb.analysisJobs', 'pfb.help',
+            'angular-loading-bar',  'pfb.login', 'pfb.analysisJobs', 'pfb.help', 'pfb.home',
             'pfb.passwordReset', 'pfb.users', 'pfb.organizations', 'pfb.neighborhoods',
             'ngAnimate', 'ngCookies', 'ngSanitize', 'ngMessages', 'ngAria',
             'ngResource', 'ui.router', 'toastr', 'ui.bootstrap', 'pfb.components']);

--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -10,6 +10,8 @@
         $stateProvider
             .state('home', {
                 url: '/',
+                controller: 'HomeController',
+                controllerAs: 'home',
                 templateUrl: 'app/home/home.html'
             })
             .state('places', {

--- a/src/angularjs/src/styles/components/_map.scss
+++ b/src/angularjs/src/styles/components/_map.scss
@@ -6,3 +6,7 @@
   bottom: 0;
   background-color: #eee;
 }
+
+.map-below {
+  z-index: 0;
+}


### PR DESCRIPTION
## Overview

This is part 1 of a two part set to add the neighborhoods map at the bottom of the public homepage. I stopped here since this PR adds a HomeController and adds the MapDirective that can be used elsewhere. I will continue work on displaying the neighborhoods on the map in a separate branch/PR.

### Demo

![screen shot 2017-04-18 at 17 09 37](https://cloud.githubusercontent.com/assets/1818302/25153215/d77245dc-2459-11e7-8e26-f8900826d413.png)

### Notes

Kept the map directive as simple as possible. Added options to set map options/bounds/zoom/center/baselayer but anything else needs to be dealt with using the pfbMapReady function which provides the map object to the wrapping controller. This MapDirective should be sufficient for the individual static maps in the cards all over the site as well as for the larger more interactive maps.

@designmatty should we use a default basemap other than Stamen toner lite?

## Testing Instructions

 * Load up page, see map


Connects #247
