### PR TITLE
Display scores using metadata on compare page

### DIFF
--- a/src/angularjs/src/app/components/scoremetadata.service.js
+++ b/src/angularjs/src/app/components/scoremetadata.service.js
@@ -10,7 +10,7 @@
 
     /* @ngInject */
     function ScoreMetadata($resource) {
-        return $resource('/api/score_metadata/', {}, {});
+        return $resource('/api/score_metadata/', {}, {cache: true});
     }
 
     angular.module('pfb.components')

--- a/src/angularjs/src/app/components/states.service.js
+++ b/src/angularjs/src/app/components/states.service.js
@@ -10,7 +10,8 @@
     /* @ngInject */
     function State($resource) {
         return $resource('/api/states/', {}, {
-            'query': {
+            cache: true,
+            query: {
                 method: 'GET',
                 isArray: true
             }

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -35,8 +35,11 @@
                             pfb-thumbnail-map-place="place.neighborhood.uuid"></pfb-thumbnail-map>
                     </div>
                     <ul class="metric-list">
-                        <li ng-repeat="result in place.scores">{{result.metric}}
-                            <span class="network-score small">{{result.score | number:0}}</span>
+                        <li ng-repeat="result in place.scores">
+                            {{ ::compare.metadata[result.metric].label }}
+                            <span class="network-score small">
+                                {{result.score_normalized | number:0}}
+                            </span>
                         </li>
                         <li>
                             <section>


### PR DESCRIPTION
## Overview

Add score labels from new metadata endpoint to comparison page metrics.


### Demo

![image](https://cloud.githubusercontent.com/assets/960264/25960039/bb8cbe6e-3643-11e7-891f-08d7bad7b25f.png)


## Testing Instructions

 * Check compare page
 * Metrics should have pretty labels and still line up across columns


Closes #428.
