### PR TITLE
Feature/kak/direct geojson serialization#373

### DIFF
--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 
 from pfb_analysis.models import AnalysisJob, Neighborhood
 from pfb_network_connectivity.serializers import PFBModelSerializer
-from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 
 class PrimaryKeyReferenceRelatedField(serializers.PrimaryKeyRelatedField):
@@ -61,24 +60,6 @@ class NeighborhoodSerializer(PFBModelSerializer):
                    'geom_pt',)
         read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
                             'organization', 'name',)
-
-
-class NeighborhoodGeoJsonSerializer(GeoFeatureModelSerializer):
-
-    class Meta:
-        model = Neighborhood
-        id_field = 'uuid'
-        geo_field = 'geom_pt'
-        fields = ('uuid', 'name', 'label', 'state_abbrev', 'organization', 'geom_pt')
-
-
-class NeighborhoodBoundsGeoJsonSerializer(GeoFeatureModelSerializer):
-
-    class Meta:
-        model = Neighborhood
-        id_field = 'uuid'
-        geo_field = 'geom_simple'
-        fields = ('uuid', 'name', 'label', 'state_abbrev', 'organization', 'geom_simple')
 
 
 class NeighborhoodSummarySerializer(PFBModelSerializer):

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -1,13 +1,15 @@
 from collections import OrderedDict
 from datetime import datetime
+import logging
 
 import us
 
-from django.db import connection
+from django.db import connection, DataError
 from django.utils.text import slugify
 
 from rest_framework import status
 from rest_framework.decorators import detail_route
+from rest_framework.exceptions import NotFound
 from rest_framework.filters import DjangoFilterBackend, OrderingFilter
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
@@ -19,10 +21,11 @@ from pfb_network_connectivity.permissions import IsAdminOrgAndAdminCreateEditOnl
 
 from .models import AnalysisJob, Neighborhood
 from .serializers import (AnalysisJobSerializer,
-                          NeighborhoodSerializer,
-                          NeighborhoodGeoJsonSerializer,
-                          NeighborhoodBoundsGeoJsonSerializer)
+                          NeighborhoodSerializer)
 from .filters import AnalysisJobFilterSet
+
+
+logger = logging.getLogger(__name__)
 
 
 class AnalysisJobViewSet(ModelViewSet):
@@ -70,18 +73,13 @@ class AnalysisJobViewSet(ModelViewSet):
             return Response(None, status=status.HTTP_404_NOT_FOUND)
 
 
-class NeighborhoodMixin(APIView):
-    """Shared properties of the neighborhood viewsets."""
+class NeighborhoodViewSet(ModelViewSet):
+    """For listing or retrieving neighborhoods."""
 
     queryset = Neighborhood.objects.all()
     permission_classes = (IsAdminOrgAndAdminCreateEditOnly,)
     filter_fields = ('organization', 'name', 'label', 'state_abbrev')
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
-
-
-class NeighborhoodViewSet(NeighborhoodMixin, ModelViewSet):
-    """For listing or retrieving neighborhoods."""
-
     serializer_class = NeighborhoodSerializer
     pagination_class = OptionalLimitOffsetPagination
     ordering_fields = ('created_at',)
@@ -92,17 +90,81 @@ class NeighborhoodViewSet(NeighborhoodMixin, ModelViewSet):
                             name=slugify(serializer.validated_data['label']))
 
 
-class NeighborhoodBoundsGeoJsonViewSet(NeighborhoodMixin, ReadOnlyModelViewSet):
-    """For retrieving neighborhood bounds multipolygon as GeoJSON feature collection."""
+class NeighborhoodBoundsGeoJsonViewList(APIView):
+    """For retrieving all neighborhood bounds multipolygons as GeoJSON feature collection."""
 
-    serializer_class = NeighborhoodBoundsGeoJsonSerializer
     pagination_class = None
