### PR TITLE
Attempt a single retry in case of job failure

### DIFF
--- a/deployment/aws-batch/job-definitions/production-pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/production-pfb-analysis-run-job.json
@@ -2,6 +2,9 @@
     "jobDefinitionName": "production-pfb-analysis-run-job",
     "type": "container",
     "parameters": {},
+    "retryStrategy": {
+        "attempts": 2
+    },
     "containerProperties": {
         "image": "{image}",
         "vcpus": 7,

--- a/deployment/aws-batch/job-definitions/production-pfb-tilemaker-run-job.json
+++ b/deployment/aws-batch/job-definitions/production-pfb-tilemaker-run-job.json
@@ -2,6 +2,9 @@
     "jobDefinitionName": "production-pfb-tilemaker-run-job",
     "type": "container",
     "parameters": {},
+    "retryStrategy": {
+        "attempts": 2
+    },
     "containerProperties": {
         "image": "{image}",
         "vcpus": 1,

--- a/deployment/aws-batch/job-definitions/staging-pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/staging-pfb-analysis-run-job.json
@@ -2,6 +2,9 @@
     "jobDefinitionName": "staging-pfb-analysis-run-job",
     "type": "container",
     "parameters": {},
+    "retryStrategy": {
+        "attempts": 2
+    },
     "containerProperties": {
         "image": "{image}",
         "vcpus": 2,

--- a/deployment/aws-batch/job-definitions/staging-pfb-tilemaker-run-job.json
+++ b/deployment/aws-batch/job-definitions/staging-pfb-tilemaker-run-job.json
@@ -2,6 +2,9 @@
     "jobDefinitionName": "staging-pfb-tilemaker-run-job",
     "type": "container",
     "parameters": {},
+    "retryStrategy": {
+        "attempts": 2
+    },
     "containerProperties": {
         "image": "{image}",
         "vcpus": 1,


### PR DESCRIPTION
## Overview

AWS Batch added a "retryStrategy" option that allows for automatic retries in case a job returns a non-zero exit code. This provides a single automatic retry in the case of transient AWS/network issues, backing instance termination, etc. I didn't think more than one retry is necessary, but I could bump attempts to 3.

## Notes

The job is not retried if cancelled or manually terminated.

Any progress is lost and jobs are restarted from the beginning.

## Testing Instructions

Nothing really, I'm going run a few tests after this is merged and deployed and submit a followup PR if necessary to address any issues.

