### PR TITLE
Clip OSM extract by census block extent

### DIFF
--- a/src/analysis/import/clip_osm.sql
+++ b/src/analysis/import/clip_osm.sql
@@ -1,0 +1,31 @@
+----------------------------------------
+-- INPUTS
+-- location: neighborhood
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=1000 -f clip_osm.sql
+----------------------------------------
+
+
+DELETE FROM neighborhood_ways AS ways
+    USING neighborhood_boundary AS boundary
+    WHERE NOT ST_DWithin(ways.geom, boundary.geom, :nb_boundary_buffer);
+
+DELETE FROM neighborhood_ways_intersections AS intersections
+    USING neighborhood_boundary AS boundary
+    WHERE NOT ST_DWithin(intersections.geom, boundary.geom, :nb_boundary_buffer);
+
+DELETE FROM neighborhood_osm_full_line AS lines
+    USING neighborhood_boundary AS boundary
+    WHERE NOT ST_DWithin(lines.way, boundary.geom, :nb_boundary_buffer);
+
+DELETE FROM neighborhood_osm_full_point AS points
+    USING neighborhood_boundary AS boundary
+    WHERE NOT ST_DWithin(points.way, boundary.geom, :nb_boundary_buffer);
+
+DELETE FROM neighborhood_osm_full_polygon AS polygons
+    USING neighborhood_boundary AS boundary
+    WHERE NOT ST_DWithin(polygons.way, boundary.geom, :nb_boundary_buffer);
+
+DELETE FROM neighborhood_osm_full_roads AS roads
+    USING neighborhood_boundary AS boundary
+    WHERE NOT ST_DWithin(roads.way, boundary.geom, :nb_boundary_buffer);

--- a/src/analysis/import/import_osm.sh
+++ b/src/analysis/import/import_osm.sh
@@ -12,6 +12,7 @@ NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
 NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
 NB_OUTPUT_SRID="${NB_OUTPUT_SRID:-2163}"
 NB_SIGCTL_SEARCH_DIST="${NB_SIGCTL_SEARCH_DIST:-25}"    # max search distance for intersection controls
+NB_BOUNDARY_BUFFER="${NB_BOUNDARY_BUFFER:-$NB_MAX_TRIP_DISTANCE}"
 
 # drop old tables
 echo 'Dropping old tables'
@@ -164,7 +165,12 @@ psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
 # process tables
 echo 'Updating field names'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-    -v nb_output_srid="${NB_OUTPUT_SRID}" -f ./prepare_tables.sql
+    -v nb_output_srid="${NB_OUTPUT_SRID}" \
+    -f ./prepare_tables.sql
+echo 'Clipping OSM source data to boundary + buffer'
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+    -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" \
+    -f ./clip_osm.sql
 echo 'Setting values on road segments'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ../features/one_way.sql
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ../features/width_ft.sql


### PR DESCRIPTION
## Overview

Clips OSM extract by the extent of the trimmed census blocks which is equal to the extent of the boundary + buffer. In the default case, buffer == max_trip_distance. This leads to only slightly more OSM data than is necessary, which was not necessarily the case in the old extent calculation. It also allows us to reduce the amount of data we're pulling from the Overpass API.

### Demo

OSM extent for a local Germantown job using the MapZen Philadelphia OSM extract:
![screen shot 2017-04-19 at 11 11 32](https://cloud.githubusercontent.com/assets/1818302/25187716/e291d6ba-24f1-11e7-8961-d37de0a442dd.png)


### Notes

`osmconvert` allows clipping via a `.poly` file, which is an arcane format which would have required extensive processing to create using the union of the clipped census blocks, and would only be slightly better in the 'average' case. In the best case, where the boundary+buffer is almost square, the extent would be almost equal to using a `.poly` file.


## Testing Instructions

- Run analysis job and generate neighborhood ways tiles
- Display tiles on map, following [instructions](https://github.com/azavea/pfb-network-connectivity/pull/277#issuecomment-293647993)
- Ensure output approximates the extent of the boundary+buffer

Closes #308 
