### PR TITLE
Feature/kak/thumbnail maps#337

### DIFF
--- a/src/angularjs/src/app/components/module.js
+++ b/src/angularjs/src/app/components/module.js
@@ -5,5 +5,6 @@
                    ['pfb.components.analysis-jobs',
                     'pfb.components.auth',
                     'pfb.components.filters',
-                    'pfb.components.map']);
+                    'pfb.components.map',
+                    'pfb.components.thumbnailMap']);
 })();

--- a/src/angularjs/src/app/components/thumbnail-map/module.js
+++ b/src/angularjs/src/app/components/thumbnail-map/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('pfb.components.thumbnailMap', ['pfb.components.map']);
+})();

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -7,7 +7,13 @@
         ctl.map = null;
 
         ctl.$onInit = function () {
-            ctl.mapOptions = { scrollWheelZoom: false, interactive: false };
+            ctl.mapOptions = {
+                scrollWheelZoom: false,
+                interactive: false,
+                zoomControl: false,
+                attributionControl: false
+            };
+
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
                 'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -1,0 +1,43 @@
+
+(function() {
+
+    /* @ngInject */
+    function ThumbnailMapController($log) {
+        var ctl = this;
+        ctl.map = null;
+
+        ctl.$onInit = function () {
+            ctl.mapOptions = { scrollWheelZoom: false, interactive: false };
+            ctl.mapCenter = [39.963277, -75.142971];
+            ctl.baselayer = L.tileLayer(
+                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                });
+        };
+
+        ctl.onMapReady = function (map) {
+            ctl.map = map;
+
+            $log.debug('ready!');
+        };
+    }
+
+    function ThumbnailMapDirective() {
+        var module = {
+            restrict: 'E',
+            scope: true,
+            controller: 'ThumbnailMapController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            templateUrl: 'app/components/thumbnail-map/thumbnail-map.html'
+        };
+        return module;
+    }
+
+
+    angular.module('pfb.components.thumbnailMap')
+        .controller('ThumbnailMapController', ThumbnailMapController)
+        .directive('pfbThumbnailMap', ThumbnailMapDirective);
+
+})();

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -14,6 +14,7 @@
                 attributionControl: false
             };
 
+            // TODO: set center and zoom level by zooming to fit geojson polygon bounds
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
                 'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
@@ -1,0 +1,12 @@
+<!-- TODO: fix styling. removing card-map class makes map visible -->
+<div class="card-map">
+    <!-- keep the .map class. It's important for sizing. -->
+    <div class="map map-below" id="map-{{::$id}}"
+        pfb-map
+        pfb-map-zoom="12"
+        pfb-map-center="ctl.mapCenter"
+        pfb-map-baselayer="ctl.baselayer"
+        pfb-map-options="ctl.mapOptions"
+        pfb-map-ready="ctl.onMapReady(map)">
+    </div>
+</div>

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
@@ -1,12 +1,9 @@
-<!-- TODO: fix styling. removing card-map class makes map visible -->
-<div class="card-map">
-    <!-- keep the .map class. It's important for sizing. -->
-    <div class="map map-below" id="map-{{::$id}}"
-        pfb-map
-        pfb-map-zoom="12"
-        pfb-map-center="ctl.mapCenter"
-        pfb-map-baselayer="ctl.baselayer"
-        pfb-map-options="ctl.mapOptions"
-        pfb-map-ready="ctl.onMapReady(map)">
-    </div>
+<!-- keep the .map class. It's important for sizing. -->
+<div class="map map-below" id="map-{{::$id}}"
+    pfb-map
+    pfb-map-zoom="12"
+    pfb-map-center="ctl.mapCenter"
+    pfb-map-baselayer="ctl.baselayer"
+    pfb-map-options="ctl.mapOptions"
+    pfb-map-ready="ctl.onMapReady(map)">
 </div>

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -26,7 +26,9 @@
             <div class="column-6" ng-repeat="city in home.cities">
                 <div class="card">
                     <a ui-sref="places.detail({uuid: '{{city.uuid}}' })" class="card-link"></a>
-                    <pfb-thumbnail-map></pfb-thumbnail-map>
+                    <div class="card-map">
+                        <pfb-thumbnail-map></pfb-thumbnail-map>
+                    </div>
                     <div class="card-details">
                         <h3>{{city.label}}</h3>
                         <h4>{{city.state_abbrev}}</h4>

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -26,9 +26,7 @@
             <div class="column-6" ng-repeat="city in home.cities">
                 <div class="card">
                     <a ui-sref="places.detail({uuid: '{{city.uuid}}' })" class="card-link"></a>
-                    <div class="card-map">
-                        <div class="map"></div>
-                    </div>
+                    <pfb-thumbnail-map></pfb-thumbnail-map>
                     <div class="card-details">
                         <h3>{{city.label}}</h3>
                         <h4>{{city.state_abbrev}}</h4>

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -11,7 +11,7 @@
         </div>
     </div>
     <!-- keep the .map class. It's important for sizing. -->
-    <div class="map map-below"
+    <div class="map map-below" id="map-{{::$id}}"
         pfb-map
         pfb-map-bounds="ctl.boundsConus"
         pfb-map-baselayer="ctl.baselayer"

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -86,7 +86,7 @@
 
                     <!-- .result-preview should display the shapefile preview -->
                     <div class="result-preview">
-                        <img src="http://placehold.it/75" alt="Shape Preview">
+                        <pfb-thumbnail-map></pfb-thumbnail-map>
                     </div>
                     <div class="result-title">{{neighborhood.label}}, {{neighborhood.state_abbrev}}
                         <div class="location-timestamp"><span>Last updated:</span> {{neighborhood.modifiedAt | date:'MMMM dd, yyyy'}}</div>

--- a/src/angularjs/src/styles/components/_card.scss
+++ b/src/angularjs/src/styles/components/_card.scss
@@ -4,7 +4,7 @@
   position: relative;
   height: 100%;
   display: flex;
-  
+
   @include respond-to(sm-down) {
     flex-direction: column;
   }
@@ -42,6 +42,7 @@
 .card-map {
   flex-basis: none;
   width: 200px;
+  height: 100%;
   position: relative;
 
   @include respond-to(sm-down) {

--- a/src/angularjs/src/styles/pages/_mapping.scss
+++ b/src/angularjs/src/styles/pages/_mapping.scss
@@ -107,6 +107,7 @@ section.active {
     min-width: 60px;
     height: 60px;
     min-height: 60px;
+    position: relative;
   }
 
   .result-title {


### PR DESCRIPTION
## Overview

Adds a directive for loading thumbnail static maps, as used in places cards on public home view and places list.


### Demo

In places list:
![image](https://cloud.githubusercontent.com/assets/960264/25284770/17a101f6-2686-11e7-85aa-a5bc1fa2f712.png)

On home page:
![image](https://cloud.githubusercontent.com/assets/960264/25284801/311c0504-2686-11e7-9e89-689a6391439a.png)


### Notes

Does not load the neighborhood results/centroid layer. Should be straightforward to add in `onMapReady` when available.


## Testing Instructions

 * First card on homepage should have map http://localhost:9301/#/
 * Exisitng neighborhood map on homepage should still display correctly
 * Places in list at http://localhost:9301/#/places/ should have map on left

Connects #337
