### PR TITLE
Feature/kak/places list compare#251

### DIFF
--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -12,7 +12,8 @@
                 scrollWheelZoom: false,
                 interactive: false,
                 zoomControl: false,
-                attributionControl: false
+                attributionControl: false,
+                zoomAnimation: false
             };
 
             // will set center and zoom level by zooming to fit geojson polygon bounds when loaded
@@ -36,6 +37,20 @@
         ctl.onMapReady = function (map) {
             ctl.map = map;
 
+            ctl.map.on('layeradd', function() {
+                // Tell map to recalculate its size. Otherwise transition to compare page may
+                // result in incorrect pan/zoom to bounds.
+                ctl.map.invalidateSize(false);
+
+                if (ctl.boundsLayer) {
+                    var bounds = ctl.boundsLayer.getBounds();
+                    ctl.map.fitBounds(bounds, {
+                        maxZoom: MapConfig.conusMaxZoom,
+                        animate: false
+                    });
+                }
+            });
+
             if (ctl.pfbThumbnailMapPlace) {
                 loadBounds(ctl.pfbThumbnailMapPlace);
             }
@@ -45,7 +60,6 @@
             Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
                 ctl.boundsLayer = L.geoJSON(data, {});
                 ctl.map.addLayer(ctl.boundsLayer);
-                ctl.map.fitBounds(ctl.boundsLayer.getBounds());
             });
         }
     }

--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -20,7 +20,7 @@
                 template: '<ui-view/>'
             })
             .state('places.list', {
-                url: '',
+                url: ':place1/:place2/:place3/',
                 controller: 'PlaceListController',
                 controllerAs: 'placeList',
                 templateUrl: 'app/places/list/place-list.html'
@@ -32,7 +32,7 @@
                 templateUrl: 'app/places/detail/places-detail.html'
             })
             .state('places.compare', {
-                url: ':compare/:place1/:place2/:place3/',
+                url: '/compare/:place1/:place2/:place3/',
                 controller: 'CompareController',
                 controllerAs: 'compare',
                 templateUrl: 'app/places/compare/compare.html'

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -38,10 +38,15 @@
             });
         }
 
+        /**
+         * Remove a place selected for comparison. Update URL and clear card without reloading.
+         *
+         * @param {Integer} num Offset to clear in list of three slots for places to compare
+         */
         function clearSelection(num) {
-            var newParams = _.extend({}, $stateParams);
-            newParams['place' + (num + 1)] = '';
-            $state.go('places.compare', newParams);
+            $stateParams['place' + (num + 1)] = '';
+            ctl.places[num] = null;
+            $state.go('places.compare', $stateParams, {notify: false});
         }
 
         // navigate to places list, preserving route parameters for selected places to compare

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -18,6 +18,7 @@
         function initialize() {
             ctl.places = new Array(3);
             ctl.clearSelection = clearSelection;
+            ctl.goToPlacesList = goToPlacesList;
 
             getPlaces([$stateParams.place1, $stateParams.place2, $stateParams.place3]);
         }
@@ -41,6 +42,11 @@
             var newParams = _.extend({}, $stateParams);
             newParams['place' + (num + 1)] = '';
             $state.go('places.compare', newParams);
+        }
+
+        // navigate to places list, preserving route parameters for selected places to compare
+        function goToPlacesList() {
+            $state.go('places.list', $stateParams);
         }
     }
 

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -11,7 +11,8 @@
                 <div class="btn-group">
                     <button class="btn btn-secondary"
                         ui-sref="places.compare({place1: '', place2: '', place3: ''})">Clear Selections</button>
-                    <button ui-sref="places.list" class="btn btn-secondary">Back to Search</button>
+                    <button ng-click="compare.goToPlacesList()"
+                        class="btn btn-secondary">Back to Search</button>
                 </div>
         </div>
 

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -31,7 +31,8 @@
                             {{place.lastJob.modifiedAt | date:'MMMM dd, yyyy'}}</div>
                     </div>
                     <div class="card-map">
