### PR TITLE
Text changes to UI to use 'place'

### DIFF
--- a/src/angularjs/src/app/components/footer/footer.html
+++ b/src/angularjs/src/app/components/footer/footer.html
@@ -7,10 +7,10 @@
             </a>
         </div>
         <nav class="footer-right">
-            <a ui-sref="places.list">All locations</a>
+            <a ui-sref="places.list">All places</a>
             <a href="#">About</a>
             <a ui-sref="methodology">Methodology</a>
-            <a href="http://www.peopleforbikes.org/" target="_blank">People for bikes</a>
+            <a href="http://www.peopleforbikes.org/" target="_blank">PeopleForBikes</a>
             <a ng-if="footer.loggedIn" ui-sref="login" ng-click="footer.logout()">Sign Out</a>
             <a ng-if="!footer.loggedIn" ui-sref="login">Sign In</a>
         </nav>

--- a/src/angularjs/src/app/components/navbar/navbar.html
+++ b/src/angularjs/src/app/components/navbar/navbar.html
@@ -11,12 +11,12 @@
     <div class="navbar-right">
       <nav>
         <span ng-if="!navbar.admin">
-          <a ui-sref="places.list">All locations</a>
+          <a ui-sref="places.list">All places</a>
           <a href="#">About</a>
           <a ui-sref="methodology">Methodology</a>
           <a href="http://www.peopleforbikes.org/placesforbikes/pages/bike-network-analysis"
             target="_blank">Feedback</a>
-          <a href="http://www.peopleforbikes.org/" target="_blank">People for bikes</a>
+          <a href="http://www.peopleforbikes.org/" target="_blank">PeopleForBikes</a>
         </span>
         <span ng-if="navbar.admin">
           <a ui-sref="admin.help">Help</a>

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -4,7 +4,7 @@
     <div class="container text-center">
         <img src="assets/images/placesforbikes-icon.png" alt="Places for bikes" class="pfb-logo">
         <div class="pfb-logo-text">PlacesForBikes Network Score</div>
-        <h1>Learn how biking in your city/town stacks up against other cities/towns in terms of biking</h1>
+        <h1>Learn how biking in your place stacks up against other places in terms of biking</h1>
     </div>
 </header>
 <!-- Top most header with hero image -->

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -1,13 +1,13 @@
 <h2 class="decor">
     <i class="icon-map"></i>
-    Is your city/town on the map?
+    Is your place on the map?
 </h2>
 <div class="overview-map">
     <div class="card">
         <div class="card-details">
             <div class="overview-total">{{ ctl.count || "--" }}</div>
-            <div class="overview-total-label">Cities/Towns Nationwide</div>
-            <a ui-sref="places.list" class="btn btn-primary">Find your City/Town
+            <div class="overview-total-label">Places Nationwide</div>
+            <a ui-sref="places.list" class="btn btn-primary">Find your Place
                 <i class="icon-arrow-right"></i>
             </a>
         </div>

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -5,7 +5,7 @@
     <div class="container">
         <h2 class="decor">
             <i class="icon-compare"></i>
-            City/Town Comparison
+            Place Comparison
         </h2>
         <div class="row align-center">
                 <div class="btn-group">
@@ -51,9 +51,9 @@
                 <div class="card compare-placeholder" ng-if="!place.neighborhood">
                     <div class="card-details">
                         <i class="icon-map"></i>
-                        <div class="h2">Add a city/town to compare</div>
+                        <div class="h2">Add a place to compare</div>
                         <a ng-click="compare.goToPlacesList()"
-                            class="btn btn-primary btn-block">Search city/towns</a>
+                            class="btn btn-primary btn-block">Search places</a>
                     </div>
                 </div>
             </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -6,11 +6,11 @@
 
     <!-- Everything in .sidebar-header will not scroll.  -->
     <div class="sidebar-header">
-        <h2 class="sidebar-title">City/Town Search</h2>
+        <h2 class="sidebar-title">Place Search</h2>
         <div class="row">
             <div class="column">
                 <div class="form-group">
-                    <label for="neighborhood-filter">Filter by city or town name</label>
+                    <label for="neighborhood-filter">Filter by place name</label>
                     <input name="neighborhood-filter" ng-model="placeList.neighborhoodFilter"
                         type="text" class="form-control"
                         uib-typeahead="neighborhood as (neighborhood.label + ', ' +


### PR DESCRIPTION
## Overview

Replace occurrences of 'city/town' or 'location' with 'place'.
Also remove spaces from 'People for Bikes' in header and footer.

Addresses items 1-4 in the [document](https://docs.google.com/a/azavea.com/document/d/1NNj8k7D8ySqROuCA2QQkWZfb4HB9zxjzVlsDISr4P6E/edit?usp=sharing) linked to on #380.


### Notes

Searched for occurrences of 'city' or 'town' in the angular app and replaced all user-facing occurrences with 'place'.

The document calls for taking the spaces out of 'People for Bikes' in the header, replacing with camel case. While that looks fine in the footer, the header does an uppercase text transform, so the camel casing is lost. Tried excluding the uppercase transform from just that link text, but it looked odd next to the others. Here's how it is now:
![image](https://cloud.githubusercontent.com/assets/960264/25763792/ccc16f3a-31b2-11e7-8099-44ce7ba0ac94.png)

Maybe @designmatty knows of a better way to present that.


## Testing Instructions

 * Should have text changes from document applied
 * Should no longer have user facing 'city' or 'town' text


Closes #380 
