### PR TITLE
Feature/kak/typeahead search#328

### DIFF
--- a/src/angularjs/bower.json
+++ b/src/angularjs/bower.json
@@ -20,7 +20,6 @@
     "moment": "2.17.1",
     "animate.css": "3.5.2",
     "angular-bootstrap": "1.3.3",
-    "ui-select": "angular-ui-select#^0.19.5",
     "urijs": "1.18.7",
     "lodash": "4.6.1",
     "ng-file-upload": "^12.2.13",

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
@@ -34,7 +34,7 @@
                 return;
             }
             ctl.filters = {
-                neighborhood: newFilter,
+                neighborhood: newFilter ? newFilter.uuid : null,
                 status: AnalysisJobStatuses.filterMap[ctl.statusFilter]
             };
         }
@@ -44,7 +44,7 @@
                 return;
             }
             ctl.filters = {
-                neighborhood: ctl.neighborhoodFilter,
+                neighborhood: ctl.neighborhoodFilter ? ctl.neighborhoodFilter.uuid : null,
                 status: AnalysisJobStatuses.filterMap[newFilter]
             };
         }
@@ -54,7 +54,7 @@
                 return;
             }
             ctl.filters = {
-                neighborhood: ctl.neighborhoodFilter,
+                neighborhood: ctl.neighborhoodFilter ? ctl.neighborhoodFilter.uuid : null,
                 status: AnalysisJobStatuses.filterMap[ctl.statusFilter]
             };
         }

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.html
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.html
@@ -2,27 +2,23 @@
     <th>ID</th>
     <th>
         <div class="dropdown">
-            <ui-select ng-model="ctl.statusFilter" title="Filter by Status">
-                <ui-select-match allow-clear="true" placeholder="Status" >
-                    {{$select.selected}}
-                </ui-select-match>
-                <ui-select-choices repeat="status in ctl.statuses | filter: $select.search">
-                    <div ng-bind-html="status | highlight: $select.search"></div>
-                </ui-select-choices>
-            </ui-select>
+        <input name="neighborhood-filter" ng-model="ctl.statusFilter" title="Filter by Status"
+            placeholder="Status" type="text" class="form-control"
+            uib-typeahead="status for status in ctl.statuses |
+                           filter: $viewValue |
+                           limitTo: 8">
         </div>
     </th>
     <th>
         <div class="dropdown neighborhood">
-            <ui-select ng-model="ctl.neighborhoodFilter" title="Filter by Neighborhood">
-                <ui-select-match allow-clear="true" placeholder="Neighborhood" >
-                    {{$select.selected.label}}
-                </ui-select-match>
-                <ui-select-choices repeat="neighborhood.uuid as neighborhood in
-                                           ctl.neighborhoods | filter: {uuid : $select.search}">
-                    <div ng-bind-html="neighborhood.label | highlight: $select.search"></div>
-                </ui-select-choices>
-            </ui-select>
+            <input title="Filter by Neighborhood" placeholder="Neighborhood"
+                ng-model="ctl.neighborhoodFilter"
+                type="text" class="form-control"
+                uib-typeahead="neighborhood as (neighborhood.label + ', ' +
+                               neighborhood.state_abbrev) for neighborhood in ctl.neighborhoods |
+                               filter: {label : $viewValue} |
+                               limitTo: 8">
+
         </div>
     </th>
     <th>Batch Job ID</th>

--- a/src/angularjs/src/app/components/filters/module.js
+++ b/src/angularjs/src/app/components/filters/module.js
@@ -1,5 +1,5 @@
 (function() {
     'use strict';
 
-    angular.module('pfb.components.filters', ['ui.select']);
+    angular.module('pfb.components.filters', []);
 })();

--- a/src/angularjs/src/app/components/filters/user-filter.directive.js
+++ b/src/angularjs/src/app/components/filters/user-filter.directive.js
@@ -31,7 +31,7 @@
             }
             ctl.filters = {
                 role: UserRoles.roleFilters[newFilter],
-                organization: ctl.organizationFilter
+                organization: ctl.organizationFilter ? ctl.organizationFilter.uuid : null
             };
 
         }
@@ -42,7 +42,7 @@
             }
             ctl.filters = {
                 role: UserRoles.roleFilters[ctl.roleFilter],
-                organization: newFilter
+                organization: newFilter ? newFilter.uuid : null
             };
         }
     }

