### PR TITLE
Add log in/out links to footer

### DIFF
--- a/src/angularjs/src/app/components/footer/footer.directive.js
+++ b/src/angularjs/src/app/components/footer/footer.directive.js
@@ -11,7 +11,16 @@
     'use strict';
 
     /** @ngInject */
-    function FooterController() {
+    function FooterController(AuthService) {
+        var ctl = this;
+
+        initialize();
+
+        function initialize() {
+            ctl.logout = AuthService.logout;
+            // if user ID cookie is set, assume user is logged in
+            ctl.loggedIn = !!AuthService.getUserId();
+        }
     }
 
     function pfbFooter() {

--- a/src/angularjs/src/app/components/footer/footer.html
+++ b/src/angularjs/src/app/components/footer/footer.html
@@ -11,6 +11,8 @@
             <a href="#">About</a>
             <a href="#">Methodology</a>
             <a href="http://www.peopleforbikes.org/" target="_blank">People for bikes</a>
+            <a ng-if="footer.loggedIn" ui-sref="login" ng-click="footer.logout()">Sign Out</a>
+            <a ng-if="!footer.loggedIn" ui-sref="login">Sign In</a>
         </nav>
     </div>
 </footer>


### PR DESCRIPTION
## Overview

For access to admin site login from public site.


### Demo

![image](https://cloud.githubusercontent.com/assets/960264/25679444/61e616fe-301b-11e7-8b13-8f093baae866.png)


### Notes

Supersedes #391. Since the public site doesn't function yet without logged-in API access, attempting to view home page when logged out will still simply redirect to login (Only 'sign out' link can be seen in footer currently.)


## Testing Instructions

 * Should be able to log out via 'Sign out' link in public page footer; should redirect to login page


Closes #312
