### PR TITLE
Cleanup Django S3 url signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Run `./scripts/setup` to install project dependencies and prepare the developmen
 vagrant ssh
 ```
 
+Once in the VM, with your AWS credentials configured, run the following commands to configure your development S3 buckets:
+```
+aws s3api create-bucket --bucket "${DEV_USER}-pfb-storage-us-east-1"
+aws s3api put-bucket-policy --bucket "${DEV_USER}-pfb-storage-us-east-1" --policy "{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::${DEV_USER}-pfb-storage-us-east-1/*\"}]}"
+```
+
 At this point, if you only intend to run the 'Bike Network Analysis', skip directly to [Running the Analysis](#running-the-analysis)
 
 To start the application containers:

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -519,15 +519,10 @@ class AnalysisJob(PFBModel):
         return '{}/tiles'.format(self.s3_results_path)
 
     def _s3_url_for_result_resource(self, filename):
-        key = '/'.join((self.s3_results_path, filename))
-        s3 = boto3.client('s3')
-        return s3.generate_presigned_url(
-            ClientMethod='get_object',
-            ExpiresIn=settings.PFB_ANALYSIS_PRESIGNED_URL_EXPIRES,
-            Params={
-                'Bucket': settings.AWS_STORAGE_BUCKET_NAME,
-                'Key': key
-            }
+        return 'https://s3.amazonaws.com/{bucket}/{path}/{filename}'.format(
+            bucket=settings.AWS_STORAGE_BUCKET_NAME,
+            path=self.s3_results_path,
+            filename=filename,
         )
 
 

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -243,11 +243,9 @@ WATCHMAN_CHECKS = (
 # https://github.com/jschneier/django-storages
 
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-AWS_AUTO_CREATE_BUCKET = True
 AWS_STORAGE_BUCKET_NAME = os.getenv('PFB_S3_STORAGE_BUCKET',
                                     '{0}-pfb-storage-{1}'.format(DEV_USER, AWS_REGION))
 AWS_QUERYSTRING_AUTH = False
-AWS_QUERYSTRING_EXPIRE = 3600 * 24 * 14     # Two weeks
 
 
 # Email

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -246,6 +246,7 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 AWS_AUTO_CREATE_BUCKET = True
 AWS_STORAGE_BUCKET_NAME = os.getenv('PFB_S3_STORAGE_BUCKET',
                                     '{0}-pfb-storage-{1}'.format(DEV_USER, AWS_REGION))
+AWS_QUERYSTRING_AUTH = False
 AWS_QUERYSTRING_EXPIRE = 3600 * 24 * 14     # Two weeks
 
 


### PR DESCRIPTION
## Overview

A bit more fallout from running batches. In this case, it appears pre-singed URLs are failing if they sit in the AWS Batch queue for too long. The presigned url is set to expire after two weeks, but since the requests are generated on an EC2 instance, they contain an `x-amz-security-token` which contains the EC2 instance temporary credential used to sign the request, and this fails, presumably because the EC2 credentials are rotated by the time the signed url is used. In any case, in #354 we made the storage bucket public so this just switches to use unsigned urls for all objects that live in the storages bucket.

@KlaasH you might want to take a look as well, since this requires running a command to update your dev storage bucket permissions.


### Demo

![screen shot 2017-04-28 at 09 48 02](https://cloud.githubusercontent.com/assets/1818302/25531470/ce5a4472-2bf7-11e7-9515-f9f25e1a22b5.png)


## Testing Instructions

If you don't already have your local storage bucket created, in the VM run:
```
aws s3api create-bucket --bucket "${DEV_USER}-pfb-storage-us-east-1"
```
Then, to ensure the public read policy is attached to your bucket, run:
```
aws s3api put-bucket-policy --bucket "${DEV_USER}-pfb-storage-us-east-1" --policy "{\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::${DEV_USER}-pfb-storage-us-east-1/*\"}]}"
```

Afterwards, navigate to a Job Results page in the admin UI and inspect the resource URLs. They should work as before and not contain any signing information.
