### PR TITLE
Filter job search on neighborhood label

### DIFF
--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -36,7 +36,7 @@ class AnalysisJobFilterSet(filters.FilterSet):
         return queryset
 
     def filter_search(self, queryset, name, value):
-        return queryset.filter(Q(neighborhood__name__icontains=value) |
+        return queryset.filter(Q(neighborhood__label__icontains=value) |
                                Q(neighborhood__state_abbrev__icontains=value))
 
     class Meta:


### PR DESCRIPTION
## Overview

Filter job search on neighborhood label instead of name

### Demo

**Before:**
![screen shot 2017-05-12 at 13 36 42](https://cloud.githubusercontent.com/assets/1818302/26009807/60649838-3718-11e7-850f-82445b3278b1.png)

**After:**
![screen shot 2017-05-12 at 13 37 06](https://cloud.githubusercontent.com/assets/1818302/26009808/606797f4-3718-11e7-933c-a500152ca060.png)

## Testing Instructions

- Enter search queries that match the names presented in the UI. Search should filter as expected.

Closes #440 
