### PR TITLE
Feature/place detail map#255

### DIFF
--- a/src/angularjs/src/app/components/map/map.directive.js
+++ b/src/angularjs/src/app/components/map/map.directive.js
@@ -9,7 +9,7 @@
 
         ctl.$onChanges = function (changes) {
             ctl.updateMapOptions(changes);
-        }
+        };
 
         ctl.$postLink = function () {
             ctl.map = L.map(ctl.mapHTMLElement, ctl.pfbMapOptions);
@@ -20,7 +20,7 @@
                 pfbMapBaselayer: { currentValue: ctl.pfbMapBaselayer }
             });
             ctl.pfbMapReady({map: ctl.map});
-        }
+        };
 
         ctl.updateMapOptions = function (changes) {
             if (ctl.map) {
@@ -43,7 +43,7 @@
                     ctl.map.addLayer(ctl.baselayer);
                 }
             }
-        }
+        };
     }
 
     function PFBMapDirective() {

--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -54,9 +54,7 @@
 
                 if (lastJob) {
                     AnalysisJob.results({uuid: lastJob.uuid}).$promise.then(function(results) {
-                        $log.debug(results);
                         ctl.mapLayers = results.destinations_urls;
-                        $log.debug(ctl.mapLayers);
                         if (results.overall_scores) {
                             ctl.jobResults = _.map(results.overall_scores, function(obj, key) {
                                 return {

--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -26,6 +26,7 @@
             ctl.place = null;
             ctl.lastJobScore = null;
             ctl.jobResults = null;
+            ctl.mapLayers = {};
             ctl.getPlace = getPlace;
 
             ctl.downloads = null;
@@ -40,6 +41,7 @@
 
             AnalysisJob.query({neighborhood: uuid, latest: 'True'}).$promise.then(function(data) {
 
+                ctl.mapLayers = {};
                 if (!data.results || !data.results.length) {
                     $log.warn('no matching analysis job found for neighborhood ' + uuid);
                     ctl.lastJobScore = null;
@@ -52,6 +54,9 @@
 
                 if (lastJob) {
                     AnalysisJob.results({uuid: lastJob.uuid}).$promise.then(function(results) {
+                        $log.debug(results);
+                        ctl.mapLayers = results.destinations_urls;
+                        $log.debug(ctl.mapLayers);
                         if (results.overall_scores) {
                             ctl.jobResults = _.map(results.overall_scores, function(obj, key) {
                                 return {

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -70,6 +70,6 @@
 
 <!-- Map -->
 <div class="preview-map">
-    <pfb-places-map></pfb-places-map>
+    <pfb-places-map pfb-places-map-layers="placeDetail.mapLayers"></pfb-places-map>
 </div>
 <!-- Map -->

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -70,6 +70,6 @@
 
 <!-- Map -->
 <div class="preview-map">
-    <div class="map"></div>
+    <pfb-places-map></pfb-places-map>
 </div>
 <!-- Map -->

--- a/src/angularjs/src/app/places/map/module.js
+++ b/src/angularjs/src/app/places/map/module.js
@@ -1,0 +1,4 @@
+(function () {
+    'use strict';
+    angular.module('pfb.places.map', ['pfb.components.map']);
+ })();

--- a/src/angularjs/src/app/places/map/places-map.directive.js
+++ b/src/angularjs/src/app/places/map/places-map.directive.js
@@ -1,7 +1,7 @@
 (function() {
 
     /* @ngInject */
-    function PlacesMapController($filter, $http, $sanitize, $scope) {
+    function PlacesMapController($filter, $http, $sanitize) {
         var ctl = this;
         ctl.map = null;
         ctl.layerControl = null;
@@ -18,13 +18,19 @@
                     attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                     maxZoom: 18
                 });
+        };
 
-            $scope.$watch(function(){return ctl.pfbPlacesMapLayers;}, setLayers);
+        ctl.$onChanges = function(changes) {
+            // set map layers once received from parent scope (paret-detail.controller)
+            if (changes.pfbPlacesMapLayers && changes.pfbPlacesMapLayers.currentValue && ctl.map) {
+                setLayers(changes.pfbPlacesMapLayers.currentValue);
+            }
         };
 
         ctl.onMapReady = function (map) {
             ctl.map = map;
 
+            // in case map layers set before map was ready, add layers now map is ready to go
             if (ctl.pfbPlacesMapLayers) {
                 setLayers(ctl.pfbPlacesMapLayers);
             }
@@ -103,7 +109,7 @@
         var module = {
             restrict: 'E',
             scope: {
-                pfbPlacesMapLayers: '='
+                pfbPlacesMapLayers: '<'
             },
             controller: 'PlacesMapController',
             controllerAs: 'ctl',

--- a/src/angularjs/src/app/places/map/places-map.directive.js
+++ b/src/angularjs/src/app/places/map/places-map.directive.js
@@ -1,0 +1,46 @@
+(function() {
+
+    /* @ngInject */
+    function PlacesMapController($log) {
+        var ctl = this;
+        ctl.map = null;
+
+        ctl.$onInit = function () {
+            ctl.mapOptions = {
+                scrollWheelZoom: true
+            };
+
+            // TODO: set center and zoom level by zooming to fit geojson polygon bounds
+            ctl.mapCenter = [39.963277, -75.142971];
+            ctl.baselayer = L.tileLayer(
+                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                });
+        };
+
+        ctl.onMapReady = function (map) {
+            ctl.map = map;
+
+            $log.debug('ready!');
+        };
+    }
+
+    function PlacesMapDirective() {
+        var module = {
+            restrict: 'E',
+            scope: true,
+            controller: 'PlacesMapController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            templateUrl: 'app/places/map/places-map.html'
+        };
+        return module;
+    }
+
+
+    angular.module('pfb.places.map')
+        .controller('PlacesMapController', PlacesMapController)
+        .directive('pfbPlacesMap', PlacesMapDirective);
+
+})();

--- a/src/angularjs/src/app/places/map/places-map.directive.js
+++ b/src/angularjs/src/app/places/map/places-map.directive.js
@@ -1,7 +1,7 @@
 (function() {
 
     /* @ngInject */
-    function PlacesMapController($log) {
+    function PlacesMapController($log, $scope) {
         var ctl = this;
         ctl.map = null;
 
@@ -17,19 +17,34 @@
                     attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                     maxZoom: 18
                 });
+
+            $scope.$watch(function(){return ctl.pfbPlacesMapLayers;}, setLayers);
         };
 
         ctl.onMapReady = function (map) {
             ctl.map = map;
 
             $log.debug('ready!');
+            $log.debug(ctl.pfbPlacesMapLayers);
+
+            if (ctl.pfbPlacesMapLayers) {
+                setLayers(ctl.pfbPlacesMapLayers);
+            }
         };
+
+        function setLayers(layers) {
+            $log.debug('setLayers');
+            $log.debug(layers);
+            //$log.debug(ctl.pfbPlacesMapLayers);
+        }
     }
 
     function PlacesMapDirective() {
         var module = {
             restrict: 'E',
-            scope: true,
+            scope: {
+                pfbPlacesMapLayers: '='
+            },
             controller: 'PlacesMapController',
             controllerAs: 'ctl',
             bindToController: true,

--- a/src/angularjs/src/app/places/map/places-map.html
+++ b/src/angularjs/src/app/places/map/places-map.html
@@ -1,0 +1,9 @@
+<!-- keep the .map class. It's important for sizing. -->
+ <div class="map map-below" id="map-{{::$id}}"
+     pfb-map
+     pfb-map-zoom="12"
+     pfb-map-center="ctl.mapCenter"
+     pfb-map-baselayer="ctl.baselayer"
+     pfb-map-options="ctl.mapOptions"
+     pfb-map-ready="ctl.onMapReady(map)">
+ </div>

--- a/src/angularjs/src/app/places/map/places-map.html
+++ b/src/angularjs/src/app/places/map/places-map.html
@@ -1,6 +1,7 @@
 <!-- keep the .map class. It's important for sizing. -->
  <div class="map map-below" id="map-{{::$id}}"
      pfb-map
+     pfb-places-map-layers="ctl.mapLayers"
      pfb-map-zoom="12"
      pfb-map-center="ctl.mapCenter"
      pfb-map-baselayer="ctl.baselayer"

--- a/src/angularjs/src/app/places/module.js
+++ b/src/angularjs/src/app/places/module.js
@@ -2,5 +2,5 @@
     'use strict';
 
     angular.module('pfb.places',
-                   ['pfb.places.list', 'pfb.places.detail']);
+                   ['pfb.places.list', 'pfb.places.detail', 'pfb.places.map']);
 })();


### PR DESCRIPTION
## Overview

Adds map to public places detail view with a control containing the results GeoJSON layers.


### Demo

A popup:
![pfb_university_map_popup](https://cloud.githubusercontent.com/assets/960264/25406247/0f8ff534-29d4-11e7-8749-98ff986d64da.png)


### Notes

Things not done:
 - Display neighborhood bounds polygon, as there is currently no endpoint for that (will we add one?)
 - Properly zoom/fit map to neighborhood area. If we add bounds polygon, can be accomplished with that
 - Style results markers/popups. At the least, should vary marker color by layer to distinguish
 - Display results tile layer (depends on #350).

At least for my test run for Philly, many of the results were missing values for low/high stress and pop. score; there were some for some schools in the 'university' layer (as in popup pictured above).


## Testing Instructions

 * As a workaround for #349, go to your S3 results bucket and enable CORS
 * Visit places detail page
 * Should get a map with a layer control in upper right, with a layer for each metric
 * Should be able to turn layers on and off
 * Should have GeoJSON properties in layer marker popups

Closes #255
