### PR TITLE
Apply text fixes and changes per feedback

### DIFF
--- a/src/angularjs/src/app/home/home.controller.js
+++ b/src/angularjs/src/app/home/home.controller.js
@@ -24,7 +24,7 @@
         ctl.cities = null;
         ctl.scoreCards = [{
             title: 'People',
-            description: 'Sometimes you want to meet at a friend’s house or visit your parents. It is important for bike networks to connect people to each other. Our People measure uses population data from the U.S. Census to determine how well you are connected by bike to the people around you.'
+            description: 'Sometimes you want to meet at a friend&#39s house or visit your parents. It is important for bike networks to connect people to each other. Our People measure uses population data from the U.S. Census to determine how well you are connected by bike to the people around you.'
         }, {
             title: 'Opportunity',
             description: 'Jobs and education are critical to ensuring that everyone has opportunities to improve their situation. Our Opportunity measure uses job data from the U.S. Census along with locations of K-12 schools, vocational and technical colleges, and institutes of higher education to evaluate how easily you can access these opportunities by bike.'

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -3,8 +3,8 @@
 <header class="main-header">
     <div class="container text-center">
         <img src="assets/images/placesforbikes-icon.png" alt="Places for bikes" class="pfb-logo">
-        <div class="pfb-logo-text">PlacesForBikes Network Score</div>
-        <h1>Learn how biking in your place stacks up against other places in terms of biking</h1>
+        <div class="pfb-logo-text">PlacesForBikes Bike Network Analysis (BNA) Score</div>
+        <h1>Find out how biking in your community stacks up against other places</h1>
     </div>
 </header>
 <!-- Top most header with hero image -->

--- a/src/angularjs/src/app/methodology.html
+++ b/src/angularjs/src/app/methodology.html
@@ -10,7 +10,9 @@
                 <div class="card alternate">
                     <div class="card-image"></div>
                     <div class="card-details">
-                        <p>The Bike Network Analysis (BNA) score is computed over four steps: data collection, traffic stress, destination access, and score aggregation. Each of these is described in separate sections below.</p>
+                        <p>The Bike Network Analysis (BNA) score is an evolving project to measure how well bike networks connect people with the places they want to go. Because most people are interested in biking only when it's a low-stress option, our maps recognize only low-stress biking connections.</p>
+
+                        <p>We compute the score over four steps: data collection, traffic stress, destination access, and score aggregation. Each of these is described in separate sections below.</p>
                         <div class="card-title">
                             <h3>Data Collection</h3>
                         </div>

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -27,10 +27,10 @@
                     <div class="column">
                         <label class="network-score large flex-row columns-center">
                             {{placeDetail.lastJobScore | number:0}}
-                            <span class="h3">Network Score</span>
+                            <span class="h3">BNA Score</span>
 
                             <!-- Tooltips how it works: If you have a div with class .tooltip add a title. The content of the title will display in the toolip using css. -->
-                            <div class="tooltip" title="This is a tooltip that keeps sdfjhskdjfh dfskjhas kjhdfsa kjdfsah sdfakjh kjfdsah "><i class="icon-info-circled"></i></div>
+                            <!-- <div class="tooltip" title="TEXT NEEDED"><i class="icon-info-circled"></i></div> -->
                         </label>
                     </div>
                     <div class="column text-right">

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -35,7 +35,7 @@
             <div class="column">
                 <!-- Compare dropdown -->
                 <div class="form-group">
-                    <label for="dropdown-compare">Compare</label>
+                    <label for="dropdown-compare">Compare (up to 3 places)</label>
                     <div class="btn-group" uib-dropdown is-open="status.isopen">
                         <button class="btn btn-default btn-block" type="button"
                             id="dropdown-compare" aria-haspopup="true" aria-expanded="true"

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -15,7 +15,7 @@
         var ctl = this;
 
         var sortingOptions = [
-            {value: 'neighborhood__state_abbrev,neighborhood__label', label: 'Alphabetical'},
+            {value: 'neighborhood__state_abbrev,neighborhood__label', label: 'Alphabetical by State'},
             {value: '-overall_score', label: 'Highest Rated'},
             {value: 'overall_score', label: 'Lowest Rated'},
             {value: '-modified_at', label: 'Last Updated'}

--- a/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
+++ b/src/django/pfb_analysis/fixtures/analysis-score-metadata.json
@@ -5,7 +5,7 @@
     "fields": {
       "label": "People",
       "category": "",
-      "description": "On average, this is how residents score for access to other people."
+      "description": "On average, this is how well people can reach other people by bike."
     }
   },
   {
@@ -14,7 +14,7 @@
     "fields": {
       "label": "Employment",
       "category": "Opportunity",
-      "description": "On average, this is how residents score for access to jobs."
+      "description": "On average, this is how well people can reach jobs by bike."
     }
   },
   {
@@ -23,7 +23,7 @@
     "fields": {
       "label": "K12 Education",
       "category": "Opportunity",
-      "description": "On average, this is how people score for access to K-12 schools."
+      "description": "On average, this is how well people can reach K-12 schools by bike."
     }
   },
   {
@@ -32,7 +32,7 @@
     "fields": {
       "label": "Tech/Vocational College",
       "category": "Opportunity",
-      "description": "On average, this is how people score for access to a technical or vocational college."
+      "description": "On average, this is how well people can reach a technical or vocational college by bike."
     }
   },
   {
@@ -41,7 +41,7 @@
     "fields": {
       "label": "Higher Education",
       "category": "Opportunity",
-      "description": "On average, this is how people score for access to a university."
+      "description": "On average, this is how well people can reach a university by bike."
     }
   },
   {
@@ -50,7 +50,7 @@
     "fields": {
       "label": "Opportunity Total",
       "category": "Opportunity",
-      "description": "On average, this is how people score for access to employment and educational opportunities."
+      "description": "On average, this is how well people can reach employment and educational opportunities by bike."
     }
   },
   {
@@ -59,7 +59,7 @@
     "fields": {
       "label": "Doctors",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to doctors."
+      "description": "On average, this is how well people can reach doctors by bike."
     }
   },
   {
@@ -68,7 +68,7 @@
     "fields": {
       "label": "Dentists",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to dentists."
+      "description": "On average, this is how well people can reach dentists by bike."
     }
   },
   {
@@ -77,7 +77,7 @@
     "fields": {
       "label": "Hospitals",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to a hospital."
+      "description": "On average, this is how well people can reach a hospital by bike."
     }
   },
   {
@@ -86,7 +86,7 @@
     "fields": {
       "label": "Pharmacies",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to pharmacies."
+      "description": "On average, this is how well people can reach pharmacies by bike."
     }
   },
   {
@@ -95,7 +95,7 @@
     "fields": {
       "label": "Grocery",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to groceries."
+      "description": "On average, this is how well people can reach groceries by bike."
     }
   },
   {
@@ -104,7 +104,7 @@
     "fields": {
       "label": "Social Services",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to social services."
+      "description": "On average, this is how well people can reach social services by bike."
     }
   },
   {
@@ -113,7 +113,7 @@
     "fields": {
       "label": "Core Services Total",
       "category": "Core Services",
-      "description": "On average, this is how people score for access to Core Services."
+      "description": "On average, this is how well people can reach Core Services by bike."
     }
   },
   {
@@ -122,7 +122,7 @@
     "fields": {
       "label": "Retail",
       "category": "Retail",
-      "description": "On average, this is how people score for access to retail shopping opportunities."
+      "description": "On average, this is how well people can reach retail shopping opportunities by bike."
     }
   },
   {
@@ -131,7 +131,7 @@
     "fields": {
       "label": "Parks",
       "category": "Recreation",
-      "description": "On average, this is how people score for access to parks."
+      "description": "On average, this is how well people can reach parks by bike."
     }
   },
   {
@@ -140,7 +140,7 @@
     "fields": {
       "label": "Trails",
       "category": "Recreation",
-      "description": "On average, this is how people score for access to off-street trails and paths for recreational riding."
+      "description": "On average, this is how well people can reach off-street trails and paths for recreational riding by bike."
     }
   },
   {
@@ -149,7 +149,7 @@
     "fields": {
       "label": "Community Centers",
       "category": "Recreation",
-      "description": "On average, this is how people score for access to community centers."
+      "description": "On average, this is how well people can reach community centers by bike."
     }
   },
   {
@@ -158,7 +158,7 @@
     "fields": {
       "label": "Recreation Total",
       "category": "Recreation",
-      "description": "On average, this is how people score for access to recreation opportunities."
+      "description": "On average, this is how well people can reach recreation opportunities by bike."
     }
   },
   {
@@ -167,7 +167,7 @@
     "fields": {
       "label": "Transit",
       "category": "Transit",
-      "description": "On average, this is how people score for access to major transit hubs."
+      "description": "On average, this is how well people can reach major transit hubs by bike."
     }
   },
   {


### PR DESCRIPTION
The one remaining issue for #464 is the tooltip text for "BNA Score" at the top of the detail page. This comments it out, since we don't have the desired text yet.

### Notes

The change to the score descriptions ("how people score on access to X" tooltips -> "how well people can reach X by bike") applied pretty smoothly.  The one that I didn't change was "On average, this is how people score for overall access."  It doesn't quite fit the pattern and I couldn't readily think of a way to adapt it to be closer.

## Testing Instructions

- run `./scripts/django-manage loaddata analysis-score-metadata`, since this changes the analysis score metadata
- go on a scavenger hunt for the things listed in https://docs.google.com/a/azavea.com/document/d/17DwS_olu8S1kcMGDKGEaRwLJ8wXBvRaHGXj0A5aeZe8/edit?usp=sharing

Connects #464.