--- a/src/angularjs/src/app/components/filters/user-filter.html
+++ b/src/angularjs/src/app/components/filters/user-filter.html
@@ -3,14 +3,11 @@
     <th>Name</th>
     <th>
         <div class="dropdown user">
-            <ui-select ng-model="ctl.organizationFilter" title="Filter by Organization">
-                <ui-select-match allow-clear="true" placeholder="Organization" >
-                    {{$select.selected.name}}
-                </ui-select-match>
-                <ui-select-choices repeat="org.uuid as org in ctl.organizations | filter: { label: $select.search }">
-                    <div ng-bind-html="org.name | highlight: $select.search"></div>
-                </ui-select-choices>
-            </ui-select>
+            <input ng-model="ctl.organizationFilter" title="Filter by Organization"
+            placeholder="Organization" type="text" class="form-control"
+            uib-typeahead="org as org.name for org in ctl.organizations |
+                           filter: $viewValue |
+                           limitTo: 8">
         </div>
     </th>
     <th>

--- a/src/angularjs/src/app/components/filters/user-filter.html
+++ b/src/angularjs/src/app/components/filters/user-filter.html
@@ -12,14 +12,11 @@
     </th>
     <th>
         <div class="dropdown user">
-            <ui-select ng-model="ctl.roleFilter" title="Filter by Role">
-                <ui-select-match allow-clear="true" placeholder="Role" >
-                    {{$select.selected}}
-                </ui-select-match>
-                <ui-select-choices repeat="role as role in ctl.roles | filter: $select.search">
-                    <div ng-bind-html="role | highlight: $select.search"></div>
-                </ui-select-choices>
-            </ui-select>
+            <input ng-model="ctl.roleFilter" title="Filter by Role"
+            placeholder="Role" type="text" class="form-control"
+            uib-typeahead="role for role in ctl.roles |
+                           filter: $viewValue |
+                           limitTo: 8">
         </div>
     </th>
     <th>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -11,20 +11,14 @@
             <div class="column">
                 <div class="form-group">
                     <label for="neighborhood-filter">Filter by city or town name</label>
-                    <ui-select
-                        name="neighborhood-filter"
-                        ng-model="placeList.neighborhoodFilter"
-                        title="Filter by Neighborhood">
+                    <input name="neighborhood-filter" ng-model="placeList.neighborhoodFilter"
+                        type="text" class="form-control"
+                        uib-typeahead="neighborhood as (neighborhood.label + ', ' +
+                                       neighborhood.state_abbrev) for neighborhood in
+                                       placeList.allNeighborhoods |
+                                       filter: {label : $viewValue} |
+                                       limitTo: 8">
 
-                        <ui-select-match allow-clear="true" placeholder="Neighborhood" >
-                            {{$select.selected.label}}
-                        </ui-select-match>
-                        <ui-select-choices repeat="neighborhood.uuid as neighborhood in
-                                                   placeList.allNeighborhoods |
-                                                   filter: {label : $select.search}">
-                            <div ng-bind-html="neighborhood.label | highlight: $select.search"></div>
-                        </ui-select-choices>
-                    </ui-select>
                 </div>
             </div>
         </div>

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -72,7 +72,7 @@
             params = params || _.merge({}, $stateParams, defaultParams);
             params.ordering = ctl.sortBy.value;
             if (ctl.neighborhoodFilter) {
-                params.neighborhood = ctl.neighborhoodFilter;
+                params.neighborhood = ctl.neighborhoodFilter.uuid;
             }
 
             AnalysisJob.query(params).$promise.then(function(data) {


### PR DESCRIPTION
## Overview

Banish `ui.select` control from Angular app. Use Bootstrap typeahead instead. The select control offers a scrolling dropdown that can grow quite large; the typeahead control gets limited to the first eight matches by default.


### Demo

Also modified neighborhood filter control to include the state in the autocomplete label:
![reworked_dropdown](https://cloud.githubusercontent.com/assets/960264/25353376/047f7520-28fd-11e7-86f9-9bca86cf7c10.png)


### Notes

Note #305 is still outstanding (admin styling is broken).

## Testing Instructions

 * Rebuild angular container
 * Try out filters for admin analysis jobs: http://localhost:9301/#/admin/analysis-jobs/
 * Also for user management: http://localhost:9301/#/admin/users/
 * Also also for public 'places' list: http://localhost:9301/#/places/


Closes #328
Incidentally closes #329 (by removing the control)