### PR TITLE
Option to sort places by population

### DIFF
--- a/src/angularjs/src/app/components/places.service.js
+++ b/src/angularjs/src/app/components/places.service.js
@@ -52,8 +52,10 @@
                     place.scores = _(results.overall_scores).map(function(obj, key) {
                         return {
                             metric: key,
-                            score: obj.score,
-                            score_normalized: obj.score_normalized
+                            score: obj.score_original,
+                            // 'population_total' is missing its 'score_normalized'
+                            score_normalized: (key === 'population_total' ? obj.score_original :
+                                               obj.score_normalized)
                         };
                     }).sortBy(function(result) { return result.metric; }).value();
 

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -18,7 +18,8 @@
             {value: 'neighborhood__state_abbrev,neighborhood__label', label: 'Alphabetical by State'},
             {value: '-overall_score', label: 'Highest Rated'},
             {value: 'overall_score', label: 'Lowest Rated'},
-            {value: '-modified_at', label: 'Last Updated'}
+            {value: '-modified_at', label: 'Last Updated'},
+            {value: '-population_total', label: 'Population'}
         ];
 
         var defaultParams = {

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -243,8 +243,12 @@ class AnalysisBatch(PFBModel):
 class AnalysisJobManager(models.Manager):
     def get_queryset(self):
         qs = super(AnalysisJobManager, self).get_queryset()
-        return qs.annotate(overall_score=ObjectAtPath('overall_scores',
-                                                      ('overall_score', 'score_normalized')))
+        qs = (qs.annotate(overall_score=ObjectAtPath('overall_scores',
+                                                     ('overall_score', 'score_normalized')))
+                .annotate(population_total=ObjectAtPath('overall_scores',
+                                                        ('population_total', 'score_original'),
+                          output_field=models.PositiveIntegerField())))
+        return qs
 
 
 def generate_analysis_job_def():

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -86,6 +86,7 @@ class AnalysisJobSerializer(PFBModelSerializer):
     neighborhood = PrimaryKeyReferenceRelatedField(queryset=Neighborhood.objects.all(),
                                                    serializer=NeighborhoodSummarySerializer)
     overall_score = serializers.FloatField(read_only=True)
+    population_total = serializers.IntegerField(read_only=True)
 
     def get_logs_url(self, obj):
         return obj.logs_url

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -45,7 +45,7 @@ class AnalysisJobViewSet(ModelViewSet):
     filter_class = AnalysisJobFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
     ordering_fields = ('created_at', 'modified_at', 'overall_score', 'neighborhood__label',
-                       'neighborhood__state_abbrev')
+                       'neighborhood__state_abbrev', 'population_total')
     ordering = ('-created_at',)
 
     def perform_create(self, serializer):


### PR DESCRIPTION
## Overview

Adds "Population" to the "Sort By" options on the Places list view.

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://cloud.githubusercontent.com/assets/6598836/26266257/a66ec836-3cb2-11e7-8256-14cf20d0a0fb.png)

### Notes

- I used the same method we used for `overall_score`, pulling the value out of the jsonb field into a pseudo-property of the AnalysisJob using an annotation.
- There's no `score_normalized` on the `population_total` metric, so this includes a workaround to use `score_original` for that specific one, which fixes the bug whereby it has been always showing zero.

## Testing Instructions

Select "Population" and watch it resort accordingly.  Of course this assumes you have multiple completed jobs and that their populations are such that you can tell one sort order from another...

Resolves #395.
