### PR TITLE
Load Neighborhood geojson on map

### DIFF
--- a/src/angularjs/src/app/components/neighborhoods.service.js
+++ b/src/angularjs/src/app/components/neighborhoods.service.js
@@ -21,6 +21,11 @@
                 params: {
                     limit: 'all'
                 }
+            },
+            'geojson': {
+                method: 'GET',
+                isArray: false,
+                url: '/api/neighborhoods_geojson/'
             }
         });
     }

--- a/src/angularjs/src/app/home/home.controller.js
+++ b/src/angularjs/src/app/home/home.controller.js
@@ -10,22 +10,7 @@
     'use strict';
 
     /** @ngInject */
-    function HomeController($log) {
-        var ctl = this;
-
-        ctl.$onInit = function () {
-            ctl.conusMapOptions = { scrollWheelZoom: false };
-            ctl.conusBounds = [[24.396308, -124.848974], [49.384358, -66.885444]];
-            ctl.baselayer = L.tileLayer(
-                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-                    maxZoom: 18
-                });
-        };
-
-        ctl.onConusMapReady = function (map) {
-            $log.debug(map.getBounds());
-        };
+    function HomeController() {
     }
 
     angular

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -85,15 +85,7 @@
                     <a href="/search.html" class="btn btn-primary">Find your City/Town <i class="icon-arrow-right"></i></a>
                 </div>
             </div>
-
-            <!-- keep the .map class. It's important for sizing. -->
-            <div class="map map-below"
-                pfb-map
-                pfb-map-bounds="home.conusBounds"
-                pfb-map-baselayer="home.baselayer"
-                pfb-map-options="home.conusMapOptions"
-                pfb-map-ready="home.onConusMapReady(map)">
-            </pfb-map>
+            <pfb-neighborhood-map></pfb-neighborhood-map>
         </div>
     </div>
 </section>

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -73,20 +73,7 @@
 <!-- Section containing nationwide overview map -->
 <section class="nationwide-map">
     <div class="container">
-        <h2 class="decor">
-            <i class="icon-map"></i>
-            Is your city/town on the map?
-        </h2>
-        <div class="overview-map">
-            <div class="card">
-                <div class="card-details">
-                    <div class="overview-total">256</div>
-                    <div class="overview-total-label">Cities/Towns Nationwide</div>
-                    <a href="/search.html" class="btn btn-primary">Find your City/Town <i class="icon-arrow-right"></i></a>
-                </div>
-            </div>
-            <pfb-neighborhood-map></pfb-neighborhood-map>
-        </div>
+        <pfb-neighborhood-map></pfb-neighborhood-map>
     </div>
 </section>
 <!-- Section containing nationwide overview map -->

--- a/src/angularjs/src/app/home/module.js
+++ b/src/angularjs/src/app/home/module.js
@@ -1,5 +1,5 @@
 (function () {
     'use strict';
 
-    angular.module('pfb.home', []);
+    angular.module('pfb.home', ['pfb.components']);
 })();

--- a/src/angularjs/src/app/home/neighborhood-map.directive.js
+++ b/src/angularjs/src/app/home/neighborhood-map.directive.js
@@ -1,0 +1,62 @@
+
+(function() {
+
+    /* @ngInject */
+    function NeighborhoodMapController(Neighborhood) {
+        var ctl = this;
+        ctl.map = null;
+
+        ctl.$onInit = function () {
+            ctl.mapOptions = { scrollWheelZoom: false };
+            ctl.boundsConus = [[24.396308, -124.848974], [49.384358, -66.885444]];
+            ctl.baselayer = L.tileLayer(
+                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                });
+        };
+
+        ctl.onMapReady = function (map) {
+            ctl.map = map;
+            Neighborhood.geojson().$promise.then(function (data) {
+                ctl.neighborhoodLayer = L.geoJSON(data, {
+                    onEachFeature: onEachFeature
+                });
+                map.addLayer(ctl.neighborhoodLayer);
+            });
+
+            function onEachFeature(feature, layer) {
+                // TODO: Style marker and popup
+                // TODO: Add link to neighborhood detail in popup
+                layer.on({
+                    click: function () {
+                        var popup = L.popup()
+                            .setLatLng([
+                                feature.geometry.coordinates[1],
+                                feature.geometry.coordinates[0]
+                            ])
+                            .setContent(feature.properties.label);
+                        ctl.map.openPopup(popup);
+                    }
+                });
+            }
+        };
+    }
+
+    function NeighborhoodMapDirective() {
+        var module = {
+            restrict: 'E',
+            controller: 'NeighborhoodMapController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            templateUrl: 'app/home/neighborhood-map.html'
+        };
+        return module;
+    }
+
+
+    angular.module('pfb.home')
+        .controller('NeighborhoodMapController', NeighborhoodMapController)
+        .directive('pfbNeighborhoodMap', NeighborhoodMapDirective);
+
+})();

