### PR TITLE
Add feedback link

### DIFF
--- a/src/angularjs/src/app/components/navbar/navbar.html
+++ b/src/angularjs/src/app/components/navbar/navbar.html
@@ -14,6 +14,8 @@
           <a ui-sref="places.list">All locations</a>
           <a href="#">About</a>
           <a href="#">Methodology</a>
+          <a href="http://www.peopleforbikes.org/placesforbikes/pages/bike-network-analysis"
+            target="_blank">Feedback</a>
           <a href="http://www.peopleforbikes.org/" target="_blank">People for bikes</a>
         </span>
         <span ng-if="navbar.admin">


### PR DESCRIPTION
## Overview

In navbar for public site, add link to feedback page.
Closes #351.


### Demo

![image](https://cloud.githubusercontent.com/assets/960264/25668455/b3e7b524-2ff4-11e7-8724-d39872e03b67.png)


## Testing Instructions

 * Link should appear on public site navbar and not in admin site navbar
 * Should open feedback page in new tab


Closes #351