-                        <pfb-thumbnail-map></pfb-thumbnail-map>
+                        <pfb-thumbnail-map
+                            pfb-thumbnail-map-place="place.neighborhood.uuid"></pfb-thumbnail-map>
                     </div>
                     <ul class="metric-list">
                         <li ng-repeat="result in place.scores">{{result.metric}}

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -51,7 +51,8 @@
                     <div class="card-details">
                         <i class="icon-map"></i>
                         <div class="h2">Add a city/town to compare</div>
-                        <a ui-sref="places.list" class="btn btn-primary btn-block">Search city/towns</a>
+                        <a ng-click="compare.goToPlacesList()"
+                            class="btn btn-primary btn-block">Search city/towns</a>
                     </div>
                 </div>
             </div>

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -29,12 +29,18 @@
                         <div class="location-timestamp"><span>Last updated:</span>
                             {{place.lastJob.modifiedAt | date:'MMMM dd, yyyy'}}</div>
                     </div>
-                    <div class="card-map">s
+                    <div class="card-map">
                         <pfb-thumbnail-map></pfb-thumbnail-map>
                     </div>
-                    <ul class="metric-list" ng-repeat="result in place.scores">
-                        <li>{{result.metric}}
+                    <ul class="metric-list">
+                        <li ng-repeat="result in place.scores">{{result.metric}}
                             <span class="network-score small">{{result.score | number:0}}</span>
+                        </li>
+                        <li>
+                            <section>
+                                <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"
+                                    class="btn btn-secondary btn-block">View Place</a>
+                            </section>
                         </li>
                     </ul>
                 </div>

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -20,9 +20,9 @@
             <div class="column-4" ng-repeat="place in compare.places track by $index">
                 <div class="card stack" ng-if="place.neighborhood">
                     <div class="card-details">
-                        <!-- TODO: fix styling. Why does this not appear without btn classes? -->
-                        <a class="compare-remove btn btn-secondary"
-                            ng-click="compare.clearSelection($index)"><i class="icon-cross"></i></a>
+                        <!-- TODO: fix styling. Why does icon not appear? -->
+                        <a class="compare-remove"
+                            ng-click="compare.clearSelection($index)"><i class="icon-cross"></i>X</a>
                         <h3>{{place.neighborhood.label}}</h3>
                         <h4>{{place.neighborhood.state_abbrev}}</h4>
                         <div class="network-score large">{{place.lastJob.overall_score | number:0}}</div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -37,31 +37,26 @@
 
                 <!-- Compare dropdown -->
                 <div class="form-group">
-                    <label for="3">Compare</label>
-                    <div class="dropdown">
-                      <button class="btn btn-default dropdown-toggle btn-block" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                        3 Selected
-                        <span class="caret"></span>
-                      </button>
-
-                      <!-- We are using bootstraps dropdown js -->
-                      <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdownMenu1">
-
-                        <!-- Only up to 3 to compare. Duplicate li and children for each item -->
-                        <li>
-                            <div class="compare-title">Los Angeles, California</div>
-                            <div class="network-score small">90</div>
+                    <label for="compare-dropdown">Compare</label>
+                    <select ng-model="placeList.placeToRemoveFromComparison" name="compare-dropdown"
+                        ng-disabled="!placeList.comparePlaces.length" class="form-control"
+                        id="role" type="text">
+                    <option selected disabled value="">{{placeList.comparePlaces.length}} Selected</option>
+                    <option ng-repeat="neighborhood in placeList.comparePlaces"
+                        value="{{neighborhood.uuid}}">
+                        <div>
+                            <div class="compare-title">{{neighborhood.label}},
+                                {{neighborhood.state_abbrev}}</div>
+                            <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
                             <a href="#" class="compare-remove">Remove</a>
