### PR TITLE
Sort places by state, then label

### DIFF
--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -15,7 +15,7 @@
         var ctl = this;
 
         var sortingOptions = [
-            {value: 'neighborhood__label', label: 'Alphabetical'},
+            {value: 'neighborhood__state_abbrev,neighborhood__label', label: 'Alphabetical'},
             {value: '-overall_score', label: 'Highest Rated'},
             {value: 'overall_score', label: 'Lowest Rated'},
             {value: '-modified_at', label: 'Last Updated'}

--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -62,6 +62,7 @@ class AnalysisJobFilterSet(filters.FilterSet):
         fields = {'neighborhood': ['exact', 'in'],
                   'neighborhood__name': ['exact', 'contains'],
                   'neighborhood__label': ['exact', 'contains'],
+                  'neighborhood__state_abbrev': ['exact'],
                   'batch': ['exact', 'in'],
                   'status': ['exact'],
                   'latest': ['exact']}

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -31,7 +31,8 @@ class AnalysisJobViewSet(ModelViewSet):
     permission_classes = (RestrictedCreate,)
     filter_class = AnalysisJobFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
-    ordering_fields = ('created_at', 'modified_at', 'overall_score', 'neighborhood__label')
+    ordering_fields = ('created_at', 'modified_at', 'overall_score', 'neighborhood__label',
+                       'neighborhood__state_abbrev')
     ordering = ('-created_at',)
 
     def perform_create(self, serializer):


### PR DESCRIPTION
## Overview

When sorting public places view alphabetically, sort by state first, then label.
Closes #327.


### Notes

The DRF `ordering` parameter apparently [accepts a comma-separated list](https://github.com/encode/django-rest-framework/blob/33290170e875b3c48782224910cc07c278e395bb/rest_framework/filters.py#L201) of fields to order by, so this simply adds `state_abbrev` as an available field to use in ordering, then modifies the front end to sort by that first.


## Testing Instructions

 * query http://localhost:9200/api/analysis_jobs/?ordering=neighborhood__state_abbrev,neighborhood__label
 * Should get jobs ordered by neighborhood state, then label

Connects #327