+    filter_class = None
+
+    def get(self, request, format=None, *args, **kwargs):
+        query = """
+        SELECT row_to_json(fc)
+        FROM (
+            SELECT 'FeatureCollection' AS type,
+                array_to_json(array_agg(f)) AS features
+            FROM (SELECT 'Feature' AS type,
+                  ST_AsGeoJSON(g.geom_simple)::json AS geometry,
+                  g.uuid AS id,
+                  row_to_json((SELECT p FROM (
+                    SELECT uuid AS id, name, label, state_abbrev, organization_id) AS p))
+                    AS properties
+            FROM pfb_analysis_neighborhood AS g) AS f) AS fc;
+        """
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            json = cursor.fetchone()
+            if not json or not len(json):
+                return Response({})
+
+        return Response(json[0])
+
+
+class NeighborhoodBoundsGeoJsonViewDetail(APIView):
+    """For retrieving a single neighborhood bound multipolygon as GeoJSON feature collection."""
+
+    pagination_class = None
+    filter_class = None
+
+    def get(self, request, format=None, *args, **kwargs):
+        query = """
+        SELECT row_to_json(fc)
+        FROM (
+            SELECT 'FeatureCollection' AS type,
+                array_to_json(array_agg(f)) AS features
+            FROM (SELECT 'Feature' AS type,
+                  ST_AsGeoJSON(g.geom_simple)::json AS geometry,
+                  g.uuid AS id,
+                  row_to_json((SELECT p FROM (
+                    SELECT uuid AS id, name, label, state_abbrev, organization_id) AS p))
+                    AS properties
+            FROM pfb_analysis_neighborhood AS g WHERE g.uuid = %s) AS f) AS fc;
+        """
+
+        # get the neighborhood ID from the request
+        uuid = kwargs.get('neighborhood', '')
+        if not uuid:
+            return Response({})
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(query, [uuid])
+                json = cursor.fetchone()
+                if not json or not len(json):
+                    return Response({})
+        except DataError:
+            raise NotFound(detail='{} is not a valid neighborhood UUID.'.format(uuid))
+
+        return Response(json[0])
 
 
 class NeighborhoodGeoJsonViewSet(APIView):
     """For retrieving all neighborhood centroids as GeoJSON feature collection."""
 