-                        </li>
-                        <li>
-                            <div class="compare-title">Los Angeles, California</div>
-                            <div class="network-score small">90</div>
-                            <a href="#" class="compare-remove">Remove</a>
-                        </li>
-                        <li><a href="/compare.html" class="compare-btn">Compare Neighborhoods</a></li>
-                      </ul>
-                    </div>
+                        </div>
+                    </option>
+                    <option value="compare">
+                        <a href="#" class="compare-btn">Compare Places</a>
+                    </option>
+                    </select>
                 </div>
+
             </div>
         </div>
     </div>
@@ -90,7 +85,10 @@
                 <div class="result-right">
                     <div class="network-score">{{neighborhood.overall_score | number:0}}</div>
                     <div class="compare">
-                        <button class="btn btn-toggle active">Compare <span></span></button>
+                        <button ng-disabled="neighborhood.comparing" class="btn btn-toggle active"
+                            ng-click="placeList.addPlaceToCompare(neighborhood)">Compare
+                            <span></span>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -56,7 +56,9 @@
                             </div>
                         </li>
                         <li>
-                            <a ng-click="placeList.goComparePlaces()"
+                            <!-- only go to comparison page if at least two places selected -->
+                            <a ng-click="placeList.comparePlacesCount > 1 ? placeList.goComparePlaces() : ''"
+                                ng-disabled="placeList.comparePlacesCount < 2"
                                 class="compare-btn">Compare Places</a>
                         </li>
                     </ul>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -40,8 +40,8 @@
                     <div class="btn-group" uib-dropdown is-open="status.isopen">
                         <button class="btn btn-default btn-block" type="button"
                             id="dropdown-compare" aria-haspopup="true" aria-expanded="true"
-                            uib-dropdown-toggle ng-disabled="placeList.comparePlacesCount() < 1">
-                                {{placeList.comparePlacesCount()}} Selected
+                            uib-dropdown-toggle ng-disabled="placeList.comparePlacesCount < 1">
+                                {{placeList.comparePlacesCount}} Selected
                                 <span class="caret"></span>
                         </button>
                     <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdown-compare"
@@ -90,8 +90,8 @@
                     <div class="network-score">{{neighborhood.overall_score | number:0}}</div>
                     <div class="compare">
                         <button ng-if="!neighborhood.comparing"
-                            ng-disabled="placeList.comparePlacesCount() >=3"
-                            ng-class="(placeList.comparePlacesCount() >=3) ?
+                            ng-disabled="placeList.comparePlacesCount >=3"
+                            ng-class="(placeList.comparePlacesCount >=3) ?
                                 'btn btn-toggle' : 'btn btn-toggle active'"
                             ng-click="placeList.addPlaceToCompare(neighborhood, true)">Compare
                             <span></span>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -40,7 +40,7 @@
                     <div class="btn-group" uib-dropdown is-open="status.isopen">
                         <button class="btn btn-default btn-block" type="button"
                             id="dropdown-compare" aria-haspopup="true" aria-expanded="true"
-                            uib-dropdown-toggle>
+                            uib-dropdown-toggle ng-disabled="placeList.comparePlacesCount() < 1">
                                 {{placeList.comparePlacesCount()}} Selected
                                 <span class="caret"></span>
                         </button>
@@ -51,12 +51,12 @@
                                 <div class="compare-title">{{neighborhood.label}},
                                     {{neighborhood.state_abbrev}}</div>
                                 <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
-                                <a ng-click="placeList.selectedComparePlace(neighborhood.uuid)"
+                                <a ng-click="placeList.removeComparePlace(neighborhood.uuid)"
                                     class="compare-remove">Remove</a>
                             </div>
                         </li>
                         <li>
-                            <a ng-click="placeList.selectedComparePlace('compare')"
+                            <a ng-click="placeList.goComparePlaces()"
                                 class="compare-btn">Compare Places</a>
                         </li>
                     </ul>
@@ -89,8 +89,15 @@
                 <div class="result-right">
                     <div class="network-score">{{neighborhood.overall_score | number:0}}</div>
                     <div class="compare">
