### PR TITLE
Feature/awf/angular fix list map#418

### DIFF
--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -43,24 +43,25 @@
                                 {{placeList.comparePlacesCount}} Selected
                                 <span class="caret"></span>
                         </button>
-                    <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdown-compare"
-                        uib-dropdown-menu>
-                        <li ng-repeat="neighborhood in placeList.comparePlaces | filter:{uuid: '!!'}">
-                            <div>
-                                <div class="compare-title">{{neighborhood.label}},
-                                    {{neighborhood.state_abbrev}}</div>
-                                <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
-                                <a ng-click="placeList.removeComparePlace(neighborhood.uuid)"
-                                    class="compare-remove">Remove</a>
-                            </div>
-                        </li>
-                        <li>
-                            <!-- only go to comparison page if at least two places selected -->
-                            <a ng-click="placeList.comparePlacesCount > 1 ? placeList.goComparePlaces() : ''"
-                                ng-disabled="placeList.comparePlacesCount < 2"
-                                class="compare-btn">Compare Places</a>
-                        </li>
-                    </ul>
+                        <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdown-compare"
+                            uib-dropdown-menu>
+                            <li ng-repeat="neighborhood in placeList.comparePlaces | filter:{uuid: '!!'}">
+                                <div>
+                                    <div class="compare-title">{{neighborhood.label}},
+                                        {{neighborhood.state_abbrev}}</div>
+                                    <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
+                                    <a ng-click="placeList.removeComparePlace(neighborhood.uuid)"
+                                        class="compare-remove">Remove</a>
+                                </div>
+                            </li>
+                            <li>
+                                <!-- only go to comparison page if at least two places selected -->
+                                <a ng-click="placeList.comparePlacesCount > 1 ? placeList.goComparePlaces() : ''"
+                                    ng-disabled="placeList.comparePlacesCount < 2"
+                                    class="compare-btn">Compare Places</a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>
@@ -71,7 +72,6 @@
 
             The stick headers are probably only needed when sorting alphabetically. -->
     <div class="sidebar-scrollable" id="scrollHeaders">
-
         <section>
             <!-- Duplicate .result div for each result. -->
             <div class="result" ng-repeat="neighborhood in placeList.places track by neighborhood.uuid">

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -39,8 +39,8 @@
                     <div class="btn-group" uib-dropdown is-open="status.isopen">
                         <button class="btn btn-default btn-block" type="button"
                             id="dropdown-compare" aria-haspopup="true" aria-expanded="true"
-                            uib-dropdown-toggle ng-disabled="placeList.comparePlacesCount < 1">
-                                {{placeList.comparePlacesCount}} Selected
+                            uib-dropdown-toggle ng-disabled="placeList.comparePlaces.length < 1">
+                                {{placeList.comparePlaces.length}} Selected
                                 <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu compare-dropdown" aria-labelledby="dropdown-compare"
@@ -56,8 +56,8 @@
                             </li>
                             <li>
                                 <!-- only go to comparison page if at least two places selected -->
-                                <a ng-click="placeList.comparePlacesCount > 1 ? placeList.goComparePlaces() : ''"
-                                    ng-disabled="placeList.comparePlacesCount < 2"
+                                <a ng-click="placeList.comparePlaces.length > 1 ? placeList.goComparePlaces() : ''"
+                                    ng-disabled="placeList.comparePlaces.length < 2"
                                     class="compare-btn">Compare Places</a>
                             </li>
                         </ul>
@@ -90,15 +90,16 @@
                 <div class="result-right">
                     <div class="network-score">{{neighborhood.overall_score | number:0}}</div>
                     <div class="compare">
-                        <button ng-if="!neighborhood.comparing"
-                            ng-disabled="placeList.comparePlacesCount >=3"
-                            ng-class="(placeList.comparePlacesCount >=3) ?
-                                'btn btn-toggle' : 'btn btn-toggle active'"
-                            ng-click="placeList.addPlaceToCompare(neighborhood, true)">Compare
+                        <button ng-if="!placeList.isInPlaceCompare(neighborhood.uuid)"
+                                ng-disabled="placeList.isPlaceCompareFull()"
+                                ng-class="(placeList.isPlaceCompareFull()) ?
+                                    'btn btn-toggle' : 'btn btn-toggle active'"
+                                ng-click="placeList.addPlaceToCompare(neighborhood)">Compare
                             <span></span>
                         </button>
