### PR TITLE
removes image section from score cards

### DIFF
--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -61,13 +61,6 @@
         <div class="row stack-xs">
             <div class="column-6" ng-repeat="card in home.scoreCards">
                 <div class="card alternate">
-
-                    <!-- This card image div is currently empty
-                             because I dont know what the metric names
-                             are. Images or icons might not make sense
-                             to even show so we might remove. If we do
-                             the layout will auto adjust. -->
-                    <div class="card-image"></div>
                     <div class="card-details">
                         <div class="card-title">
                             <h3>{{ ::card.title }}</h3>

--- a/src/angularjs/src/styles/pages/_home.scss
+++ b/src/angularjs/src/styles/pages/_home.scss
@@ -30,7 +30,7 @@
 
   .pfb-logo {
     max-width: 10rem;
-  } 
+  }
 
   .pfb-logo-text {
     font-size: 3rem;
@@ -137,5 +137,29 @@
 
   .decor {
     color: #fff;
+  }
+
+  .card-details {
+    &:before,
+    &:after {
+      content: '';
+      height: 6px;
+      transform: skew(45deg);
+      display: inline-block;
+      position: absolute;
+      top: 0px;
+    }
+
+    &:before {
+      background: #00aaf6;
+      width: 25%;
+      left: 5px;
+    }
+
+    &:after {
+      background: red;
+      width: 35%;
+      left: 40%;
+    }
   }
 }


### PR DESCRIPTION
## Overview

This will remove the placeholder image section from each score card on the homepage. It adds the stripe of red/blue/white at the top of each card to give a little life to each card.


### Demo
<img width="802" alt="screen shot 2017-05-12 at 4 01 52 pm" src="https://cloud.githubusercontent.com/assets/1928955/26014927/c93f74ea-372c-11e7-974a-f97b8b2b3d6b.png">


Connects #411
