### PR TITLE
Bump terraform version to 0.9.3

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -16,4 +16,4 @@ docker_options: "--storage-opt dm.basesize=20G"
 docker_compose_version: 1.9.0
 
 # azavea.terraform
-terraform_version: 0.9.1
+terraform_version: 0.9.3

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -6,6 +6,5 @@ terraform {
   backend "s3" {
     region  = "us-east-1"
     encrypt = "true"
-    lock    = "false"
   }
 }

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -125,7 +125,7 @@ resource "aws_iam_role_policy_attachment" "ecs_for_ec2_policy_container_instance
 
 resource "aws_iam_instance_profile" "app_container_instance" {
   name  = "${aws_iam_role.app_container_instance_ec2.name}"
-  roles = ["${aws_iam_role.app_container_instance_ec2.name}"]
+  role =  "${aws_iam_role.app_container_instance_ec2.name}"
 }
 
 #
@@ -148,5 +148,5 @@ resource "aws_iam_role_policy_attachment" "batch_ec2_s3_policy" {
 
 resource "aws_iam_instance_profile" "batch_container_instance" {
   name  = "${aws_iam_role.batch_container_instance_ec2.name}"
-  roles = ["${aws_iam_role.batch_container_instance_ec2.name}"]
+  role = "${aws_iam_role.batch_container_instance_ec2.name}"
 }


### PR DESCRIPTION
## Overview

Bump terraform version to 0.9.3, which removes the `lock` configuration parameter and uses `role` instead of `roles` in the `aws_iam_instance_profile` resource.


### Demo

n/a


### Notes

Terraform also adds the `treat_missing_data` option to work with a new [CloudWatch feature](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data). The default of `missing` seemed appropriate so I left it as is.


## Testing Instructions

 * Ensure that you can run `scripts/infra plan` according to the directions in the `README`