-                        <button ng-disabled="neighborhood.comparing" class="btn btn-toggle active"
+                        <button ng-if="!neighborhood.comparing"
+                            ng-disabled="placeList.comparePlacesCount() >=3"
+                            ng-class="(placeList.comparePlacesCount() >=3) ?
+                                'btn btn-toggle' : 'btn btn-toggle active'"
                             ng-click="placeList.addPlaceToCompare(neighborhood, true)">Compare
+                            <span></span>
+                        </button>
+                        <button ng-if="neighborhood.comparing" class="btn btn-toggle"
+                            ng-click="placeList.removeComparePlace(neighborhood.uuid)">Remove
                             <span></span>
                         </button>
                     </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -34,29 +34,33 @@
                 </div>
             </div>
             <div class="column">
-
                 <!-- Compare dropdown -->
                 <div class="form-group">
-                    <label for="compare-dropdown">Compare</label>
-                    <select ng-model="placeList.placeToRemoveFromComparison" name="compare-dropdown"
-                        ng-disabled="!placeList.comparePlacesCount()" class="form-control"
-                        id="role" type="text">
-                    <option selected disabled value="">{{placeList.comparePlacesCount()}} Selected</option>
-                    <option ng-repeat="neighborhood in placeList.comparePlaces | filter:{uuid: '!!'}"
-                        value="{{neighborhood.uuid}}">
-                        <div>
-                            <div class="compare-title">{{neighborhood.label}},
-                                {{neighborhood.state_abbrev}}</div>
-                            <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
-                            <a href="#" class="compare-remove">Remove</a>
-                        </div>
-                    </option>
-                    <option value="compare">
-                        <a href="#" class="compare-btn">Compare Places</a>
-                    </option>
-                    </select>
+                    <label for="dropdown-compare">Compare</label>
+                    <div class="btn-group" uib-dropdown is-open="status.isopen">
+                        <button class="btn btn-default btn-block" type="button"
+                            id="dropdown-compare" aria-haspopup="true" aria-expanded="true"
+                            uib-dropdown-toggle>
+                                {{placeList.comparePlacesCount()}} Selected
+                                <span class="caret"></span>
+                        </button>
+                    <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdown-compare"
+                        uib-dropdown-menu>
+                        <li ng-repeat="neighborhood in placeList.comparePlaces | filter:{uuid: '!!'}">
+                            <div>
+                                <div class="compare-title">{{neighborhood.label}},
+                                    {{neighborhood.state_abbrev}}</div>
+                                <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
+                                <a ng-click="placeList.selectedComparePlace(neighborhood.uuid)"
+                                    class="compare-remove">Remove</a>
+                            </div>
+                        </li>
+                        <li>
+                            <a ng-click="placeList.selectedComparePlace('compare')"
+                                class="compare-btn">Compare Places</a>
+                        </li>
+                    </ul>
                 </div>
-
             </div>
         </div>
     </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -39,10 +39,10 @@
                 <div class="form-group">
                     <label for="compare-dropdown">Compare</label>
                     <select ng-model="placeList.placeToRemoveFromComparison" name="compare-dropdown"
-                        ng-disabled="!placeList.comparePlaces.length" class="form-control"
+                        ng-disabled="!placeList.comparePlacesCount()" class="form-control"
                         id="role" type="text">
-                    <option selected disabled value="">{{placeList.comparePlaces.length}} Selected</option>
-                    <option ng-repeat="neighborhood in placeList.comparePlaces"
+                    <option selected disabled value="">{{placeList.comparePlacesCount()}} Selected</option>
+                    <option ng-repeat="neighborhood in placeList.comparePlaces | filter:{uuid: '!!'}"
                         value="{{neighborhood.uuid}}">
                         <div>
                             <div class="compare-title">{{neighborhood.label}},

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -86,7 +86,7 @@
                     <div class="network-score">{{neighborhood.overall_score | number:0}}</div>
                     <div class="compare">
                         <button ng-disabled="neighborhood.comparing" class="btn btn-toggle active"
