### PR TITLE
Feature/kak/places detail#254

### DIFF
--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -25,6 +25,12 @@
                 controllerAs: 'placeList',
                 templateUrl: 'app/places/list/place-list.html'
             })
+            .state('places.detail', {
+                url: ':uuid/',
+                controller: 'PlaceDetailController',
+                controllerAs: 'placeDetail',
+                templateUrl: 'app/places/detail/places-detail.html'
+            })
             .state('login', {
                 url: '/login/',
                 controller: 'LoginController',

--- a/src/angularjs/src/app/places/detail/module.js
+++ b/src/angularjs/src/app/places/detail/module.js
@@ -1,0 +1,4 @@
+(function () {
+    'use strict';
+    angular.module('pfb.places.detail', []);
+ })();

--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -13,6 +13,13 @@
     function PlaceDetailController($stateParams, Neighborhood, AnalysisJob, $log) {
         var ctl = this;
 
+        var downloadOptions = [
+            {value: 'ways_url', label: 'Neighborhood Ways (shp)'},
+            {value: 'census_blocks_url', label: 'Census Blocks (shp)'},
+            {value: 'connected_census_blocks_url', label: 'Connected Census Blocks (csv)'},
+            {value: 'overall_scores_url', label: 'Overall Scores (csv)'}
+        ];
+
         initialize();
 
         function initialize() {
@@ -20,6 +27,8 @@
             ctl.lastJobScore = null;
             ctl.jobResults = null;
             ctl.getPlace = getPlace;
+
+            ctl.downloads = null;
 
             getPlace($stateParams.uuid);
         }
@@ -34,16 +43,15 @@
                 if (!data.results || !data.results.length) {
                     $log.warn('no matching analysis job found for neighborhood ' + uuid);
                     ctl.lastJobScore = null;
+                    ctl.downloads = null;
                     return;
                 }
 
                 var lastJob = new AnalysisJob(data.results[0]);
-
                 ctl.lastJobScore = lastJob.overall_score;
 
                 if (lastJob) {
                     AnalysisJob.results({uuid: lastJob.uuid}).$promise.then(function(results) {
-
                         if (results.overall_scores) {
                             ctl.jobResults = _.map(results.overall_scores, function(obj, key) {
                                 return {
@@ -51,9 +59,14 @@
                                     score: obj.score_normalized
                                 };
                             });
+
+                            ctl.downloads = _.map(downloadOptions, function(option) {
+                                return {label: option.label, url: results[option.value]};
+                            });
                         } else {
                             $log.warn('no job results found');
                             ctl.jobResults = null;
+                            ctl.downloads = null;
                         }
                     });
                 }

--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -1,0 +1,67 @@
+/**
+ * @ngdoc controller
+ * @name pfb.analysis-jobs.detail.controller:PlaceDetailController
+ *
+ * @description
+ * Controller for showing details about an analysis job
+ *
+ */
+(function() {
+    'use strict';
+
+    /** @ngInject */
+    function PlaceDetailController($stateParams, Neighborhood, AnalysisJob, $log) {
+        var ctl = this;
+
+        initialize();
+
+        function initialize() {
+            ctl.place = null;
+            ctl.lastJobScore = null;
+            ctl.jobResults = null;
+            ctl.getPlace = getPlace;
+
+            getPlace($stateParams.uuid);
+        }
+
+        function getPlace(uuid) {
+            Neighborhood.query({uuid: uuid}).$promise.then(function(data) {
+                ctl.place = new Neighborhood(data);
+            });
+
+            AnalysisJob.query({neighborhood: uuid, latest: 'True'}).$promise.then(function(data) {
+
+                if (!data.results || !data.results.length) {
+                    $log.warn('no matching analysis job found for neighborhood ' + uuid);
+                    ctl.lastJobScore = null;
+                    return;
+                }
+
+                var lastJob = new AnalysisJob(data.results[0]);
+
+                ctl.lastJobScore = lastJob.overall_score;
+
+                if (lastJob) {
+                    AnalysisJob.results({uuid: lastJob.uuid}).$promise.then(function(results) {
+
+                        if (results.overall_scores) {
+                            ctl.jobResults = _.map(results.overall_scores, function(obj, key) {
+                                return {
+                                    metric: key.replace(/_/g, ' '),
+                                    score: obj.score_normalized
+                                };
+                            });
+                        } else {
+                            $log.warn('no job results found');
+                            ctl.jobResults = null;
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    angular
+        .module('pfb.places.detail')
+        .controller('PlaceDetailController', PlaceDetailController);
+})();

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -19,7 +19,7 @@
         </div>
     </div>
 
-    <!-- Everythign in sidebar-scrollable will scroll. -->
+    <!-- Everything in sidebar-scrollable will scroll. -->
     <div class="sidebar-scrollable">
         <section>
             <div class="metric-details">
@@ -34,20 +34,19 @@
                         </label>
                     </div>
                     <div class="column text-right">
-                        <div class="dropdown">
-                          <button class="btn btn-default dropdown-toggle btn-s" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                            Download
-                            <span class="caret"></span>
-                          </button>
-                          <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-                            <li>
-                                <a href="#" class="compare-remove">Shapefile</a>
-                            </li>
-                            <li>
-                                <a href="#" class="compare-remove">CSV</a>
-                            </li>
-                          </ul>
-                        </div>
+
+                    <div class="btn-group dropdown" uib-dropdown is-open="status.isopen"
+                        ng-if="placeDetail.downloads">
+                      <button id="single-button" type="button" class="btn btn-default btn-s" uib-dropdown-toggle ng-disabled="disabled" id="downloadButton">
+                        Download <span class="caret"></span>
+                      </button>
+                      <ul class="dropdown-menu" uib-dropdown-menu role="menu"
+                        aria-labelledby="downloadButton">
+                        <li ng-repeat="item in placeDetail.downloads">
+                            <a role="menuitem" href="{{item.url}}"
+                                class="compare-remove">{{item.label}}</a>
+                        </li>
+                      </ul>
                     </div>
                 </div>
                 <div class="row" ng-if="!placeDetail.lastJobScore">

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -1,0 +1,76 @@
+<pfb-navbar></pfb-navbar>
+
+<!-- Sidebar -->
+<!-- ATTENTION: note the use of location-overview class -->
+<div class="sidebar location-overview">
+
+    <!-- Everything in .sidebar-header will not scroll.  -->
+    <div class="sidebar-header">
+        <div class="row">
+            <div class="column-8">
+                <h2 class="sidebar-title">{{placeDetail.place.label}}</h2>
+                <h4 class="sidebar-title">{{placeDetail.place.state_abbrev}}</h4>
+                <div class="location-timestamp"><span>Last updated:</span>
+                    {{placeDetail.place.modifiedAt | date:'MMMM dd, yyyy'}}</div>
+            </div>
+            <div class="column text-right">
+                <a class="btn btn-primary" ui-sref="places.list">Back to search</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Everythign in sidebar-scrollable will scroll. -->
+    <div class="sidebar-scrollable">
+        <section>
+            <div class="metric-details">
+                <div class="row" ng-if="placeDetail.lastJobScore">
+                    <div class="column">
+                        <label class="network-score large flex-row columns-center">
+                            {{placeDetail.lastJobScore | number:0}}
+                            <span class="h3">Network Score</span>
+
+                            <!-- Tooltips how it works: If you have a div with class .tooltip add a title. The content of the title will display in the toolip using css. -->
+                            <div class="tooltip" title="This is a tooltip that keeps sdfjhskdjfh dfskjhas kjhdfsa kjdfsah sdfakjh kjfdsah "><i class="icon-info-circled"></i></div>
+                        </label>
+                    </div>
+                    <div class="column text-right">
+                        <div class="dropdown">
+                          <button class="btn btn-default dropdown-toggle btn-s" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                            Download
+                            <span class="caret"></span>
+                          </button>
+                          <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+                            <li>
+                                <a href="#" class="compare-remove">Shapefile</a>
+                            </li>
+                            <li>
+                                <a href="#" class="compare-remove">CSV</a>
+                            </li>
+                          </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="row" ng-if="!placeDetail.lastJobScore">
+                    <div class="column">
+                        <label class="network-score large flex-row columns-center">
+                            <span class="h3">No results available</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <ul class="metric-list" ng-repeat="result in placeDetail.jobResults">
+            <li>{{result.metric}}
+                <div class="tooltip" title="This is a tooltip "><i class="icon-info-circled"></i></div>
+                <span class="network-score small">{{result.score | number:0}}</span>
+            </li>
+        </ul>
+    </div>
+</div>
+<!-- Sidebar -->
+
+<!-- Map -->
+<div class="preview-map">
+    <div class="map"></div>
+</div>
+<!-- Map -->

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -10,8 +10,21 @@
         <div class="row">
             <div class="column">
                 <div class="form-group">
-                    <label for="1">Filter by city or town name</label>
-                    <input type="text" class="form-control">
+                    <label for="neighborhood-filter">Filter by city or town name</label>
+                    <ui-select
+                        name="neighborhood-filter"
+                        ng-model="placeList.neighborhoodFilter"
+                        title="Filter by Neighborhood">
+
+                        <ui-select-match allow-clear="true" placeholder="Neighborhood" >
+                            {{$select.selected.label}}
+                        </ui-select-match>
+                        <ui-select-choices repeat="neighborhood.uuid as neighborhood in
+                                                   placeList.allNeighborhoods |
+                                                   filter: {label : $select.search}">
+                            <div ng-bind-html="neighborhood.label | highlight: $select.search"></div>
+                        </ui-select-choices>
+                    </ui-select>
                 </div>
             </div>
         </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -69,8 +69,7 @@
         <section>
             <!-- Duplicate .result div for each result. -->
             <div class="result" ng-repeat="neighborhood in placeList.places">
-                <!-- TODO: link to details page here -->
-                <a href="#" class="result-link"></a>
+                <a ui-sref="places.detail({uuid: '{{neighborhood.uuid}}' })" class="result-link"></a>
                 <div class="result-left">
 
                     <!-- .result-preview should display the shapefile preview -->

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -18,12 +18,11 @@
         <div class="row">
             <div class="column-7">
                 <div class="form-group">
-                    <label for="2">Sort by</label>
-                    <select name="2" id="" class="form-control">
-                        <option value="">Alphabetical</option>
-                        <option value="">Highest Rated</option>
-                        <option value="">Lowest Rated</option>
-                        <option value="">Last Updated</option>
+                    <label for="sort-options">Sort by</label>
+                    <select name="sort-options" class="form-control"
+                        ng-options="item as item.label for item in placeList.sortingOptions track by item.value"
+                        ng-model="placeList.sortBy"
+                        ng-change="placeList.getPlaces()">
                     </select>
                 </div>
             </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -50,7 +50,7 @@
                         <span class="caret"></span>
                       </button>
 
-                      <!-- Were using bootstraps dropdown js -->
+                      <!-- We are using bootstraps dropdown js -->
                       <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdownMenu1">
 
                         <!-- Only up to 3 to compare. Duplicate li and children for each item -->

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -41,7 +41,7 @@
             ctl.getPrev = getPrev;
             ctl.places = [];
 
-            ctl.filters = {};
+            ctl.neighborhoodFilter = null;
 
             ctl.sortBy = sortingOptions[0]; // default to alphabetical order
             ctl.sortingOptions = sortingOptions;
@@ -49,11 +49,32 @@
             ctl.getPlaces = getPlaces;
 
             getPlaces();
+            loadOptions();
+            $scope.$watch(function(){return ctl.neighborhoodFilter;}, filterNeighborhood);
+        }
+
+        function filterNeighborhood(newFilter, oldFilter) {
+            if (newFilter === oldFilter) {
+                return;
+            }
+
+            getPlaces();
+        }
+
+        function loadOptions() {
+            // fetch all neighborhoods, to populate the search bar
+            Neighborhood.all().$promise.then(function(data) {
+                ctl.allNeighborhoods = data.results;
+            });
         }
 
         function getPlaces(params) {
             params = params || _.merge({}, $stateParams, defaultParams);
             params.ordering = ctl.sortBy.value;
+            if (ctl.neighborhoodFilter) {
+                params.neighborhood = ctl.neighborhoodFilter;
+            }
+
             AnalysisJob.query(params).$promise.then(function(data) {
 
                 ctl.places = _.map(data.results, function(obj) {

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -14,6 +14,13 @@
                                  Neighborhood, AnalysisJob) {
         var ctl = this;
 
+        var sortingOptions = [
+            {value: 'neighborhood__label', label: 'Alphabetical'},
+            {value: '-overall_score', label: 'Highest Rated'},
+            {value: 'overall_score', label: 'Lowest Rated'},
+            {value: '-modified_at', label: 'Last Updated'}
+        ];
+
         var defaultParams = {
             limit: null,
             offset: null,
@@ -36,11 +43,17 @@
 
             ctl.filters = {};
 
+            ctl.sortBy = sortingOptions[0]; // default to alphabetical order
+            ctl.sortingOptions = sortingOptions;
+
+            ctl.getPlaces = getPlaces;
+
             getPlaces();
         }
 
         function getPlaces(params) {
             params = params || _.merge({}, $stateParams, defaultParams);
+            params.ordering = ctl.sortBy.value;
             AnalysisJob.query(params).$promise.then(function(data) {
 
                 ctl.places = _.map(data.results, function(obj) {

--- a/src/angularjs/src/app/places/module.js
+++ b/src/angularjs/src/app/places/module.js
@@ -2,5 +2,5 @@
     'use strict';
 
     angular.module('pfb.places',
-                   ['pfb.places.list']);
+                   ['pfb.places.list', 'pfb.places.detail']);
 })();


### PR DESCRIPTION
## Overview

Add places detail view and implement sorting and filtering for places list.
Closes #250 and closes #254.

### Demo

Neighborhood name dropdown filter:
![image](https://cloud.githubusercontent.com/assets/960264/25201453/cc28bb2c-251f-11e7-8382-3cf8dfc92850.png)

A detail view:
![image](https://cloud.githubusercontent.com/assets/960264/25201477/dba3b62e-251f-11e7-9ab9-ace40e66e99b.png)

Detail view when there's no scores to see:
![image](https://cloud.githubusercontent.com/assets/960264/25201762/dd335bba-2520-11e7-8c26-eccc420d29bd.png)



### Notes

Did not attempt to implement download dropdown. Not sure what should go in there; there's _a lot_ of links available in the response, at various nesting levels.


## Testing Instructions

 * Go to http://localhost:9301/#/places/
 * Try filtering by neighborhood name: should be able to type stuff for autocomplete, or click things
 * Try changing sort order (note #322 may make for some odd-looking score sort results)
 * Click a neighborhood in the results list to go to details page; should have scores listed
 * Clicking a neighborhood without a valid completed job shows a message about 'no results available'


Closes #250 
Closes #254