-                        <button ng-if="neighborhood.comparing" class="btn btn-toggle"
-                            ng-click="placeList.removeComparePlace(neighborhood.uuid)">Remove
+                        <button ng-if="placeList.isInPlaceCompare(neighborhood.uuid)"
+                                class="btn btn-toggle"
+                                ng-click="placeList.removeComparePlace(neighborhood.uuid)">Remove
                             <span></span>
                         </button>
                     </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -122,6 +122,8 @@
 
 <!-- Map -->
 <div class="preview-map">
-    <pfb-places-list-map></pfb-places-list-map>
+    <pfb-places-list-map
+        pfb-places-list-map-neighborhoods="placeList.mapPlaces">
+    </pfb-places-list-map>
 </div>
 <!-- Map -->

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -27,6 +27,10 @@
             latest: 'True',
             status: 'COMPLETE'
         };
+        var mapStyleKeys = {
+            DEFAULT: 'default',
+            COMPARE: 'compare'
+        };
         var nextParams = {};
         var prevParams = {};
 
@@ -42,6 +46,7 @@
             ctl.getPrev = getPrev;
             ctl.places = [];
             ctl.searchText = '';
+            ctl.mapPlaces = {};
 
             ctl.comparePlaces = new Array(3);
             ctl.addPlaceToCompare = addPlaceToCompare;
@@ -82,6 +87,7 @@
                 if (updateUrl) {
                     updateComparisonsInUrl();
                 }
+                setMapPlaces(ctl.places);
             } else {
                 $log.warn('already have three places to compare');
 
@@ -115,6 +121,7 @@
                 ctl.comparePlaces[removeOffset] = null;
                 ctl.comparePlacesCount--;
                 updateComparisonsInUrl();
+                setMapPlaces(ctl.places);
             } else {
                 $log.warn('no place with UUID ' + uuid + ' found to remove from comparison');
             }
@@ -163,6 +170,7 @@
 
                     return neighborhood;
                 });
+                setMapPlaces(ctl.places);
 
                 if (data.next) {
                     ctl.hasNext = true;
@@ -195,6 +203,19 @@
             getPlaces(params);
         }
 
+        // Must set ctl.mapPlaces via this so that the object ref gets updated
+        function setMapPlaces(places) {
+            var mapPlaces = _.reduce(places, function (result, value) {
+                result[value.uuid] = mapStyleKeys.DEFAULT;
+                return result;
+            }, {});
+            _.forEach(ctl.comparePlaces, function (place) {
+                if (place && place.uuid) {
+                    mapPlaces[place.uuid] = mapStyleKeys.COMPARE;
+                }
+            });
+            ctl.mapPlaces = mapPlaces;
+        }
     }
 
     angular

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -48,13 +48,14 @@
             ctl.searchText = '';
             ctl.mapPlaces = {};
 
-            ctl.comparePlaces = new Array(3);
+            ctl.comparePlaces = [];
+            ctl.maxPlaceCompare = 3;
             ctl.addPlaceToCompare = addPlaceToCompare;
             ctl.removeComparePlace = removeComparePlace;
             ctl.filterNeighborhoods = filterNeighborhoods;
             ctl.goComparePlaces = goComparePlaces;
-            // convenience property to track number of selected places; must be updated on add/remove
-            ctl.comparePlacesCount = 0;
+            ctl.isInPlaceCompare = isInPlaceCompare;
+            ctl.isPlaceCompareFull = isPlaceCompareFull;
 
             ctl.sortBy = sortingOptions[0]; // default to alphabetical order
             ctl.sortingOptions = sortingOptions;
@@ -68,29 +69,16 @@
          * Add a place to the list of up to three places to view on compare page.
          *
          * @param {Neighborhood} place Neighborhood to list of places to compare
-         * @param {boolean} updateUrl If true, will update URL without refreshing the page
-                                      to include the place UUID in the route
          */
