### PR TITLE
Fixup admin users unable to create AnalysisJob/Neighborhood

### DIFF
--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -11,7 +11,7 @@ from rest_framework import status
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
 from rest_framework.filters import DjangoFilterBackend, OrderingFilter
-from rest_framework.permissions import (AllowAny, DjangoModelPermissionsOrAnonReadOnly)
+from rest_framework.permissions import (AllowAny, IsAuthenticatedOrReadOnly)
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from rest_framework.response import Response
@@ -34,7 +34,7 @@ class AnalysisJobViewSet(ModelViewSet):
 
     queryset = AnalysisJob.objects.all()
     serializer_class = AnalysisJobSerializer
-    permission_classes = (RestrictedCreate, DjangoModelPermissionsOrAnonReadOnly)
+    permission_classes = (RestrictedCreate, IsAuthenticatedOrReadOnly)
     filter_class = AnalysisJobFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
     ordering_fields = ('created_at', 'modified_at', 'overall_score', 'neighborhood__label',
@@ -78,7 +78,7 @@ class NeighborhoodViewSet(ModelViewSet):
     """For listing or retrieving neighborhoods."""
 
     queryset = Neighborhood.objects.all()
-    permission_classes = (IsAdminOrgAndAdminCreateEditOnly, DjangoModelPermissionsOrAnonReadOnly)
+    permission_classes = (IsAdminOrgAndAdminCreateEditOnly, IsAuthenticatedOrReadOnly)
     filter_fields = ('organization', 'name', 'label', 'state_abbrev')
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
     serializer_class = NeighborhoodSerializer


### PR DESCRIPTION
## Overview

Restores lost ability to create AnalysisJob/Neighborhood objects as an admin user. 

### Notes

Permissions are implemented via custom Permission classes,
and do not interface with the Django model permissions feature.

So IsAuthenticatedOrReadOnly is sufficient here.

## Testing Instructions

Ensure a public user can still access GET for analysisjob, neighborhood and the geojson endpoints.

Ensure a logged in viewer user can view the same GET endpoints, but no user/org info or write to analysisjob/neighborhood

Ensure an admin user can write to everything.

Connects #402 
