### PR TITLE
Add Leaflet images to dist build

### DIFF
--- a/src/angularjs/gulp/build.js
+++ b/src/angularjs/gulp/build.js
@@ -79,6 +79,16 @@ gulp.task('images', function () {
     .pipe(gulp.dest(path.join(conf.paths.dist, '/assets/images/')));
 });
 
+gulp.task('leaflet', function () {
+    return gulp.src(path.join(conf.paths.bower, '/leaflet/dist/images/*'))
+    .pipe($.imagemin({
+      optimizationLevel: 3,
+      progressive: true,
+      interlaced: true
+    }))
+    .pipe(gulp.dest(path.join(conf.paths.dist, '/styles/images/')));
+});
+
 gulp.task('favicons', function () {
     return gulp.src(path.join(conf.paths.src, '/assets/favicons/**/*'))
         .pipe(gulp.dest(path.join(conf.paths.dist, '/')));
@@ -109,4 +119,4 @@ gulp.task('clean', function () {
   return $.del([path.join(conf.paths.dist, '/'), path.join(conf.paths.tmp, '/')]);
 });
 
-gulp.task('build', ['html', 'images', 'favicons', 'fonts', 'other']);
+gulp.task('build', ['html', 'images', 'leaflet', 'favicons', 'fonts', 'other']);

--- a/src/angularjs/gulp/conf.js
+++ b/src/angularjs/gulp/conf.js
@@ -13,6 +13,7 @@ var gutil = require('gulp-util');
  */
 exports.paths = {
     src: 'src',
+    bower: 'bower_components',
     dist: 'dist',
     tmp: '.tmp',
     e2e: 'e2e'


### PR DESCRIPTION
## Overview

Apparently Leaflet does not properly include image assets in its bower configuration for the bower gulp plugin to pick up, so explicitly include them when gathering image assets.


### Notes

Leaflet expects its images to be in a different location (`/styles/images/`) than where our other images are stored (`/assets/images/`). So, broke this out into a separate task from the app image gulp task.


## Testing Instructions

Inside VM:
* rebuild assets for production: `docker-compose build angularjs`
* restart containers: `./scripts/server`
* log into frontend container: `./scripts/console angularjs -it /bin/bash`
* check out images: `cd dist/styles/images/`

Should have leaflet images in directory, including `layers.png`. Path should match what staging/prod servers are expecting, which is a relative path like `/styles/images/layers.png`.

Closes #374