-        function addPlaceToCompare(place, updateUrl) {
-            if (place.comparing) {
+        function addPlaceToCompare(place) {
+            if (isInPlaceCompare(place.uuid)) {
                 $log.warn('aready have place selected to compare');
-                return;
-            }
-
-            // put place in first empty comparison slot of the three available
-            var firstEmpty = _.findIndex(ctl.comparePlaces, function(place) { return !place; });
-            if (firstEmpty > -1) {
-                place.comparing = true;
-                ctl.comparePlaces[firstEmpty] = place;
-                ctl.comparePlacesCount++;
-                // update URL to include place to compare, to retain state in case of page refresh
-                if (updateUrl) {
-                    updateComparisonsInUrl();
-                }
-                setMapPlaces(ctl.places);
-            } else {
+            } else if (isPlaceCompareFull()) {
                 $log.warn('already have three places to compare');
-
+            } else {
+                ctl.comparePlaces.push(place);
+                updateComparisonsInUrl();
+                setMapPlaces(ctl.places);
             }
         }
 
@@ -110,16 +98,10 @@
                 return; // on page load, this watch fires will no value
             }
 
-            var removeOffset = _.findIndex(ctl.comparePlaces, function(place) {
-                return place && place.uuid === uuid;
-            });
-
+            var removeOffset = getPlaceCompareIndex(uuid);
             if (removeOffset > -1) {
-                // unset flag on Neighborhood marking selection for comparison
-                ctl.comparePlaces[removeOffset].comparing = false;
                 // remove Neighborhood from array of places selected for comparison
-                ctl.comparePlaces[removeOffset] = null;
-                ctl.comparePlacesCount--;
+                ctl.comparePlaces.splice(removeOffset, 1);
                 updateComparisonsInUrl();
                 setMapPlaces(ctl.places);
             } else {
@@ -127,11 +109,26 @@
             }
         }
 
+        function getPlaceCompareIndex(uuid) {
+            return _.findIndex(ctl.comparePlaces, function (p) {
+                return p && p.uuid === uuid;
+            });
+        }
+
+        function isInPlaceCompare(uuid) {
+            return getPlaceCompareIndex(uuid) !== -1;
+        }
+
+        function isPlaceCompareFull() {
+            return ctl.comparePlaces.length >= ctl.maxPlaceCompare;
+        }
+
         // helper to update URL after places added or removed for comparison, without reloading
         function updateComparisonsInUrl() {
-            _.each(ctl.comparePlaces, function(place, index) {
-                $stateParams['place' + (index + 1)] = place ? place.uuid : '';
-            });
+            for (var i = 0; i < ctl.maxPlaceCompare; i++) {
+                var place = ctl.comparePlaces[i];
+                $stateParams['place' + (i + 1)] = place ? place.uuid : '';
+            }
             $state.go('places.list', $stateParams, {notify: false});
         }
 
@@ -158,11 +155,8 @@
                     neighborhood.modifiedAt = obj.modifiedAt;
                     neighborhood.overall_score = obj.overall_score;
 
-                    // add convenience flag to indicate if place selected for comparison
                     if (_.includes(uuidsToCompare, neighborhood.uuid)) {
-                        addPlaceToCompare(neighborhood, false);
-                    } else {
-                        neighborhood.comparing = false;
+                        addPlaceToCompare(neighborhood);
                     }
 
                     return neighborhood;

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -146,9 +146,6 @@
                 params.search = ctl.searchText;
             }
 
-            ctl.comparePlacesCount = 0;
-            ctl.comparePlaces = new Array(3);
-
             // Read out pre-set places to compare from the URL. Keep this state in the URL
             // so user can navigate between places list and comparison without losing selections.
             var uuidsToCompare = [$stateParams.place1, $stateParams.place2, $stateParams.place3];
@@ -187,7 +184,6 @@
                     ctl.hasPrev = false;
                     prevParams = {};
                 }
-
             });
         }
 


### PR DESCRIPTION
## Overview

Makes the map reappear and implements the additional functionality detailed in #418:
- [x] A marker for each neighborhood shown in the list sidebar
- [x] Markers should filter along with the list when filtering occurs
- [x] Map should always show any neighborhoods selected for comparison 

### Demo

![screen shot 2017-05-12 at 10 50 09](https://cloud.githubusercontent.com/assets/1818302/26003485/ccee254a-3700-11e7-9034-5f543c12654b.png)
![screen shot 2017-05-12 at 10 50 00](https://cloud.githubusercontent.com/assets/1818302/26003486/ccf02ef8-3700-11e7-9eda-127f76586948.png)

### Notes

Missing map was due to an improperly matched div in the `div.sidebar-header`

Implements the geojson map filtering in such a way that it would be relatively trivial to add the functionality detailed in #431 

## Testing Instructions

Navigate to places list, see map. Do some filtering, choose some to compare, compare items should always show, map should update on list filter and compare selection changes.

To test #415, make the vertical height of your window small enough that scrolling should activate, then scroll.

Closes #415, Closes #418 