-                            ng-click="placeList.addPlaceToCompare(neighborhood)">Compare
+                            ng-click="placeList.addPlaceToCompare(neighborhood, true)">Compare
                             <span></span>
                         </button>
                     </div>

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -90,6 +90,7 @@
             }
         }
 
+        // Convenience method to transition to places comparison page.
         function goComparePlaces() {
             $state.go('places.compare', $stateParams);
         }

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -47,7 +47,8 @@
             ctl.comparePlaces = new Array(3);
             ctl.addPlaceToCompare = addPlaceToCompare;
             ctl.comparePlacesCount = comparePlacesCount;
-            ctl.selectedComparePlace = selectedComparePlace;
+            ctl.removeComparePlace = removeComparePlace;
+            ctl.goComparePlaces = goComparePlaces;
 
             ctl.sortBy = sortingOptions[0]; // default to alphabetical order
             ctl.sortingOptions = sortingOptions;
@@ -87,33 +88,33 @@
             }
         }
 
+        function goComparePlaces() {
+            $state.go('places.compare', $stateParams);
+        }
+
         /**
          * Fired when an option selected from comparison drop-down.
-         * Either remove a selected place from comparison list, or if special last option selected,
-         * go to comparison page with selections.
+         * Remove a selected place from comparison list.
+         *
+         * @param {String} uuid Neighborhood ID to remove from set of places to compare
          */
