### PR TITLE
Parallelize tilemaker

### DIFF
--- a/deployment/aws-batch/job-definitions/production-pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/production-pfb-analysis-run-job.json
@@ -7,7 +7,7 @@
     },
     "containerProperties": {
         "image": "{image}",
-        "vcpus": 7,
+        "vcpus": 8,
         "memory": 30720,
         "command": [
             "/pfb/scripts/entrypoint.sh"

--- a/deployment/aws-batch/job-definitions/production-pfb-tilemaker-run-job.json
+++ b/deployment/aws-batch/job-definitions/production-pfb-tilemaker-run-job.json
@@ -7,8 +7,8 @@
     },
     "containerProperties": {
         "image": "{image}",
-        "vcpus": 1,
-        "memory": 1024,
+        "vcpus": 4,
+        "memory": 4096,
         "command": [],
         "jobRoleArn": "",
         "environment": [],

--- a/deployment/aws-batch/job-definitions/staging-pfb-tilemaker-run-job.json
+++ b/deployment/aws-batch/job-definitions/staging-pfb-tilemaker-run-job.json
@@ -7,8 +7,8 @@
     },
     "containerProperties": {
         "image": "{image}",
-        "vcpus": 1,
-        "memory": 1024,
+        "vcpus": 2,
+        "memory": 2048,
         "command": [],
         "jobRoleArn": "",
         "environment": [],

--- a/src/tilemaker/Dockerfile
+++ b/src/tilemaker/Dockerfile
@@ -66,7 +66,7 @@ RUN set -xe && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm -r ./awscli-bundle*
 
-RUN apt-get install -y gdal-bin time
+RUN apt-get install -y gdal-bin time parallel
 
 # Install tl and other utilities
 RUN npm install -g \

--- a/src/tilemaker/entrypoint.sh
+++ b/src/tilemaker/entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 source /opt/pfb/tilemaker/scripts/utils.sh
 
 export TL_MIN_ZOOM="${TL_MIN_ZOOM:-8}"
-export TL_MAX_ZOOM="${TL_MAX_ZOOM:-18}"
+export TL_MAX_ZOOM="${TL_MAX_ZOOM:-17}"
 export TL_NUM_PARTS="${TL_NUM_PARTS:-4}"
 export TIME="\nTIMING: %C\nTIMING:\t%E elapsed %Kkb mem\n"
 

--- a/src/tilemaker/entrypoint.sh
+++ b/src/tilemaker/entrypoint.sh
@@ -7,6 +7,8 @@ source /opt/pfb/tilemaker/scripts/utils.sh
 
 export TL_MIN_ZOOM="${TL_MIN_ZOOM:-8}"
 export TL_MAX_ZOOM="${TL_MAX_ZOOM:-18}"
+export TL_NUM_PARTS="${TL_NUM_PARTS:-4}"
+export TIME="\nTIMING: %C\nTIMING:\t%E elapsed %Kkb mem\n"
 
 if [ -z "${PFB_JOB_ID}" ]; then
     echo "Error: PFB_JOB_ID is required"

--- a/src/tilemaker/scripts/split_bbox.py
+++ b/src/tilemaker/scripts/split_bbox.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+""" A little utility script to take a bounding box, a number of partitions, and the number for
+which partition is desired, and return a piece of the bounding box that's 1/num_parts wide.
+"""
+
+import sys
+
+try:
+    args = sys.argv[1].split(' ')
+    (w, s, e, n) = [float(val) for val in args[0:4]]
+    (num_parts, part) = [int(val) for val in args[4:6]]
+    if part <= 0 or part > num_parts:
+        raise Exception("Invalid bounding box partition: part {} of {}".format(part, num_parts))
+except:
+    sys.stderr.write("""
+    Usage: {} W S E N NUM_PARTS PART
+
+    Given bounding box, number of partitions, and which partition to return, breaks the box up
+    horizontally into NUM_PARTS sections and returns the given section (1-indexed).
+
+    argv was {}
+    """.format(sys.argv[0], ' '.join(sys.argv[1:])))
+    print "argv: ", sys.argv
+    print "argv length: ", len(sys.argv)
+    print "part {}, num_parts {}".format(part, num_parts)
+    exit(1)
+
+diff = (e - w) / num_parts
+new_e = w + (part * diff)
+print ' '.join([str(val) for val in new_e - diff, s, new_e, n])


### PR DESCRIPTION
## Overview & Notes

Makes tilemaker much more parallel, using GNU `parallel`.

In addition to running one command per zoomlevel, it also divides the bounding box into segments and runs one command per segment.  The default I went with is 4.  Any tile that falls at all within a boundary gets generated, so more partitions would result in more tiles getting generated twice.  So I only used the partitioning at higher zoomlevels (cutoff of 13 chosen somewhat arbitrarily).

I also increased the resources limits in the job definition, since it should be able to make use of them now.

I didn't split ways and blocks into separate tasks.  It would be pretty easy to do so, but a little attention would have to be paid to how to keep the first one that finishes from updating the status to COMPLETE prematurely.

I'm out for the morning, so feel free to modify and merge this.  I'll be online in the afternoon.

## Testing Instructions

Build the tilemaker container and run a job (you can get the tiling command for your most analyzed-but-not-tiled job by running `AnalysisJobStatusUpdate.objects.filter(status=AnalysisJob.Status.EXPORTED).latest('timestamp').job.generate_tiles()` in shell_plus)
It should use more CPU and finish faster than before, but produce identical results.

Connects #360.
