### PR TITLE
Quote passing of Git commit SHA to Terraform

### DIFF
--- a/scripts/infra
+++ b/scripts/infra
@@ -63,7 +63,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
                 terraform plan \
                           -var-file="${PFB_SETTINGS_BUCKET}.tfvars" \
-                          -var="git_commit=${GIT_COMMIT}" \
+                          -var="git_commit=\"${GIT_COMMIT}\"" \
                           -var="batch_analysis_job_definition_name_revision=${BATCH_ANALYSIS_JOB_NAME_REVISION}" \
                           -var="batch_tilemaker_job_definition_name_revision=${BATCH_TILEMAKER_JOB_NAME_REVISION}" \
                           -out="${PFB_SETTINGS_BUCKET}.tfplan"


### PR DESCRIPTION
## Overview

After a long series of exhaustive tests, it was found that a subset of SHA1 hashes were being parsed nondeterministicly. In order to always interpret SHA1 hashes as strings, quote the value of `git_commit`.

Fixes https://github.com/azavea/pfb-network-connectivity/issues/340

## Testing Instructions

I created a small Terraform project with the following configuration:

```hcl
variable "git_commit" {}

output "git_commit" {
  value = "${var.git_commit}"
}
```

Using that, I crafted the following test using Bats:

```bash
#!/usr/bin/env bats

@test "terraform SHA variable handling" {
    sha="$(echo $RANDOM | shasum | cut -c1-7)"

    echo "SHA = ${sha}"

    rm -rf test.tfplan
    ./terraform plan -no-color -var="git_commit=${sha}" -out test.tfplan > /dev/null
    run ./terraform apply -no-color test.tfplan

    [ "${lines[2]}" = "git_commit = ${sha}" ]
}
```

I then proceeded to run that test a large number of times in an effort to get it to fail:

```bash
#!/bin/bash

set -e

for run in {1..1000}
do
    ./test.sh
done
```

This process led to failures when the following inputs were used:

```
1e27715
906841e
7e50702
99e6307
33e2885
5e57189
73131ea
83202ec
316e434
```

Perhaps Terraform thinks these are numbers supplied in exponential notation. Regardless, quoting them should prevent this from happening moving forward. After updating the tests to quote the SHA, I was able to run all 1000 tests without a failure.