### PR TITLE
Allow read-only access to neighborhoods and analysis jobs

### DIFF
--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -8,6 +8,7 @@ from django.utils.text import slugify
 from rest_framework import status
 from rest_framework.decorators import detail_route
 from rest_framework.filters import DjangoFilterBackend, OrderingFilter
+from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from rest_framework.response import Response
@@ -29,7 +30,7 @@ class AnalysisJobViewSet(ModelViewSet):
 
     queryset = AnalysisJob.objects.all()
     serializer_class = AnalysisJobSerializer
-    permission_classes = (RestrictedCreate,)
+    permission_classes = (RestrictedCreate, DjangoModelPermissionsOrAnonReadOnly)
     filter_class = AnalysisJobFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
     ordering_fields = ('created_at', 'modified_at', 'overall_score', 'neighborhood__label',
@@ -73,7 +74,7 @@ class NeighborhoodMixin(APIView):
     """Shared properties of the neighborhood viewsets."""
 
     queryset = Neighborhood.objects.all()
-    permission_classes = (IsAdminOrgAndAdminCreateEditOnly,)
+    permission_classes = (IsAdminOrgAndAdminCreateEditOnly, DjangoModelPermissionsOrAnonReadOnly)
     filter_fields = ('organization', 'name', 'label', 'state_abbrev')
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
 

--- a/src/django/pfb_network_connectivity/filters.py
+++ b/src/django/pfb_network_connectivity/filters.py
@@ -19,6 +19,8 @@ class OrgAutoFilterBackend(filters.BaseFilterBackend):
     """Filter that only allows users to see their organization's own objects."""
 
     def filter_queryset(self, request, queryset, view):
+        if not hasattr(request.user, 'organization'):
+            return queryset
         if queryset.model == Organization:
             return queryset.filter(uuid=request.user.organization_id)
         elif queryset.model == AnalysisJob:
@@ -31,7 +33,7 @@ class OrgOrAdminAutoFilterBackend(filters.BaseFilterBackend):
     """Filter that allows non-admin users to see only their own organization's objects."""
 
     def filter_queryset(self, request, queryset, view):
-        if is_admin_org(request.user):
+        if not hasattr(request.user, 'organization') or is_admin_org(request.user):
             return queryset
         elif queryset.model == Organization:
             return queryset.filter(uuid=request.user.organization_id)
@@ -43,7 +45,7 @@ class SelfUserAutoFilterBackend(filters.BaseFilterBackend):
     """Filter used on users endpoint to limit queryset to only user if user is not admin."""
 
     def filter_queryset(self, request, queryset, view):
-        if is_admin(request.user):
+        if not hasattr(request.user, 'organization') or is_admin_org(request.user):
             return queryset
         else:
             return queryset.filter(uuid=request.user.uuid)

--- a/src/django/pfb_network_connectivity/permissions.py
+++ b/src/django/pfb_network_connectivity/permissions.py
@@ -14,7 +14,7 @@ def is_admin(user):
     Returns:
         bool: True if user has an admin role
     """
-    return user.role == UserRoles.ADMIN
+    return hasattr(user, 'organization') and user.role == UserRoles.ADMIN
 
 
 def is_editor(user):
@@ -131,11 +131,11 @@ class RestrictedCreate(permissions.BasePermission):
             request (rest_framework.request.Request): request to check for
         """
 
-        if not request.user or not request.user.is_authenticated():
-            return False
-
         if request.method in permissions.SAFE_METHODS:
             return True
+
+        if not request.user or not request.user.is_authenticated():
+            return False
 
         if 'AnalysisJobViewSet' == view.__class__.__name__:
             return request.user.role != UserRoles.VIEWER


### PR DESCRIPTION
## Overview

Allow read-only access to neighborhoods and analysis jobs, to support use of the public site without login. 


## Testing Instructions

 * Log out of UI and API
 * Should be able to get results from http://localhost:9200/api/neighborhoods/
 * Should be able to get results from http://localhost:9200/api/analysis_jobs/
 * Should not be able to perform POST operations on those endpoints
 * Should not be able to access other, protected endpoints, i.e. http://localhost:9200/api/organizations/


Closes #382.
