### PR TITLE
Add print button to place detail map

### DIFF
--- a/src/angularjs/src/app/leaflet/map-button.control.js
+++ b/src/angularjs/src/app/leaflet/map-button.control.js
@@ -1,0 +1,44 @@
+(function() {
+
+    // Custom private Leaflet control implements a simple button with a click handler
+    L.Control.MapButton = L.Control.extend({
+        initialize: function (options, callback) {
+            if (!callback) {
+                throw 'L.Control.MapButton requires click handler as second argument';
+            }
+            this.iconClasses = options.iconClasses || [];
+            this.controlClasses = options.controlClasses || [];
+            this.controlClasses.push('pfb-control-map-button');
+            this.onClick = function (event) {
+                callback(event);
+                event.preventDefault();
+                event.stopPropagation();
+            }
+        },
+        onAdd: function () {
+            var self = this;
+
+            this.div = L.DomUtil.create('div');
+            _.forEach(this.controlClasses, function (c) {
+                L.DomUtil.addClass(self.div, c);
+            });
+            L.DomEvent.on(this.div, 'click', this.onClick, this);
+
+            var icon = L.DomUtil.create('i');
+            _.forEach(this.iconClasses, function (c) {
+                L.DomUtil.addClass(icon, c);
+            });
+            this.div.appendChild(icon);
+
+            return this.div;
+        },
+        onRemove: function () {
+            L.DomEvent.off(this.div, 'click', this.onClick, this);
+        }
+    });
+    if (!L.control.mapButton) {
+        L.control.mapButton = function (opts, callback) {
+            return new L.Control.MapButton(opts, callback);
+        }
+    }
+})();

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -1,7 +1,7 @@
 (function() {
 
     /* @ngInject */
-    function PlaceMapController($filter, $http, $sanitize, $q, MapConfig, Neighborhood) {
+    function PlaceMapController($filter, $http, $sanitize, $q, $window, MapConfig, Neighborhood) {
         var ctl = this;
         ctl.map = null;
         ctl.layerControl = null;
@@ -70,6 +70,14 @@
                     'Destinations': {}
                 }, {
                     exclusiveGroups: ['Overlays', 'Destinations']
+                }).addTo(ctl.map);
+            }
+            if (!ctl.printButton) {
+                ctl.printButton = L.control.mapButton({
+                    controlClasses: ['leaflet-control-layers'],
+                    iconClasses: ['icon-print']
+                }, function () {
+                    $window.print();
                 }).addTo(ctl.map);
             }
 

--- a/src/angularjs/src/styles/components/_map.scss
+++ b/src/angularjs/src/styles/components/_map.scss
@@ -10,3 +10,7 @@
 .map-below {
   z-index: 0;
 }
+
+.pfb-control-map-button {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Overview

Adds the print button on the map as expected in the wireframes via an almost trivially simple `MapButton` leaflet control.


### Demo

![screen shot 2017-05-12 at 15 46 23](https://cloud.githubusercontent.com/assets/1818302/26014406/6a356452-372a-11e7-91bc-9dba9f463f35.png)

Then click button:
![screen shot 2017-05-12 at 15 46 31](https://cloud.githubusercontent.com/assets/1818302/26014420/761c4a24-372a-11e7-87e1-62914249f8b9.png)


### Notes

Print view is unstyled, will require additional design work.

Currently uses the `leaflet-control-layers` class to match the styling of the other controls. That seemed reasonable for now.

## Testing Instructions

Click tiny button, see print view.


Closes #396 
