### PR TITLE
Implement city cards on homepage

### DIFF
--- a/src/angularjs/src/app/home/home.controller.js
+++ b/src/angularjs/src/app/home/home.controller.js
@@ -10,7 +10,33 @@
     'use strict';
 
     /** @ngInject */
-    function HomeController() {
+    function HomeController(AnalysisJob, Neighborhood) {
+        var ctl = this;
+
+        var cityParams = {
+            limit: 8,
+            offset: null,
+            latest: 'True',
+            status: 'COMPLETE',
+            ordering: '-overall_score'
+        };
+
+        ctl.cities = null;
+
+        initialize();
+
+        function initialize() {
+            AnalysisJob.query(cityParams).$promise.then(function(data) {
+
+                ctl.cities = _.map(data.results, function(obj) {
+                    var neighborhood = new Neighborhood(obj.neighborhood);
+                    // get properties from the neighborhood's last run job
+                    neighborhood.modifiedAt = obj.modifiedAt;
+                    neighborhood.overall_score = obj.overall_score;
+                    return neighborhood;
+                });
+            });
+        }
     }
 
     angular

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -23,45 +23,18 @@
 
             <!-- If you duplicate the .column-6 divs
                      and children the layout will adjust. -->
-            <div class="column-6">
+            <div class="column-6" ng-repeat="city in home.cities">
                 <div class="card">
-                    <a href="/town.html" class="card-link"></a>
+                    <a ui-sref="places.detail({uuid: '{{city.uuid}}' })" class="card-link"></a>
                     <div class="card-map">
                         <div class="map"></div>
                     </div>
                     <div class="card-details">
-                        <h3>City/Town Name</h3>
-                        <h4>State</h4>
-                        <div class="network-score large">90</div>
-                        <div class="location-timestamp"><span>Last updated:</span> August 12, 2017</div>
-                    </div>
-                </div>
-            </div>
-            <div class="column-6">
-                <div class="card">
-                    <a href="/town.html" class="card-link"></a>
-                    <div class="card-map">
-                        <div class="map"></div>
-                    </div>
-                    <div class="card-details">
-                        <h3>City/Town Name</h3>
-                        <h4>State</h4>
-                        <div class="network-score large">90</div>
-                        <div class="location-timestamp"><span>Last updated:</span> August 12, 2017</div>
-                    </div>
-                </div>
-            </div>
-            <div class="column-6">
-                <div class="card">
-                    <a href="/town.html" class="card-link"></a>
-                    <div class="card-map">
-                        <div class="map"></div>
-                    </div>
-                    <div class="card-details">
-                        <h3>City/Town Name</h3>
-                        <h4>State</h4>
-                        <div class="network-score large">90</div>
-                        <div class="location-timestamp"><span>Last updated:</span> August 12, 2017</div>
+                        <h3>{{city.label}}</h3>
+                        <h4>{{city.state_abbrev}}</h4>
+                        <div class="network-score large">{{city.overall_score | number:0}}</div>
+                        <div class="location-timestamp"><span>Last updated:</span>
+                            {{city.modifiedAt | date:'MMMM dd, yyyy'}}</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Overview

Display information on top eight scoring cities on homepage.
Closes #245.


### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://cloud.githubusercontent.com/assets/960264/25252532/5ef73958-25eb-11e7-85b8-043da088a338.png)


## Testing Instructions

 * Visit home page at http://localhost:9301/#/
 * Should have list of cities under "Leading Cities/Towns" header, if there are any completed jobs
 * Should be ordered top-scoring first, and only show top eight
 * Clicking a city card should go to the places detail page for that neighborhood


Connects #245
