### PR TITLE
Add tiles and make layers exclusive on detail map

### DIFF
--- a/src/angularjs/bower.json
+++ b/src/angularjs/bower.json
@@ -17,6 +17,7 @@
     "angular-ui-router": "0.4.2",
     "angular-toastr": "2.1.1",
     "leaflet": "1.0.3",
+    "leaflet-groupedlayercontrol": "0.6.0",
     "moment": "2.17.1",
     "animate.css": "3.5.2",
     "angular-bootstrap": "1.3.3",

--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -73,9 +73,9 @@
                   <td>Ways</td>
                   <td><a ng-href="{{ analysisJobDetail.results.ways_url }}">ESRI Shapefile</a></td>
               </tr>
-              <tr ng-repeat="(key, url) in analysisJobDetail.results.destinations_urls">
-                  <td>Destination: {{ key }}</td>
-                  <td><a ng-href="{{ url }}">GeoJSON</a></td>
+              <tr ng-repeat="layer in analysisJobDetail.results.destinations_urls">
+                  <td>Destination: {{ layer.name }}</td>
+                  <td><a ng-href="{{ layer.url }}">GeoJSON</a></td>
               </tr>
           </tbody>
       </table>

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -36,8 +36,6 @@
         ctl.onMapReady = function (map) {
             ctl.map = map;
 
-            ctl.baselayer.addTo(ctl.map);
-
             // in case map layers set before map was ready, add layers now map is ready to go
             if (ctl.pfbPlaceMapLayers) {
                 setLayers(ctl.pfbPlaceMapLayers);
@@ -58,8 +56,16 @@
                 return;
             }
 
+            var satelliteLayer = L.tileLayer(MapConfig.baseLayers.Satellite.url, {
+                attribution: MapConfig.baseLayers.Satellite.attribution,
+                maxZoom: MapConfig.conusMaxZoom
+            });
+
             if (!ctl.layerControl) {
-                ctl.layerControl = L.control.groupedLayers({}, {
+                ctl.layerControl = L.control.groupedLayers({
+                    'Positron': ctl.baselayer,
+                    'Satellite': satelliteLayer
+                }, {
                     'Overlays': {},
                     'Destinations': {}
                 }, {

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -17,7 +17,7 @@
                 MapConfig.baseLayers.Positron.url, {
                     attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
-                });
+            });
         };
 
         ctl.$onChanges = function(changes) {
@@ -36,6 +36,8 @@
         ctl.onMapReady = function (map) {
             ctl.map = map;
 
+            ctl.baselayer.addTo(ctl.map);
+
             // in case map layers set before map was ready, add layers now map is ready to go
             if (ctl.pfbPlaceMapLayers) {
                 setLayers(ctl.pfbPlaceMapLayers);
@@ -47,7 +49,7 @@
                 ctl.boundsLayer = L.geoJSON(data, {});
                 ctl.map.addLayer(ctl.boundsLayer);
                 ctl.map.fitBounds(ctl.boundsLayer.getBounds());
-                ctl.layerControl.addOverlay(ctl.boundsLayer, 'area boundary');
+                ctl.layerControl.addBaseLayer(ctl.boundsLayer, 'area boundary');
             });
         }
 
@@ -57,10 +59,18 @@
             }
 
             if (!ctl.layerControl) {
-                ctl.layerControl = L.control.layers({'Positron': ctl.baselayer}, []).addTo(ctl.map);
+                ctl.layerControl = L.control.layers({}, []).addTo(ctl.map);
             }
 
-            _.map(layers, function(url, metric) {
+            _.map(layers.tileLayers, function(url, name) {
+                var label = $sanitize(name.replace(/_/g, ' '));
+                var layer = L.tileLayer(url, {
+                    maxZoom: MapConfig.conusMaxZoom
+                });
+                ctl.layerControl.addBaseLayer(layer, label);
+            });
+
+            _.map(layers.featureLayers, function(url, metric) {
                 var label = $sanitize(metric.replace(/_/g, ' '));
                 $http.get(url).then(function(response) {
                     if (response.data && response.data.features) {

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -49,7 +49,7 @@
                 ctl.boundsLayer = L.geoJSON(data, {});
                 ctl.map.addLayer(ctl.boundsLayer);
                 ctl.map.fitBounds(ctl.boundsLayer.getBounds());
-                ctl.layerControl.addBaseLayer(ctl.boundsLayer, 'area boundary');
+                ctl.layerControl.addOverlay(ctl.boundsLayer, 'area boundary', 'Overlays');
             });
         }
 
@@ -59,10 +59,12 @@
             }
 
             if (!ctl.layerControl) {
-                var options = {
-                    sortLayers: true
-                };
-                ctl.layerControl = L.control.layers({}, {}, options).addTo(ctl.map);
+                ctl.layerControl = L.control.groupedLayers({}, {
+                    'Overlays': {},
+                    'Destinations': {}
+                }, {
+                    exclusiveGroups: ['Overlays', 'Destinations']
+                }).addTo(ctl.map);
             }
 
             _.map(layers.tileLayers, function(layerObj) {
@@ -70,7 +72,7 @@
                 var layer = L.tileLayer(layerObj.url, {
                     maxZoom: MapConfig.conusMaxZoom
                 });
-                ctl.layerControl.addBaseLayer(layer, label);
+                ctl.layerControl.addOverlay(layer, label, 'Overlays');
             });
 
             _.map(layers.featureLayers, function(layerObj) {
@@ -80,7 +82,7 @@
                         var layer = L.geoJSON(response.data, {
                             onEachFeature: onEachFeature
                         });
-                        ctl.layerControl.addOverlay(layer, label);
+                        ctl.layerControl.addOverlay(layer, label, 'Destinations');
                     }
                 });
             });

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -62,17 +62,17 @@
                 ctl.layerControl = L.control.layers({}, []).addTo(ctl.map);
             }
 
