### PR TITLE
Fallback to 2013 jobs data if 2014 can't be pulled

### DIFF
--- a/src/analysis/connectivity/census_block_jobs.sql
+++ b/src/analysis/connectivity/census_block_jobs.sql
@@ -3,8 +3,8 @@
 -- location: neighborhood
 -- data downloaded from http://lehd.ces.census.gov/data/
 -- or http://lehd.ces.census.gov/data/lodes/LODES7/
---     "ma_od_main_JT00_2014".csv
---     ma_od_aux_JT00_2014.csv
+--     "ma_od_main_JT00_{year}".csv
+--     ma_od_aux_JT00_{year}.csv
 -- import to DB and check the block id to have 15 characters
 -- also aggregate so 1 block has 1 number of total jobs
 --     (total jobs comes from S000 field
@@ -12,16 +12,16 @@
 ----------------------------------------
 
 -- process imported tables
-ALTER TABLE "state_od_aux_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
-UPDATE "state_od_aux_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
-ALTER TABLE "state_od_main_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
-UPDATE "state_od_main_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
+ALTER TABLE "state_od_aux_JT00" ALTER COLUMN w_geocode TYPE VARCHAR(15);
+UPDATE "state_od_aux_JT00" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
+ALTER TABLE "state_od_main_JT00" ALTER COLUMN w_geocode TYPE VARCHAR(15);
+UPDATE "state_od_main_JT00" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
 
 -- indexes
-CREATE INDEX IF NOT EXISTS tidx_auxjtw ON "state_od_aux_JT00_2014" (w_geocode);
-CREATE INDEX IF NOT EXISTS tidx_mainjtw ON "state_od_main_JT00_2014" (w_geocode);
-ANALYZE "state_od_aux_JT00_2014" (w_geocode);
-ANALYZE "state_od_main_JT00_2014" (w_geocode);
+CREATE INDEX IF NOT EXISTS tidx_auxjtw ON "state_od_aux_JT00" (w_geocode);
+CREATE INDEX IF NOT EXISTS tidx_mainjtw ON "state_od_main_JT00" (w_geocode);
+ANALYZE "state_od_aux_JT00" (w_geocode);
+ANALYZE "state_od_main_JT00" (w_geocode);
 
 -- create combined table
 DROP TABLE IF EXISTS generated.neighborhood_census_block_jobs;
@@ -40,7 +40,7 @@ FROM    neighborhood_census_blocks blocks;
 UPDATE  generated.neighborhood_census_block_jobs
 SET     jobs = COALESCE((
             SELECT  SUM(j."S000")
-            FROM    "state_od_main_JT00_2014" j
+            FROM    "state_od_main_JT00" j
             WHERE   j.w_geocode = neighborhood_census_block_jobs.blockid10
         ),0);
 
@@ -49,7 +49,7 @@ UPDATE  generated.neighborhood_census_block_jobs
 SET     jobs =  jobs +
                 COALESCE((
                     SELECT  SUM(j."S000")
-                    FROM    "state_od_aux_JT00_2014" j
+                    FROM    "state_od_aux_JT00" j
                     WHERE   j.w_geocode = neighborhood_census_block_jobs.blockid10
         ),0);
 


### PR DESCRIPTION
## Overview

Adds some logic to attempt downloading 2013 jobs data if wget encounters an error response. I didn't see a way to safely and consistently better scope the condition to only a 404 error.


### Demo

![screen shot 2017-05-09 at 16 29 19](https://cloud.githubusercontent.com/assets/1818302/25872066/6ac0466c-34d7-11e7-85ae-d6b987bfa53e.png)


### Notes

List of wget error codes: https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html


## Testing Instructions

 Download the [Casper, WY shapefile](https://s3.amazonaws.com/production-pfb-storage-us-east-1/neighborhood_boundaries/casper-wy/casper-wy.zip) and create a new neighborhood in development. Then trigger a local job after creating one for this boundary via the admin UI. Let it run through the jobs import and ensure that the 2013 data is subbed for the 2014 data. Consider killing the job after this point as it will take a long time to run to completion.

Additionally, run a simple Germantown, Phila job afterwards to ensure that changes to the job tables schemas cause no issues, and that the job runs to completion.


Closes #375 
