### PR TITLE
Calculate running_time from first IMPORTING status

### DIFF
--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -360,7 +360,7 @@ class AnalysisJob(PFBModel):
     @property
     def running_time(self):
         """ Return the running time of the job in seconds """
-        first_update = self.status_updates.first()
+        first_update = self.status_updates.filter(status=self.Status.IMPORTING).first()
         last_update = self.status_updates.last()
         if first_update is None or last_update is None:
             return 0


### PR DESCRIPTION
## Overview

We add a status update to set QUEUED when we submit a job, so
calculating running time from the first status update of any kind means
including all the time spent waiting to start.  IMPORTING is the first
status set by the actual analysis, so start from there instead.

## Testing Instructions

It's hard to see the difference in development, because we don't set the QUEUED status there. But you could set it manually to see the difference.  Or just confirm that `running_time` still returns sensible answers.
