### PR TITLE
Feature/kak/places list map#249

### DIFF
--- a/src/angularjs/src/app/components/map/map.constants.js
+++ b/src/angularjs/src/app/components/map/map.constants.js
@@ -21,7 +21,7 @@
         }
     },
     conusBounds: [[24.396308, -124.848974], [49.384358, -66.885444]],
-    conusMaxZoom: 18
+    conusMaxZoom: 17
   };
 
   angular

--- a/src/angularjs/src/app/components/map/map.constants.js
+++ b/src/angularjs/src/app/components/map/map.constants.js
@@ -3,6 +3,12 @@
 
   var config = {
     baseLayers: {
+        'Positron': {
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+            attribution: [
+                '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, ',
+                '&copy; <a href="https://carto.com/attribution">CARTO</a>'].join('')
+        },
         'Stamen' : {
             url: 'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
             attribution: ['Map tiles by <a href="http://stamen.com">Stamen Design</a>, ',

--- a/src/angularjs/src/app/components/map/map.constants.js
+++ b/src/angularjs/src/app/components/map/map.constants.js
@@ -1,0 +1,31 @@
+(function() {
+  'use strict';
+
+  var config = {
+    baseLayers: {
+        'Stamen' : {
+            url: 'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            attribution: ['Map tiles by <a href="http://stamen.com">Stamen Design</a>, ',
+                'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ',
+                'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under ',
+                '<a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+            ].join('')
+        },
+        'Satellite': {
+            url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            attribution: [
+                '&copy; <a href="http://www.esri.com/">Esri</a> ',
+                'Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, ',
+                'AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community'
+            ].join('')
+        }
+    },
+    conusBounds: [[24.396308, -124.848974], [49.384358, -66.885444]],
+    conusMaxZoom: 18
+  };
+
+  angular
+    .module('pfb.components.map')
+    .constant('MapConfig', config);
+
+})();

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -2,7 +2,7 @@
 (function() {
 
     /* @ngInject */
-    function ThumbnailMapController() {
+    function ThumbnailMapController(MapConfig) {
         var ctl = this;
         ctl.map = null;
 
@@ -17,9 +17,9 @@
             // TODO: set center and zoom level by zooming to fit geojson polygon bounds
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
-                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-                    maxZoom: 18
+                MapConfig.baseLayers.Stamen.url, {
+                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                    maxZoom: MapConfig.conusMaxZoom
                 });
         };
 

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -17,8 +17,8 @@
             // TODO: set center and zoom level by zooming to fit geojson polygon bounds
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
-                MapConfig.baseLayers.Stamen.url, {
-                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                MapConfig.baseLayers.Positron.url, {
+                    attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
                 });
         };

--- a/src/angularjs/src/app/home/neighborhood-map.directive.js
+++ b/src/angularjs/src/app/home/neighborhood-map.directive.js
@@ -10,8 +10,8 @@
             ctl.mapOptions = { scrollWheelZoom: false };
             ctl.boundsConus = MapConfig.conusBounds;
             ctl.baselayer = L.tileLayer(
-                MapConfig.baseLayers.Stamen.url, {
-                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                MapConfig.baseLayers.Positron.url, {
+                    attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
                 });
         };

--- a/src/angularjs/src/app/home/neighborhood-map.directive.js
+++ b/src/angularjs/src/app/home/neighborhood-map.directive.js
@@ -2,17 +2,17 @@
 (function() {
 
     /* @ngInject */
-    function NeighborhoodMapController(Neighborhood) {
+    function NeighborhoodMapController(MapConfig, Neighborhood) {
         var ctl = this;
         ctl.map = null;
 
         ctl.$onInit = function () {
             ctl.mapOptions = { scrollWheelZoom: false };
-            ctl.boundsConus = [[24.396308, -124.848974], [49.384358, -66.885444]];
+            ctl.boundsConus = MapConfig.conusBounds;
             ctl.baselayer = L.tileLayer(
-                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-                    maxZoom: 18
+                MapConfig.baseLayers.Stamen.url, {
+                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                    maxZoom: MapConfig.conusMaxZoom
                 });
         };
 

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -7,7 +7,9 @@
         <div class="card-details">
             <div class="overview-total">{{ ctl.count || "--" }}</div>
             <div class="overview-total-label">Cities/Towns Nationwide</div>
-            <a ui-sref="places" class="btn btn-primary">Find your City/Town <i class="icon-arrow-right"></i></a>
+            <a ui-sref="places.list" class="btn btn-primary">Find your City/Town
+                <i class="icon-arrow-right"></i>
+            </a>
         </div>
     </div>
     <!-- keep the .map class. It's important for sizing. -->

--- a/src/angularjs/src/app/places/detail/module.js
+++ b/src/angularjs/src/app/places/detail/module.js
@@ -1,4 +1,5 @@
 (function () {
     'use strict';
-    angular.module('pfb.places.detail', []);
+
+    angular.module('pfb.places.detail', ['pfb.components.map']);
  })();

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -1,7 +1,7 @@
 (function() {
 
     /* @ngInject */
-    function PlacesMapController($filter, $http, $sanitize) {
+    function PlaceMapController($filter, $http, $sanitize) {
         var ctl = this;
         ctl.map = null;
         ctl.layerControl = null;
@@ -22,8 +22,8 @@
 
         ctl.$onChanges = function(changes) {
             // set map layers once received from parent scope (paret-detail.controller)
-            if (changes.pfbPlacesMapLayers && changes.pfbPlacesMapLayers.currentValue && ctl.map) {
-                setLayers(changes.pfbPlacesMapLayers.currentValue);
+            if (changes.pfbPlaceMapLayers && changes.pfbPlaceMapLayers.currentValue && ctl.map) {
+                setLayers(changes.pfbPlaceMapLayers.currentValue);
             }
         };
 
@@ -31,8 +31,8 @@
             ctl.map = map;
 
             // in case map layers set before map was ready, add layers now map is ready to go
-            if (ctl.pfbPlacesMapLayers) {
-                setLayers(ctl.pfbPlacesMapLayers);
+            if (ctl.pfbPlaceMapLayers) {
+                setLayers(ctl.pfbPlaceMapLayers);
             }
         };
 
@@ -105,23 +105,23 @@
         }
     }
 
-    function PlacesMapDirective() {
+    function PlaceMapDirective() {
         var module = {
             restrict: 'E',
             scope: {
-                pfbPlacesMapLayers: '<'
+                pfbPlaceMapLayers: '<'
             },
-            controller: 'PlacesMapController',
+            controller: 'PlaceMapController',
             controllerAs: 'ctl',
             bindToController: true,
-            templateUrl: 'app/places/map/places-map.html'
+            templateUrl: 'app/places/detail/place-map.html'
         };
         return module;
     }
 
 
-    angular.module('pfb.places.map')
-        .controller('PlacesMapController', PlacesMapController)
-        .directive('pfbPlacesMap', PlacesMapDirective);
+    angular.module('pfb.places.detail')
+        .controller('PlaceMapController', PlaceMapController)
+        .directive('pfbPlaceMap', PlaceMapDirective);
 
 })();

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -1,7 +1,7 @@
 (function() {
 
     /* @ngInject */
-    function PlaceMapController($filter, $http, $sanitize) {
+    function PlaceMapController($filter, $http, $sanitize, MapConfig) {
         var ctl = this;
         ctl.map = null;
         ctl.layerControl = null;
@@ -14,9 +14,9 @@
             // TODO: set center and zoom level by zooming to fit geojson polygon bounds
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
-                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-                    maxZoom: 18
+                MapConfig.baseLayers.Stamen.url, {
+                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                    maxZoom: MapConfig.conusMaxZoom
                 });
         };
 

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -14,8 +14,8 @@
             // TODO: set center and zoom level by zooming to fit geojson polygon bounds
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
-                MapConfig.baseLayers.Stamen.url, {
-                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                MapConfig.baseLayers.Positron.url, {
+                    attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
                 });
         };
@@ -42,7 +42,7 @@
             }
 
             if (!ctl.layerControl) {
-                ctl.layerControl = L.control.layers({'Stamen': ctl.baselayer}, []).addTo(ctl.map);
+                ctl.layerControl = L.control.layers({'Positron': ctl.baselayer}, []).addTo(ctl.map);
             }
 
             _.map(layers, function(url, metric) {

--- a/src/angularjs/src/app/places/detail/place-map.html
+++ b/src/angularjs/src/app/places/detail/place-map.html
@@ -1,7 +1,7 @@
 <!-- keep the .map class. It's important for sizing. -->
  <div class="map map-below" id="map-{{::$id}}"
      pfb-map
-     pfb-places-map-layers="ctl.mapLayers"
+     pfb-place-map-layers="ctl.mapLayers"
      pfb-map-zoom="12"
      pfb-map-center="ctl.mapCenter"
      pfb-map-baselayer="ctl.baselayer"

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -70,6 +70,6 @@
 
 <!-- Map -->
 <div class="preview-map">
-    <pfb-places-map pfb-places-map-layers="placeDetail.mapLayers"></pfb-places-map>
+    <pfb-place-map pfb-place-map-layers="placeDetail.mapLayers"></pfb-place-map>
 </div>
 <!-- Map -->

--- a/src/angularjs/src/app/places/list/module.js
+++ b/src/angularjs/src/app/places/list/module.js
@@ -1,5 +1,5 @@
 (function () {
     'use strict';
 
-    angular.module('pfb.places.list', []);
+    angular.module('pfb.places.list', ['pfb.components.map']);
 })();

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -111,6 +111,6 @@
 
 <!-- Map -->
 <div class="preview-map">
-    <div class="map"></div>
+    <pfb-places-list-map></pfb-places-list-map>
 </div>
 <!-- Map -->

--- a/src/angularjs/src/app/places/list/places-list-map-directive.js
+++ b/src/angularjs/src/app/places/list/places-list-map-directive.js
@@ -9,8 +9,8 @@
         ctl.$onInit = function () {
             ctl.boundsConus = MapConfig.conusBounds;
             ctl.baselayer = L.tileLayer(
-                MapConfig.baseLayers.Stamen.url, {
-                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                MapConfig.baseLayers.Positron.url, {
+                    attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
                 });
         };
@@ -25,7 +25,7 @@
 
             if (!ctl.layerControl) {
                 ctl.layerControl = L.control.layers({
-                        'Stamen': ctl.baselayer,
+                        'Positron': ctl.baselayer,
                         'Satellite': satelliteLayer
                     },
                     []).addTo(ctl.map);

--- a/src/angularjs/src/app/places/list/places-list-map-directive.js
+++ b/src/angularjs/src/app/places/list/places-list-map-directive.js
@@ -1,36 +1,26 @@
 (function() {
 
     /* @ngInject */
-    function PlacesListMapController(Neighborhood) {
+    function PlacesListMapController(MapConfig, Neighborhood) {
         var ctl = this;
         ctl.map = null;
         ctl.layerControl = null;
 
         ctl.$onInit = function () {
-            ctl.mapOptions = {
-                scrollWheelZoom: true
-            };
-
-            ctl.boundsConus = [[24.396308, -124.848974], [49.384358, -66.885444]];
+            ctl.boundsConus = MapConfig.conusBounds;
             ctl.baselayer = L.tileLayer(
-                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
-                    maxZoom: 18
+                MapConfig.baseLayers.Stamen.url, {
+                    attribution: MapConfig.baseLayers.Stamen.attribution,
+                    maxZoom: MapConfig.conusMaxZoom
                 });
         };
 
         ctl.onMapReady = function (map) {
             ctl.map = map;
 
-            var esriSatelliteAttribution = [
-                '&copy; <a href="http://www.esri.com/">Esri</a> ',
-                'Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, ',
-                'AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community'
-            ].join('');
-
-            var satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-                attribution: esriSatelliteAttribution,
-                maxZoom: 18
+            var satelliteLayer = L.tileLayer(MapConfig.baseLayers.Satellite.url, {
+                attribution: MapConfig.baseLayers.Satellite.attribution,
+                maxZoom: MapConfig.conusMaxZoom
             });
 
             if (!ctl.layerControl) {
@@ -42,7 +32,6 @@
             }
 
             Neighborhood.geojson().$promise.then(function (data) {
-                ctl.count = data && data.features ? data.features.length : '0';
                 ctl.neighborhoodLayer = L.geoJSON(data, {
                     onEachFeature: onEachFeature
                 });

--- a/src/angularjs/src/app/places/list/places-list-map-directive.js
+++ b/src/angularjs/src/app/places/list/places-list-map-directive.js
@@ -1,0 +1,91 @@
+(function() {
+
+    /* @ngInject */
+    function PlacesListMapController(Neighborhood) {
+        var ctl = this;
+        ctl.map = null;
+        ctl.layerControl = null;
+
+        ctl.$onInit = function () {
+            ctl.mapOptions = {
+                scrollWheelZoom: true
+            };
+
+            ctl.boundsConus = [[24.396308, -124.848974], [49.384358, -66.885444]];
+            ctl.baselayer = L.tileLayer(
+                'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                });
+        };
+
+        ctl.onMapReady = function (map) {
+            ctl.map = map;
+
+            var esriSatelliteAttribution = [
+                '&copy; <a href="http://www.esri.com/">Esri</a> ',
+                'Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, ',
+                'AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community'
+            ].join('');
+
+            var satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+                attribution: esriSatelliteAttribution,
+                maxZoom: 18
+            });
+
+            if (!ctl.layerControl) {
+                ctl.layerControl = L.control.layers({
+                        'Stamen': ctl.baselayer,
+                        'Satellite': satelliteLayer
+                    },
+                    []).addTo(ctl.map);
+            }
+
+            Neighborhood.geojson().$promise.then(function (data) {
+                ctl.count = data && data.features ? data.features.length : '0';
+                ctl.neighborhoodLayer = L.geoJSON(data, {
+                    onEachFeature: onEachFeature
+                });
+                ctl.layerControl.addOverlay(ctl.neighborhoodLayer, 'Places');
+                map.addLayer(ctl.neighborhoodLayer);
+            });
+
+            function onEachFeature(feature, layer) {
+                layer.on({
+                    click: function () {
+                        if (feature && feature.geometry &&
+                            feature.geometry.coordinates) {
+                            var popup = L.popup()
+                                .setLatLng([
+                                    feature.geometry.coordinates[1],
+                                    feature.geometry.coordinates[0]
+                                ])
+                                .setContent(feature.properties.label);
+                            ctl.map.openPopup(popup);
+                        }
+                    }
+                });
+            }
+        };
+    }
+
+    function PlacesListMapDirective() {
+        var module = {
+            restrict: 'E',
+            scope: {
+                pfbPlacesListMapLayers: '<'
+            },
+            controller: 'PlacesListMapController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            templateUrl: 'app/places/list/places-list-map.html'
+        };
+        return module;
+    }
+
+
+    angular.module('pfb.places.list')
+        .controller('PlacesListMapController', PlacesListMapController)
+        .directive('pfbPlacesListMap', PlacesListMapDirective);
+
+})();

--- a/src/angularjs/src/app/places/list/places-list-map.html
+++ b/src/angularjs/src/app/places/list/places-list-map.html
@@ -1,0 +1,8 @@
+<!-- keep the .map class. It's important for sizing. -->
+ <div class="map map-below" id="map-{{::$id}}"
+     pfb-map
+     pfb-map-bounds="ctl.boundsConus"
+     pfb-map-baselayer="ctl.baselayer"
+     pfb-map-options="ctl.mapOptions"
+     pfb-map-ready="ctl.onMapReady(map)">
+ </div>

--- a/src/angularjs/src/app/places/map/module.js
+++ b/src/angularjs/src/app/places/map/module.js
@@ -1,4 +1,0 @@
-(function () {
-    'use strict';
-    angular.module('pfb.places.map', ['pfb.components.map']);
- })();

--- a/src/angularjs/src/app/places/module.js
+++ b/src/angularjs/src/app/places/module.js
@@ -2,5 +2,5 @@
     'use strict';
 
     angular.module('pfb.places',
-                   ['pfb.places.list', 'pfb.places.detail', 'pfb.places.map', 'pfb.places.compare']);
+                   ['pfb.places.list', 'pfb.places.detail', 'pfb.places.compare']);
 })();

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -57,7 +57,8 @@ class NeighborhoodSerializer(PFBModelSerializer):
 
     class Meta:
         model = Neighborhood
-        exclude = ('created_at', 'modified_at', 'created_by', 'modified_by', 'geom', 'geom_pt',)
+        exclude = ('created_at', 'modified_at', 'created_by', 'modified_by', 'geom', 'geom_simple',
+                   'geom_pt',)
         read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
                             'organization', 'name',)
 


### PR DESCRIPTION
## Overview

Implement map view on public places list page and load layer with neighborhood points. Also added a map constants file for shared use by the map directives in setting up base layers. Moved existing places detail map under `detail` module, as it can't be readily shared with the list page map.


### Demo

With satellite layer selected:
![image](https://cloud.githubusercontent.com/assets/960264/25540626/cdacdbd0-2c19-11e7-9137-d8209eddf1c4.png)



### Notes

Also fixed an issue where the new `geom_simple` GeoJSON was loading in the default neighborhood API endpoint (that endpoint should have no geometries in it).

#251 should add overlay centered over map for a places comparison overview.


## Testing Instructions

 * Visit places page at http://localhost:9301/?#/places/
 * Should get points layer of places, like on home page
 * Should have a layer switcher with a secondary satellite base layer option

Closes #249
