### PR TITLE
Set layer names and show "Stress Network" by default

### DIFF
--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -45,9 +45,8 @@
         function addBounds(uuid) {
             Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
                 ctl.boundsLayer = L.geoJSON(data, {});
-                ctl.map.addLayer(ctl.boundsLayer);
                 ctl.map.fitBounds(ctl.boundsLayer.getBounds());
-                ctl.layerControl.addOverlay(ctl.boundsLayer, 'area boundary', 'Overlays');
+                ctl.layerControl.addOverlay(ctl.boundsLayer, 'Area boundary', 'Overlays');
             });
         }
 
@@ -82,10 +81,18 @@
             }
 
             _.map(layers.tileLayers, function(layerObj) {
-                var label = $sanitize(layerObj.name.replace(/_/g, ' '));
+                // Get desired label
+                var label = {
+                    'ways': 'Stress Network',
+                    'census_blocks': 'Census blocks with access'
+                }[layerObj.name];
                 var layer = L.tileLayer(layerObj.url, {
                     maxZoom: MapConfig.conusMaxZoom
                 });
+                // Desired default view is showing the network, so add that to the map
+                if (layerObj.name === 'ways') {
+                    ctl.map.addLayer(layer);
+                }
                 ctl.layerControl.addOverlay(layer, label, 'Overlays');
             });
 
@@ -94,6 +101,7 @@
             // Loading them all before adding them to the picker lets us sort.
             var destLayerPromises = _.map(layers.featureLayers, function(layerObj) {
                 var label = $sanitize(layerObj.name.replace(/_/g, ' '));
+                label = label[0].toUpperCase() + label.slice(1);
                 return $http.get(layerObj.url).then(function(response) {
                     if (response.data && response.data.features) {
                         var layer = L.geoJSON(response.data, {

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -387,7 +387,7 @@ class AnalysisJob(PFBModel):
             'name': layer,
             'url': self._s3_url_for_result_resource('tiles/neighborhood_{}'.format(layer) +
                                                     '/{z}/{x}/{y}.png')
-        } for layer in ['census_blocks', 'ways']]
+        } for layer in ['ways', 'census_blocks']]
 
     @property
     def overall_scores_url(self):


### PR DESCRIPTION
## Overview

- #459: Renames the tile overlay layers
- #460: Changes the default overlay to "Stress Network" (formerly "ways")
- Capitalizes feature layers (just seemed sensible/more consistent)

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://cloud.githubusercontent.com/assets/6598836/26256478/14e77d6c-3c8b-11e7-827a-e9c134c42d85.png)

### Notes

I just did everything right in `place-map-directive.js`.  There was already a fair bit of hard-coded formatting going on in there, and there's no obvious place for the config to go if we wanted to separate it out from the logic.  So rather than pull what's there out, I decided to just add this to the pile.

## Testing Instructions

Only affects the place details page.  It should show the network layer on load and look like the screenshot.

Resolves #459, resolves #460.
