### PR TITLE
Make results bucket public

### DIFF
--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -58,6 +58,27 @@ data "aws_iam_policy_document" "batch_manage_jobs" {
   }
 }
 
+data "aws_iam_policy_document" "anonymous_read_storage_bucket_policy" {
+  policy_id = "S3StorageAnonymousReadPolicy"
+
+  statement {
+    sid = "S3ReadOnly"
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${lower("${var.environment}")}-pfb-storage-${var.aws_region}/*",
+    ]
+  }
+}
+
 #
 # Custom policies
 #

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -17,7 +17,16 @@ resource "aws_s3_bucket" "static" {
 
 resource "aws_s3_bucket" "storage" {
   bucket = "${lower("${var.environment}")}-pfb-storage-${var.aws_region}"
-  acl    = "private"
+  acl    = "public-read"
+  policy = "${data.aws_iam_policy_document.anonymous_read_storage_bucket_policy.json}"
+
+  cors_rule {
+    allowed_origins = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    max_age_seconds = 3000
+    allowed_headers = ["Authorization"]
+    expose_headers  = ["ETag"]
+  }
 
   tags {
     Environment = "${var.environment}"


### PR DESCRIPTION
## Overview

Makes the results bucket public and adds CORS permissions so that the feature geojson files and the tile layers can be accessed by the front-end.

### Notes

Even without of setting up CloudFront we might be able to get more fine-grained with the permissions policy, but for now this does the job.

## Testing Instructions

I applied this to the staging site, so any file in the `staging-pfb-storage-us-east-1` bucket should now be accessible at the key path appended to https://s3.amazonaws.com/staging-pfb-storage-us-east-1/.

The static tile layer URLs would be `https://s3.amazonaws.com/staging-pfb-storage-us-east-1/results/<JOB_ID>/tiles/<LAYER_NAME>/{z}/{x}/{y}.png`, where `LAYER_NAME` is "neighborhood_ways" or "neighborhood_census_blocks".

Resolves #353, resolves #350.