-        function selectedComparePlace(uuid) {
+        function removeComparePlace(uuid) {
             if (!uuid) {
                 return; // on page load, this watch fires will no value
             }
 
-            // use special flag for bottom list item, which is to go to the compare page
-            if (uuid === 'compare') {
-                $state.go('places.compare', $stateParams);
-            } else {
-                var removeOffset = _.findIndex(ctl.comparePlaces, function(place) {
-                    return place && place.uuid === uuid;
-                });
+            var removeOffset = _.findIndex(ctl.comparePlaces, function(place) {
+                return place && place.uuid === uuid;
+            });
 
-                if (removeOffset > -1) {
-                    // unset flag on Neighborhood marking selection for comparison
-                    ctl.comparePlaces[removeOffset].comparing = false;
-                    // remove Neighborhood from array of places selected for comparison
-                    ctl.comparePlaces[removeOffset] = null;
-                    updateComparisonsInUrl();
-                } else {
-                    $log.warn('no place with UUID ' + uuid + ' found to remove from comparison');
-                }
+            if (removeOffset > -1) {
+                // unset flag on Neighborhood marking selection for comparison
+                ctl.comparePlaces[removeOffset].comparing = false;
+                // remove Neighborhood from array of places selected for comparison
+                ctl.comparePlaces[removeOffset] = null;
+                updateComparisonsInUrl();
+            } else {
+                $log.warn('no place with UUID ' + uuid + ' found to remove from comparison');
             }
         }
 

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -43,11 +43,11 @@
             ctl.places = [];
 
             ctl.neighborhoodFilter = null;
-            ctl.placeToRemoveFromComparison = null;
 
             ctl.comparePlaces = new Array(3);
             ctl.addPlaceToCompare = addPlaceToCompare;
             ctl.comparePlacesCount = comparePlacesCount;
+            ctl.selectedComparePlace = selectedComparePlace;
 
             ctl.sortBy = sortingOptions[0]; // default to alphabetical order
             ctl.sortingOptions = sortingOptions;
@@ -57,7 +57,6 @@
             getPlaces();
             loadOptions();
             $scope.$watch(function(){return ctl.neighborhoodFilter;}, filterNeighborhood);
-            $scope.$watch(function(){return ctl.placeToRemoveFromComparison;}, selectedComparePlace);
         }
 
         /**
@@ -115,10 +114,6 @@
                 } else {
                     $log.warn('no place with UUID ' + uuid + ' found to remove from comparison');
                 }
-
-                // be sure to clear current selection once removing it as an option
-                // sometimes angular does this on its own, but it doesn't seem to be consistent
-                ctl.placeToRemoveFromComparison = null;
             }
         }
 

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -103,7 +103,7 @@
                 $state.go('places.compare', $stateParams);
             } else {
                 var removeOffset = _.findIndex(ctl.comparePlaces, function(place) {
-                    return place.uuid === uuid;
+                    return place && place.uuid === uuid;
                 });
 
                 if (removeOffset > -1) {

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -46,9 +46,10 @@
 
             ctl.comparePlaces = new Array(3);
             ctl.addPlaceToCompare = addPlaceToCompare;
-            ctl.comparePlacesCount = comparePlacesCount;
             ctl.removeComparePlace = removeComparePlace;
             ctl.goComparePlaces = goComparePlaces;
+            // convenience property to track number of selected places; must be updated on add/remove
+            ctl.comparePlacesCount = 0;
 
             ctl.sortBy = sortingOptions[0]; // default to alphabetical order
             ctl.sortingOptions = sortingOptions;
@@ -78,6 +79,7 @@
             if (firstEmpty > -1) {
                 place.comparing = true;
                 ctl.comparePlaces[firstEmpty] = place;
+                ctl.comparePlacesCount++;
                 // update URL to include place to compare, to retain state in case of page refresh
                 if (updateUrl) {
                     updateComparisonsInUrl();
@@ -112,21 +114,11 @@
                 ctl.comparePlaces[removeOffset].comparing = false;
                 // remove Neighborhood from array of places selected for comparison
                 ctl.comparePlaces[removeOffset] = null;
+                ctl.comparePlacesCount--;
                 updateComparisonsInUrl();
             } else {
                 $log.warn('no place with UUID ' + uuid + ' found to remove from comparison');
             }
-        }
-
-        // convenience method to track number of selected places
-        function comparePlacesCount() {
-            return _.reduce(ctl.comparePlaces, function(sum, place) {
-                if (place) {
-                    return sum + 1;
-                } else {
-                    return sum;
-                }
-            }, 0);
         }
 
         // helper to update URL after places added or removed for comparison, without reloading

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -151,6 +151,9 @@
                 params.neighborhood = ctl.neighborhoodFilter.uuid;
             }
 
+            ctl.comparePlacesCount = 0;
+            ctl.comparePlaces = new Array(3);
+
             // Read out pre-set places to compare from the URL. Keep this state in the URL
             // so user can navigate between places list and comparison without losing selections.
             var uuidsToCompare = [$stateParams.place1, $stateParams.place2, $stateParams.place3];

--- a/src/angularjs/src/styles/pages/_mapping.scss
+++ b/src/angularjs/src/styles/pages/_mapping.scss
@@ -182,6 +182,28 @@ section.active {
   @include respond-to('sm-down') {
     display: none;
   }
+
+  .card {
+    z-index: 1;
+    height: auto;
+    width: 240px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+
+        @include respond-to(xs) {
+          position: absolute;
+          width: 100%;
+          transform: none;
+          top: initial;
+
+          .card-details {
+            padding: 1rem;
+          }
+        }
+    }
 }
 
 section.paginate {


### PR DESCRIPTION
## Overview

Implement comparison feature on places list page.

### Demo

![image](https://cloud.githubusercontent.com/assets/960264/25589078/2cc22150-2e79-11e7-8f6a-942a933a7d94.png)


### Notes

Dropdown list items are currently unstyled.

Also added a footer to the comparison page cards to link to the place detail, since that was in the wireframes.

Refactored some of the comparison place tracking to preserve the offsets of selections, so the cards don't shift around on going back and forth between the place list and comparison pages after removing a selection.


## Testing Instructions

 * Go to [places list](http://localhost:9301/#/places////)
 * Should be able to add and remove places for comparison
 * Shouldn't be able to add the same place twice
 * Should be able to get to comparison page with current selections using last option in compare drop-down
 * Should be able to move between compare and list page with selections preserved

Closes #251