--- a/src/angularjs/src/app/home/neighborhood-map.directive.js
+++ b/src/angularjs/src/app/home/neighborhood-map.directive.js
@@ -19,6 +19,7 @@
         ctl.onMapReady = function (map) {
             ctl.map = map;
             Neighborhood.geojson().$promise.then(function (data) {
+                ctl.count = data && data.features ? data.features.length : '0';
                 ctl.neighborhoodLayer = L.geoJSON(data, {
                     onEachFeature: onEachFeature
                 });
@@ -30,13 +31,16 @@
                 // TODO: Add link to neighborhood detail in popup
                 layer.on({
                     click: function () {
-                        var popup = L.popup()
-                            .setLatLng([
-                                feature.geometry.coordinates[1],
-                                feature.geometry.coordinates[0]
-                            ])
-                            .setContent(feature.properties.label);
-                        ctl.map.openPopup(popup);
+                        if (feature && feature.geometry &&
+                            feature.geometry.coordinates) {
+                            var popup = L.popup()
+                                .setLatLng([
+                                    feature.geometry.coordinates[1],
+                                    feature.geometry.coordinates[0]
+                                ])
+                                .setContent(feature.properties.label);
+                            ctl.map.openPopup(popup);
+                        }
                     }
                 });
             }

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -1,0 +1,8 @@
+<!-- keep the .map class. It's important for sizing. -->
+<div class="map map-below"
+    pfb-map
+    pfb-map-bounds="ctl.boundsConus"
+    pfb-map-baselayer="ctl.baselayer"
+    pfb-map-options="ctl.mapOptions"
+    pfb-map-ready="ctl.onMapReady(map)">
+</div>

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -1,8 +1,21 @@
-<!-- keep the .map class. It's important for sizing. -->
-<div class="map map-below"
-    pfb-map
-    pfb-map-bounds="ctl.boundsConus"
-    pfb-map-baselayer="ctl.baselayer"
-    pfb-map-options="ctl.mapOptions"
-    pfb-map-ready="ctl.onMapReady(map)">
+<h2 class="decor">
+    <i class="icon-map"></i>
+    Is your city/town on the map?
+</h2>
+<div class="overview-map">
+    <div class="card">
+        <div class="card-details">
+            <div class="overview-total">{{ ctl.count || "--" }}</div>
+            <div class="overview-total-label">Cities/Towns Nationwide</div>
+            <a ui-sref="places" class="btn btn-primary">Find your City/Town <i class="icon-arrow-right"></i></a>
+        </div>
+    </div>
+    <!-- keep the .map class. It's important for sizing. -->
+    <div class="map map-below"
+        pfb-map
+        pfb-map-bounds="ctl.boundsConus"
+        pfb-map-baselayer="ctl.baselayer"
+        pfb-map-options="ctl.mapOptions"
+        pfb-map-ready="ctl.onMapReady(map)">
+    </div>
 </div>


### PR DESCRIPTION
## Overview

Part 2 after #316. Adds the neighborhoods as geojson points to the map.

- Not styled
- Link to neighborhood detail view not hooked up. Can be done as part of #254 

@designmatty we'll need to think about how we want to style the markers/popups in this view

### Demo

![screen shot 2017-04-19 at 14 40 00](https://cloud.githubusercontent.com/assets/1818302/25196394/85e94cd2-250e-11e7-8206-e704f9e3c75c.png)


### Notes

I intentionally left the map bounds set to CONUS because the final application will have points across the US.

Refactors the neighborhood map logic into a self-contained directive


Closes #247 
