### PR TITLE
Search/filtering revamp

### DIFF
--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.controller.js
@@ -41,10 +41,10 @@
         }
 
         function filterJobs(filters) {
-            var params = _.merge({}, defaultParams, filters);
+            var params = _.merge({}, defaultParams);
 
             if (filters.neighborhood) {
-                params.neighborhood = filters.neighborhood;
+                params.search = filters.neighborhood;
             }
             if (filters.status) {
                 params.status = filters.status;

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
@@ -8,54 +8,29 @@
      * Controller for the analysis job filtering table header
      */
     /** @ngInject */
-    function AnalysisJobFilterController($scope, Neighborhood, AuthService, AnalysisJobStatuses) {
+    function AnalysisJobFilterController($scope, AnalysisJobStatuses) {
         var ctl = this;
         initialize();
 
         function initialize() {
-            loadOptions(ctl.param);
-            $scope.$watch(function(){return ctl.statusFilter;}, filterStatus);
-            $scope.$watch(function(){return ctl.neighborhoodFilter;}, filterNeighborhood);
-            $scope.$watch(function(){return ctl.analysisJobFilter;}, filterBoundary);
-        }
-
-        function loadOptions() {
-            Neighborhood.all().$promise.then(function(data) {
-                ctl.neighborhoods = data.results;
-            });
-
-            ctl.statusFilter = null;
-            ctl.neighborhoodFilter = null;
+            ctl.statusFilter = '';
             ctl.statuses = AnalysisJobStatuses.statuses;
+            ctl.filterNeighborhoods = filterNeighborhoods;
+            ctl.onStatusFilterChanged = onStatusFilterChanged;
         }
 
-        function filterNeighborhood(newFilter, oldFilter) {
-            if (newFilter === oldFilter) {
-                return;
-            }
+        function filterNeighborhoods() {
             ctl.filters = {
-                neighborhood: newFilter ? newFilter.uuid : null,
+                neighborhood: ctl.searchText,
                 status: AnalysisJobStatuses.filterMap[ctl.statusFilter]
             };
         }
 
-        function filterStatus(newFilter, oldFilter) {
-            if (newFilter === oldFilter) {
-                return;
-            }
+        function onStatusFilterChanged($item) {
+            var status = AnalysisJobStatuses.filterMap[$item || ctl.statusFilter];
             ctl.filters = {
-                neighborhood: ctl.neighborhoodFilter ? ctl.neighborhoodFilter.uuid : null,
-                status: AnalysisJobStatuses.filterMap[newFilter]
-            };
-        }
-
-        function filterBoundary(newFilter, oldFilter) {
-            if (newFilter === oldFilter) {
-                return;
-            }
-            ctl.filters = {
-                neighborhood: ctl.neighborhoodFilter ? ctl.neighborhoodFilter.uuid : null,
-                status: AnalysisJobStatuses.filterMap[ctl.statusFilter]
+                neighborhood: ctl.searchText,
+                status: status || ''
             };
         }
     }

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.html
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.html
@@ -2,23 +2,29 @@
     <th>ID</th>
     <th>
         <div class="dropdown">
-        <input name="neighborhood-filter" ng-model="ctl.statusFilter" title="Filter by Status"
-            placeholder="Status" type="text" class="form-control"
-            uib-typeahead="status for status in ctl.statuses |
-                           filter: $viewValue |
-                           limitTo: 8">
+        <input name="neighborhood-filter"
+               title="Filter by Status"
+               placeholder="Status"
+               ng-model="ctl.statusFilter"
+               ng-model-options="{ debounce: 400 }"
+               ng-change="ctl.onStatusFilterChanged()"
+               type="text"
+               uib-typeahead="status for status in ctl.statuses | filter: $viewValue | limitTo: 8"
+               typeahead-wait-ms="400"
+               typeahead-on-select="ctl.onStatusFilterChanged($item)"
+               class="form-control">
         </div>
     </th>
     <th>
         <div class="dropdown neighborhood">
-            <input title="Filter by Neighborhood" placeholder="Neighborhood"
-                ng-model="ctl.neighborhoodFilter"
-                type="text" class="form-control"
-                uib-typeahead="neighborhood as (neighborhood.label + ', ' +
-                               neighborhood.state_abbrev) for neighborhood in ctl.neighborhoods |
-                               filter: {label : $viewValue} |
-                               limitTo: 8">
-
+            <input name="neighborhood-filter"
+                   title="Filter by Neighborhood"
+                   placeholder="Neighborhood"
+                   ng-model="ctl.searchText"
+                   ng-model-options="{ debounce: 400 }"
+                   ng-change="ctl.filterNeighborhoods()"
+                   type="text"
+                   class="form-control"/>
         </div>
     </th>
     <th>Batch Job ID</th>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -11,13 +11,12 @@
             <div class="column">
                 <div class="form-group">
                     <label for="neighborhood-filter">Filter by place name</label>
-                    <input name="neighborhood-filter" ng-model="placeList.neighborhoodFilter"
-                        type="text" class="form-control"
-                        uib-typeahead="neighborhood as (neighborhood.label + ', ' +
-                                       neighborhood.state_abbrev) for neighborhood in
-                                       placeList.allNeighborhoods |
-                                       filter: {label : $viewValue} |
-                                       limitTo: 8">
+                    <input name="neighborhood-filter"
+                           ng-model="placeList.searchText"
+                           ng-model-options="{ debounce: 400 }"
+                           ng-change="placeList.filterNeighborhoods()"
+                           type="text"
+                           class="form-control"/>
 
                 </div>
             </div>
@@ -75,7 +74,7 @@
 
         <section>
             <!-- Duplicate .result div for each result. -->
-            <div class="result" ng-repeat="neighborhood in placeList.places">
+            <div class="result" ng-repeat="neighborhood in placeList.places track by neighborhood.uuid">
                 <a ui-sref="places.detail({uuid: '{{neighborhood.uuid}}' })" class="result-link"></a>
                 <div class="result-left">
 

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -133,7 +133,7 @@
         }
 
         function getPlaces(params) {
-            params = params || _.merge({}, $stateParams, defaultParams);
+            params = params || _.merge({}, defaultParams);
             params.ordering = ctl.sortBy.value;
             if (ctl.searchText) {
                 params.search = ctl.searchText;

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -41,12 +41,12 @@
             ctl.hasPrev = false;
             ctl.getPrev = getPrev;
             ctl.places = [];
-
-            ctl.neighborhoodFilter = null;
+            ctl.searchText = '';
 
             ctl.comparePlaces = new Array(3);
             ctl.addPlaceToCompare = addPlaceToCompare;
             ctl.removeComparePlace = removeComparePlace;
+            ctl.filterNeighborhoods = filterNeighborhoods;
             ctl.goComparePlaces = goComparePlaces;
             // convenience property to track number of selected places; must be updated on add/remove
             ctl.comparePlacesCount = 0;
@@ -57,8 +57,6 @@
             ctl.getPlaces = getPlaces;
 
             getPlaces();
-            loadOptions();
-            $scope.$watch(function(){return ctl.neighborhoodFilter;}, filterNeighborhood);
         }
 
         /**
@@ -130,25 +128,15 @@
             $state.go('places.list', $stateParams, {notify: false});
         }
 
-        function filterNeighborhood(newFilter, oldFilter) {
-            if (newFilter === oldFilter) {
-                return;
-            }
+        function filterNeighborhoods() {
             getPlaces();
-        }
-
-        function loadOptions() {
-            // fetch all neighborhoods, to populate the search bar
-            Neighborhood.all().$promise.then(function(data) {
-                ctl.allNeighborhoods = data.results;
-            });
         }
 
         function getPlaces(params) {
             params = params || _.merge({}, $stateParams, defaultParams);
             params.ordering = ctl.sortBy.value;
-            if (ctl.neighborhoodFilter) {
-                params.neighborhood = ctl.neighborhoodFilter.uuid;
+            if (ctl.searchText) {
+                params.search = ctl.searchText;
             }
 
             ctl.comparePlacesCount = 0;

--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.db.models import Q
+
 from rest_framework import filters
 import django_filters
 
@@ -15,8 +17,9 @@ class AnalysisJobFilterSet(filters.FilterSet):
       - latest, to return only the most recent analysis job for each neighborhood
     """
 
-    status = django_filters.ChoiceFilter(choices=AnalysisJob.Status.CHOICES)
     latest = django_filters.BooleanFilter(method='filter_latest')
+    search = django_filters.CharFilter(method='filter_search')
+    status = django_filters.ChoiceFilter(choices=AnalysisJob.Status.CHOICES)
 
     def filter_latest(self, queryset, name, value):
         """ Return latest successful analysis for each neighborhood, but falls back
@@ -31,6 +34,10 @@ class AnalysisJobFilterSet(filters.FilterSet):
             queryset = queryset.filter(last_job_neighborhood__isnull=(not value))
 
         return queryset
+
+    def filter_search(self, queryset, name, value):
+        return queryset.filter(Q(neighborhood__name__icontains=value) |
+                               Q(neighborhood__state_abbrev__icontains=value))
 
     class Meta:
         model = AnalysisJob


### PR DESCRIPTION
## Overview

This PR completely refactors/revamps the AnalysisJob search feature for the admin and public sites.

Removes the typeahead and allows generic text filtering on the AnalysisJob results, sourced from the `Neighborhood.name` and `Neighborhood.state_abbrev` fields.

### Demo

Not really demoable via screenshot.

### Notes

I briefly toyed with using postgres vector search or trigrams, but figured it wasn't worth the extra complexity required to prepare the database. The list of neighborhoods isn't expected to grow above a few hundred rows, and the generic `search` param would allow for the backend implementation to be swapped later if necessary.

## Testing Instructions

Do some text searches on your completed jobs in the public places list view OR, if you only have a single germantown neighborhood there like I do, make some manual requests to http://localhost:9200/api/analysis_jobs/?search=value (so that the latest=True&status=complete filtering is not applied)

Do some filtering on the admin UI view for AnalysisJobs.

Both should be faster and feel much more natural.

I'll also do some testing of this once pushed to production to make sure it still works when the data source is larger.

Closes #419, Closes #420, Closes #422 