-    def get(self, request, format=None):
+    pagination_class = None
+    filter_class = None
+
+    def get(self, request, format=None, *args, **kwargs):
         """
         Uses raw query for fetching as GeoJSON because it is much faster to let PostGIS generate
         than Djangonauts serializer.
@@ -131,5 +193,8 @@ class NeighborhoodGeoJsonViewSet(APIView):
 class USStateView(APIView):
     """Convenience endpoint for available U.S. state options."""
 
-    def get(self, request, format=None):
+    pagination_class = None
+    filter_class = None
+
+    def get(self, request, format=None, *args, **kwargs):
         return Response([{'abbr': state.abbr, 'name': state.name} for state in us.STATES])

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -69,7 +69,6 @@ INSTALLED_APPS = [
     'django_filters',
     'localflavor',
     'rest_framework',
-    'rest_framework_gis',
     'rest_framework.authtoken',
     'storages',
     'watchman',
@@ -205,7 +204,6 @@ logging.config.dictConfig({
             'handlers': ['console'],
             'level': DJANGO_LOG_LEVEL,
         }
-
     }
 })
 

--- a/src/django/pfb_network_connectivity/urls.py
+++ b/src/django/pfb_network_connectivity/urls.py
@@ -29,9 +29,6 @@ router.register(r'organizations', user_views.OrganizationViewSet, base_name='org
 router.register(r'users', user_views.PFBUserViewSet, base_name='users')
 router.register(r'analysis_jobs', analysis_views.AnalysisJobViewSet, base_name='analysis_jobs')
 router.register(r'neighborhoods', analysis_views.NeighborhoodViewSet, base_name='neighborhoods')
-router.register(r'neighborhoods_geojson',
-                analysis_views.NeighborhoodGeoJsonViewSet,
-                base_name='neighborhoods_geojson')
 router.register(r'neighborhoods_bounds_geojson',
                 analysis_views.NeighborhoodBoundsGeoJsonViewSet,
                 base_name='neighborhoods_bounds_geojson')
@@ -44,6 +41,9 @@ urlpatterns = [
 
     # US States View
     url(r'^api/states/', analysis_views.USStateView.as_view()),
+
+    # Neighborhood points set
+    url(r'^api/neighborhoods_geojson/', analysis_views.NeighborhoodGeoJsonViewSet.as_view()),
 
     # User Views
     url(r'^api/login/', user_views.PFBUserLoginView.as_view()),

--- a/src/django/pfb_network_connectivity/urls.py
+++ b/src/django/pfb_network_connectivity/urls.py
@@ -29,9 +29,6 @@ router.register(r'organizations', user_views.OrganizationViewSet, base_name='org
 router.register(r'users', user_views.PFBUserViewSet, base_name='users')
 router.register(r'analysis_jobs', analysis_views.AnalysisJobViewSet, base_name='analysis_jobs')
 router.register(r'neighborhoods', analysis_views.NeighborhoodViewSet, base_name='neighborhoods')
-router.register(r'neighborhoods_bounds_geojson',
-                analysis_views.NeighborhoodBoundsGeoJsonViewSet,
-                base_name='neighborhoods_bounds_geojson')
 
 
 urlpatterns = [
@@ -44,6 +41,13 @@ urlpatterns = [
 
     # Neighborhood points set
     url(r'^api/neighborhoods_geojson/', analysis_views.NeighborhoodGeoJsonViewSet.as_view()),
+
+    # Neighborhood bounds
+    url(r'^api/neighborhoods_bounds_geojson/$',
+        analysis_views.NeighborhoodBoundsGeoJsonViewList.as_view()),
+    url(r'^api/neighborhoods_bounds_geojson/(?P<neighborhood>[0-9a-f-]+)/$',
+        analysis_views.NeighborhoodBoundsGeoJsonViewDetail.as_view()),
+
 
     # User Views
     url(r'^api/login/', user_views.PFBUserLoginView.as_view()),

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -5,7 +5,6 @@ Django==1.10.7
 psycopg2==2.7.1
 
 djangorestframework==3.6.2
-djangorestframework-gis==0.11
 django-filter==1.0.2
 boto3==1.4.4
 fiona==1.7.4

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,18 +1,18 @@
 # Django and psycopg2 are included in the django base container but repeated here
 # so that the analysis container will know to install them. These should be kept
 # in sync with the versions in the base container.
-Django==1.10.3
-psycopg2==2.6.2
+Django==1.10.7
+psycopg2==2.7.1
 
-djangorestframework==3.5.3
+djangorestframework==3.6.2
 djangorestframework-gis==0.11
-django-filter==1.0.1
+django-filter==1.0.2
 boto3==1.4.4
 fiona==1.7.4
 django-amazon-ses==0.3.0
-django-extensions==1.7.6
+django-extensions==1.7.9
 django-localflavor==1.4.1
 django-storages==1.5.2
-django-watchman==0.11.1
+django-watchman==0.12
 requests==2.13.0
 us==0.9.1


### PR DESCRIPTION
## Overview

To address API performance issues reported in #373, directly serialize GeoJSON responses in database. Removes Djangonauts serializer.

### Demo

Public UI front page json load times before:
![pfb_local_geojson_load_times_before](https://cloud.githubusercontent.com/assets/960264/25761028/583b3002-31a7-11e7-81c7-224b34855b04.png)

Public UI front page json load times after:
![pfb_local_geojson_load_times_after](https://cloud.githubusercontent.com/assets/960264/25761036/5d560832-31a7-11e7-9aef-528872da4d53.png)

These are for a database with only five neighborhoods loaded. For a larger set, the improvements should be considerably greater.

Single [query for raw GeoJSON of neighborhood points](http://localhost:9200/api/neighborhoods/?format=json), before:
![pfb_neighborhoods_geojson_querying_json_directly_before](https://cloud.githubusercontent.com/assets/960264/25761114/affc0dfc-31a7-11e7-9d7c-97b184088ddc.png)

After:
![pfb_neighborhoods_geojson_raw_query_after](https://cloud.githubusercontent.com/assets/960264/25761119/b3b84b18-31a7-11e7-8e19-543f392600fe.png)


### Notes

Intend to leave #373 open until deployed to production, where performance effect can be better evaluated.

Also bumped minor/bugfix versions of the Django dependencies.

When permissions modified on neighborhoods in #387, these queries will need to modifed to filter appropriately.

## Testing Instructions

 * Rebuild Django container
 * Should get neighborhood points from http://localhost:9200/api/neighborhoods_geojson/
 * Should get all neighborhood bounds from http://localhost:9200/api/neighborhoods_bounds_geojson/
 * Should get a single neighborhood bound from http://localhost:9200/api/neighborhoods_bounds_geojson/<uuid>/
 * Front end should continue to function as expected


Connects #373