-            _.map(layers.tileLayers, function(url, name) {
-                var label = $sanitize(name.replace(/_/g, ' '));
-                var layer = L.tileLayer(url, {
+            _.map(layers.tileLayers, function(layerObj) {
+                var label = $sanitize(layerObj.name.replace(/_/g, ' '));
+                var layer = L.tileLayer(layerObj.url, {
                     maxZoom: MapConfig.conusMaxZoom
                 });
                 ctl.layerControl.addBaseLayer(layer, label);
             });
 
-            _.map(layers.featureLayers, function(url, metric) {
-                var label = $sanitize(metric.replace(/_/g, ' '));
-                $http.get(url).then(function(response) {
+            _.map(layers.featureLayers, function(layerObj) {
+                var label = $sanitize(layerObj.name.replace(/_/g, ' '));
+                $http.get(layerObj.url).then(function(response) {
                     if (response.data && response.data.features) {
                         var layer = L.geoJSON(response.data, {
                             onEachFeature: onEachFeature

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -59,7 +59,10 @@
             }
 
             if (!ctl.layerControl) {
-                ctl.layerControl = L.control.layers({}, []).addTo(ctl.map);
+                var options = {
+                    sortLayers: true
+                };
+                ctl.layerControl = L.control.layers({}, {}, options).addTo(ctl.map);
             }
 
             _.map(layers.tileLayers, function(layerObj) {

--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -53,7 +53,10 @@
                 ctl.place = place.neighborhood;
                 if (place.lastJob) {
                     ctl.lastJobScore = place.lastJob.overall_score;
-                    ctl.mapLayers = place.results.destinations_urls;
+                    ctl.mapLayers = {
+                        tileLayers: place.results.tile_urls,
+                        featureLayers: place.results.destinations_urls
+                    };
                     ctl.scores = place.scores;
                     ctl.downloads = _.map(downloadOptions, function(option) {
                         return {label: option.label, url: place.results[option.value]};

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -383,6 +383,14 @@ class AnalysisJob(PFBModel):
         }
 
     @property
+    def tile_urls(self):
+        return {
+            layer: self._s3_url_for_result_resource('tiles/neighborhood_{}'.format(layer) +
+                                                    '/{z}/{x}/{y}.png')
+            for layer in ['census_blocks', 'ways']
+        }
+
+    @property
     def overall_scores_url(self):
         return self._s3_url_for_result_resource('neighborhood_overall_scores.csv')
 

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -376,19 +376,18 @@ class AnalysisJob(PFBModel):
     @property
     def destinations_urls(self):
         """ Return a dict of the available destinations files for this job """
-        return {
-            destination: self._s3_url_for_result_resource('neighborhood_{}.geojson'
-                                                          .format(destination))
-            for destination in settings.PFB_ANALYSIS_DESTINATIONS
-        }
+        return [{
+            'name': destination,
+            'url': self._s3_url_for_result_resource('neighborhood_{}.geojson'.format(destination))
+        } for destination in settings.PFB_ANALYSIS_DESTINATIONS]
 
     @property
     def tile_urls(self):
-        return {
-            layer: self._s3_url_for_result_resource('tiles/neighborhood_{}'.format(layer) +
+        return [{
+            'name': layer,
+            'url': self._s3_url_for_result_resource('tiles/neighborhood_{}'.format(layer) +
                                                     '/{z}/{x}/{y}.png')
-            for layer in ['census_blocks', 'ways']
-        }
+        } for layer in ['census_blocks', 'ways']]
 
     @property
     def overall_scores_url(self):

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -71,6 +71,7 @@ class AnalysisJobViewSet(ModelViewSet):
                 ('census_blocks_url', job.census_blocks_url),
                 ('connected_census_blocks_url', job.connected_census_blocks_url),
                 ('destinations_urls', job.destinations_urls),
+                ('tile_urls', job.tile_urls),
                 ('overall_scores', job.overall_scores),
                 ('overall_scores_url', job.overall_scores_url),
                 ('score_inputs_url', job.score_inputs_url),


### PR DESCRIPTION
## Overview

Makes two main changes to the place detail map:
- Adds the generated tile layers ("ways" and "census blocks")
- Makes the destination layers "pick one" (radio) rather than checkboxes

### Demo

![image](https://cloud.githubusercontent.com/assets/6598836/25966973/a29601a6-365a-11e7-9ff5-f874ff7c6444.png)

### Notes

This is using the [leaflet-groupedlayercontrol](https://github.com/ismyrnow/leaflet-groupedlayercontrol) plugin.  That gets us the ability to make groups mutually exclusive.  The thing it doesn't have that the regular `L.Control.layers` does is sorting.  The regular picker supports two groups (base maps and overlays), so it's possible to get the separation we want by putting our overlays in as the base maps and our destinations in as overlays.  But we can't get the destinations to be radio buttons.  Probably that's more important than sorting, and we could possibly get them to sort by some other means if we need to.

Anyway, if you want to see the `L.Control.layers` version you can check out the second-to-last commit on this branch.  It looks like this:
![image](https://cloud.githubusercontent.com/assets/6598836/25967212/60c3ac8c-365b-11e7-86b0-e73aeca9258e.png)

Speaking of base maps, this moves the actual Positron base map out of the picker altogether, which makes sense since we only offer one.

## Testing Instructions

Rebuild your `angularjs` container to get the new bower package installed, then view a neighborhood that has a fully completed (including tiling) job.  You should still get the boundary initially but now be able to switch to the ways or census blocks tiles, and you should be able to pick only one destinations layer at a time.

Resolves #426, resolves #429.
