### PR TITLE
Load neighborhood boundaries on thumbnail maps

### DIFF
--- a/src/angularjs/src/app/components/neighborhoods.service.js
+++ b/src/angularjs/src/app/components/neighborhoods.service.js
@@ -26,6 +26,11 @@
                 method: 'GET',
                 isArray: false,
                 url: '/api/neighborhoods_geojson/'
+            },
+            'bounds': {
+                method: 'GET',
+                isArray: false,
+                url: '/api/neighborhoods_bounds_geojson/:uuid/'
             }
         });
     }

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -2,9 +2,10 @@
 (function() {
 
     /* @ngInject */
-    function ThumbnailMapController(MapConfig) {
+    function ThumbnailMapController(MapConfig, Neighborhood) {
         var ctl = this;
         ctl.map = null;
+        ctl.boundsLayer = null;
 
         ctl.$onInit = function () {
             ctl.mapOptions = {
@@ -14,7 +15,7 @@
                 attributionControl: false
             };
 
-            // TODO: set center and zoom level by zooming to fit geojson polygon bounds
+            // will set center and zoom level by zooming to fit geojson polygon bounds when loaded
             ctl.mapCenter = [39.963277, -75.142971];
             ctl.baselayer = L.tileLayer(
                 MapConfig.baseLayers.Positron.url, {
@@ -23,15 +24,38 @@
                 });
         };
 
+        ctl.$onChanges = function(changes) {
+            // set map layers once received from parent scope (paret-detail.controller)
+            if (changes.pfbThumbnailMapPlace &&
+                changes.pfbThumbnailMapPlace.currentValue && ctl.map) {
+
+                loadBounds(changes.pfbThumbnailMapPlace.currentValue);
+            }
+        };
+
         ctl.onMapReady = function (map) {
             ctl.map = map;
+
+            if (ctl.pfbThumbnailMapPlace) {
+                loadBounds(ctl.pfbThumbnailMapPlace);
+            }
         };
+
+        function loadBounds(uuid) {
+            Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
+                ctl.boundsLayer = L.geoJSON(data, {});
+                ctl.map.addLayer(ctl.boundsLayer);
+                ctl.map.fitBounds(ctl.boundsLayer.getBounds());
+            });
+        }
     }
 
     function ThumbnailMapDirective() {
         var module = {
             restrict: 'E',
-            scope: true,
+            scope: {
+                'pfbThumbnailMapPlace': '<'
+            },
             controller: 'ThumbnailMapController',
             controllerAs: 'ctl',
             bindToController: true,

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -16,7 +16,7 @@
             };
 
             // will set center and zoom level by zooming to fit geojson polygon bounds when loaded
-            ctl.mapCenter = [39.963277, -75.142971];
+            ctl.boundsConus = MapConfig.conusBounds;
             ctl.baselayer = L.tileLayer(
                 MapConfig.baseLayers.Positron.url, {
                     attribution: MapConfig.baseLayers.Positron.attribution,
@@ -54,7 +54,7 @@
         var module = {
             restrict: 'E',
             scope: {
-                'pfbThumbnailMapPlace': '<'
+                pfbThumbnailMapPlace: '<'
             },
             controller: 'ThumbnailMapController',
             controllerAs: 'ctl',

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
@@ -1,5 +1,6 @@
 <!-- keep the .map class. It's important for sizing. -->
 <div class="map map-below" id="map-{{::$id}}"
+    pfbThumbnailMapPlace="ctl.pfbThumbnailMapPlace"
     pfb-map
     pfb-map-zoom="12"
     pfb-map-center="ctl.mapCenter"

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
@@ -3,7 +3,7 @@
     pfbThumbnailMapPlace="ctl.pfbThumbnailMapPlace"
     pfb-map
     pfb-map-zoom="12"
-    pfb-map-center="ctl.mapCenter"
+    pfb-map-bounds="ctl.boundsConus"
     pfb-map-baselayer="ctl.baselayer"
     pfb-map-options="ctl.mapOptions"
     pfb-map-ready="ctl.onMapReady(map)">

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -27,7 +27,7 @@
                 <div class="card">
                     <a ui-sref="places.detail({uuid: '{{city.uuid}}' })" class="card-link"></a>
                     <div class="card-map">
-                        <pfb-thumbnail-map></pfb-thumbnail-map>
+                        <pfb-thumbnail-map pfb-thumbnail-map-place="city.uuid"></pfb-thumbnail-map>
                     </div>
                     <div class="card-details">
                         <h3>{{city.label}}</h3>

--- a/src/angularjs/src/app/places/detail/place-map.html
+++ b/src/angularjs/src/app/places/detail/place-map.html
@@ -2,8 +2,9 @@
  <div class="map map-below" id="map-{{::$id}}"
      pfb-map
      pfb-place-map-layers="ctl.mapLayers"
+     pfb-place-map-uuid="ctl.pfbPlaceMapUuid"
      pfb-map-zoom="12"
-     pfb-map-center="ctl.mapCenter"
+     pfb-map-bounds="ctl.boundsConus"
      pfb-map-baselayer="ctl.baselayer"
      pfb-map-options="ctl.mapOptions"
      pfb-map-ready="ctl.onMapReady(map)">

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -70,6 +70,9 @@
 
 <!-- Map -->
 <div class="preview-map">
-    <pfb-place-map pfb-place-map-layers="placeDetail.mapLayers"></pfb-place-map>
+    <pfb-place-map
+        pfb-place-map-layers="placeDetail.mapLayers"
+        pfb-place-map-uuid="placeDetail.place.uuid">
+    </pfb-place-map>
 </div>
 <!-- Map -->

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -80,7 +80,8 @@
 
                     <!-- .result-preview should display the shapefile preview -->
                     <div class="result-preview">
-                        <pfb-thumbnail-map></pfb-thumbnail-map>
+                        <pfb-thumbnail-map pfb-thumbnail-map-place="neighborhood.uuid">
+                        </pfb-thumbnail-map>
                     </div>
                     <div class="result-title">{{neighborhood.label}}, {{neighborhood.state_abbrev}}
                         <div class="location-timestamp"><span>Last updated:</span> {{neighborhood.modifiedAt | date:'MMMM dd, yyyy'}}</div>


### PR DESCRIPTION
## Overview

Load neighborhood bounds on the thumbnail maps in home page top places cards and in places list, as in the prototype.


### Demo

In list:
![image](https://cloud.githubusercontent.com/assets/960264/25543045/fab9dcdc-2c22-11e7-8112-fd83d2d0a620.png)

On homepage:
![image](https://cloud.githubusercontent.com/assets/960264/25543071/1198a3fc-2c23-11e7-8461-f8936bd7996d.png)


### Notes

Might hold off on merging this until #368 is in, to rebase for the constants refactor.


## Testing Instructions

 * Check for proper bounds display/zoom/fit
 * In list cards: http://localhost:9301/?#/places/
 * And on home page

Closes #357
