### PR TITLE
Set osm_extract_url in batch management command if available

### DIFF
--- a/src/django/pfb_analysis/management/commands/analysis_batch_create.py
+++ b/src/django/pfb_analysis/management/commands/analysis_batch_create.py
@@ -70,6 +70,7 @@ class Command(BaseCommand):
                 for feature in source:
                     city = feature['properties']['city']
                     state = feature['properties']['state']
+                    osm_extract_url = feature['properties'].get('osm_url', None)
                     label = '{}, {}'.format(city, state)
                     name = Neighborhood.name_for_label(label)
 
@@ -95,6 +96,7 @@ class Command(BaseCommand):
                     # Create new job
                     job = AnalysisJob.objects.create(neighborhood=neighborhood,
                                                      batch=batch,
+                                                     osm_extract_url=osm_extract_url,
                                                      created_by=user,
                                                      modified_by=user)
                     self.stdout.write('ID: {} -- {}'.format(str(job.uuid), str(job)))


### PR DESCRIPTION
Looks for attribute 'osm_url' on each shapefile feature

## Overview

Updates command added in #178 to set `AnalysisJob.osm_extract_url` if attribute `osm_url` is available in the shapefile (shorter due to DBF 10-char limit on column names).


### Demo

Shapefile:
![screen shot 2017-04-19 at 11 56 29](https://cloud.githubusercontent.com/assets/1818302/25189655/cdf436f2-24f7-11e7-8cd6-f4db201e8061.png)

Trigger Batch:
![screen shot 2017-04-19 at 11 55 46](https://cloud.githubusercontent.com/assets/1818302/25189667/d529ccac-24f7-11e7-9f5b-ffebfa76ac54.png)

Job has Batch ID and OSM extract url set:
![screen shot 2017-04-19 at 11 55 53](https://cloud.githubusercontent.com/assets/1818302/25189688/e3f6ad7c-24f7-11e7-8c49-64976a2cf10a.png)

### Notes

We will need to take the shapefile provided to us and fill in the osm_url column in that shapefile with appropriate urls for each of the larger boundaries (basically any that falls within a MapZen metro extract)

## Testing Instructions

Run:
```
./scripts/django-manage analysis_batch_create --submit https://s3.amazonaws.com/pfb-batch-run-inputs-us-east-1/testing/pfb_city_boundaries_with_osm.zip
```
Inspect "CREATED" jobs in admin UI, `York` and `Allentown` should have `osm_extract_url` set, and `Lancaster` should not.

Closes #307 
