### PR TITLE
Add score labels/descriptions to public UI

### DIFF
--- a/src/angularjs/src/app/components/places.service.js
+++ b/src/angularjs/src/app/components/places.service.js
@@ -51,8 +51,9 @@
                     // sort alphabetically by metric name so they will line up by row
                     place.scores = _(results.overall_scores).map(function(obj, key) {
                         return {
-                            metric: key.replace(/_/g, ' '),
-                            score: obj.score_normalized
+                            metric: key,
+                            score: obj.score,
+                            score_normalized: obj.score_normalized
                         };
                     }).sortBy(function(result) { return result.metric; }).value();
 

--- a/src/angularjs/src/app/components/scoremetadata.service.js
+++ b/src/angularjs/src/app/components/scoremetadata.service.js
@@ -1,0 +1,18 @@
+/**
+ * @ngdoc service
+ * @name pfb.components:ScoreMetadata
+ *
+ * @description
+ * Resource for Analysis score metadata
+ */
+(function() {
+    'use strict';
+
+    /* @ngInject */
+    function ScoreMetadata($resource) {
+        return $resource('/api/score_metadata/', {}, {});
+    }
+
+    angular.module('pfb.components')
+        .factory('ScoreMetadata', ScoreMetadata);
+})();

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -58,10 +58,11 @@
                 </div>
             </div>
         </section>
-        <ul class="metric-list" ng-repeat="result in placeDetail.scores">
-            <li>{{result.metric}}
-                <div class="tooltip" title="This is a tooltip "><i class="icon-info-circled"></i></div>
-                <span class="network-score small">{{result.score | number:0}}</span>
+        <ul class="metric-list">
+            <li ng-repeat="result in placeDetail.scores">
+                {{ ::placeDetail.metadata[result.metric].label }}
+                <div class="tooltip" title="{{ ::placeDetail.metadata[result.metric].description }}"><i class="icon-info-circled"></i></div>
+                <span class="network-score small">{{ ::result.score_normalized | number:0 }}</span>
             </li>
         </ul>
     </div>

--- a/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
+++ b/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
@@ -118,7 +118,7 @@
   },
   {
     "model": "pfb_analysis.AnalysisScoreMetadata",
-    "pk": "core_services_retail",
+    "pk": "retail",
     "fields": {
       "label": "Retail",
       "category": "Retail",

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from rest_framework import serializers
 
-from pfb_analysis.models import AnalysisJob, Neighborhood
+from pfb_analysis.models import AnalysisJob, AnalysisScoreMetadata, Neighborhood
 from pfb_network_connectivity.serializers import PFBModelSerializer
 
 
@@ -106,3 +106,11 @@ class AnalysisJobSerializer(PFBModelSerializer):
                    '_analysis_job_name', '_tilemaker_job_name',)
         read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
                             'batch_job_id', 'batch', 'census_block_count', 'final_runtime',)
+
+
+class AnalysisScoreMetadataSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = AnalysisScoreMetadata
+        fields = ('name', 'label', 'category', 'description',)
+        read_only_fields = ('name', 'label', 'category', 'description',)

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -20,8 +20,9 @@ from pfb_network_connectivity.pagination import OptionalLimitOffsetPagination
 from pfb_network_connectivity.filters import OrgAutoFilterBackend
 from pfb_network_connectivity.permissions import IsAdminOrgAndAdminCreateEditOnly, RestrictedCreate
 
-from .models import AnalysisJob, Neighborhood
+from .models import AnalysisJob, AnalysisScoreMetadata, Neighborhood
 from .serializers import (AnalysisJobSerializer,
+                          AnalysisScoreMetadataSerializer,
                           NeighborhoodSerializer)
 from .filters import AnalysisJobFilterSet
 
@@ -72,6 +73,16 @@ class AnalysisJobViewSet(ModelViewSet):
             return Response(results, status=status.HTTP_200_OK)
         else:
             return Response(None, status=status.HTTP_404_NOT_FOUND)
+
+
+class AnalysisScoreMetadataViewSet(ReadOnlyModelViewSet):
+    """Convenience endpoint for available analysis score metadata"""
+
+    queryset = AnalysisScoreMetadata.objects.all()
+    serializer_class = AnalysisScoreMetadataSerializer
+    pagination_class = None
+    filter_class = None
+    permission_classes = (AllowAny,)
 
 
 class NeighborhoodViewSet(ModelViewSet):

--- a/src/django/pfb_network_connectivity/urls.py
+++ b/src/django/pfb_network_connectivity/urls.py
@@ -28,6 +28,8 @@ router = routers.DefaultRouter()
 router.register(r'organizations', user_views.OrganizationViewSet, base_name='organizations')
 router.register(r'users', user_views.PFBUserViewSet, base_name='users')
 router.register(r'analysis_jobs', analysis_views.AnalysisJobViewSet, base_name='analysis_jobs')
+router.register(r'score_metadata', analysis_views.AnalysisScoreMetadataViewSet,
+                base_name='score_metadata')
 router.register(r'neighborhoods', analysis_views.NeighborhoodViewSet, base_name='neighborhoods')
 
 


### PR DESCRIPTION
## Overview

Adds score labels and descriptions to the places detail view


### Demo

![screen shot 2017-05-10 at 10 04 14](https://cloud.githubusercontent.com/assets/1818302/25903009/368ca2b8-3569-11e7-8ba4-2c4e05096db6.png)
![screen shot 2017-05-10 at 10 13 08](https://cloud.githubusercontent.com/assets/1818302/25903065/6164c0d8-3569-11e7-99c5-fa0e54d98267.png)



### Notes

The description tooltips won't currently display because the fontello.css file isn't being built into the application bundle. I spent 15 mins attempting to fix it but no luck, needs a bit more digging to get properly bundled. The description text is added to the DOM, so if you manually give the tooltip div a width via dev tools you can hover the blank div and view the tooltips.

## Testing Instructions

- `./scripts/django-manage loaddata analysis-score-metadata`
- Navigate to places detail page
- Labels should replace the score names, and descriptions should exist in the DOM 
- http://localhost:9200/api/score_metadata/ should exist and return data without logging in

Closes #378 
