### PR TITLE
Draw intersection stress

### DIFF
--- a/src/analysis/features/ways_carto.sql
+++ b/src/analysis/features/ways_carto.sql
@@ -1,0 +1,77 @@
+----------------------------------------
+-- Creates a table of segmented geometries
+-- based on neighborhood_ways. Used for
+-- showing segment and intersection stress
+-- in mapping.
+--
+-- Variables:
+--      :nb_output_srid -> SRID of the analysis
+--      :min_length -> Minimum length, below which lines are split based on percentages
+--      :int_length -> Length of line to reserve for intersection stress
+----------------------------------------
+DROP TABLE IF EXISTS generated.neighborhood_ways_carto;
+CREATE TABLE generated.neighborhood_ways_carto (
+    id SERIAL PRIMARY KEY,
+    parent_tdg_id TEXT,
+    parent_position TEXT,
+    geom geometry(linestring,:nb_output_srid),
+    ft_stress INTEGER,
+    tf_stress INTEGER
+);
+
+-- segment
+INSERT INTO generated.neighborhood_ways_carto (
+    parent_tdg_id, parent_position, geom, ft_stress, tf_stress
+)
+SELECT  tdg_id,
+        'segment',
+        CASE
+        WHEN ST_Length(geom) < :min_length
+            THEN ST_LineSubstring(geom,0.15,0.85)
+        ELSE ST_LineSubstring(
+            geom,
+            20 / ST_Length(geom),
+            1 - 20 / ST_Length(geom)
+        )
+        END,
+        CASE WHEN COALESCE(one_way,'ft') = 'ft' THEN ft_seg_stress ELSE NULL END,
+        CASE WHEN COALESCE(one_way,'tf') = 'tf' THEN tf_seg_stress ELSE NULL END
+FROM    neighborhood_ways;
+
+-- to intersection
+INSERT INTO generated.neighborhood_ways_carto (
+    parent_tdg_id, parent_position, geom, ft_stress, tf_stress
+)
+SELECT  tdg_id,
+        'segment',
+        CASE
+        WHEN ST_Length(geom) < :min_length
+            THEN ST_LineSubstring(geom,0.85,1)
+        ELSE ST_LineSubstring(
+            geom,
+            1 - :int_length / ST_Length(geom),
+            1
+        )
+        END,
+        CASE WHEN COALESCE(one_way,'ft') = 'ft' THEN GREATEST(ft_int_stress, ft_seg_stress) ELSE NULL END,
+        CASE WHEN COALESCE(one_way,'tf') = 'tf' THEN tf_seg_stress ELSE NULL END
+FROM    neighborhood_ways;
+
+-- from intersection
+INSERT INTO generated.neighborhood_ways_carto (
+    parent_tdg_id, parent_position, geom, ft_stress, tf_stress
+)
+SELECT  tdg_id,
+        'segment',
+        CASE
+        WHEN ST_Length(geom) < :min_length
+            THEN ST_LineSubstring(geom,0,0.15)
+        ELSE ST_LineSubstring(
+            geom,
+            0,
+            :int_length / ST_Length(geom)
+        )
+        END,
+        CASE WHEN COALESCE(one_way,'ft') = 'ft' THEN ft_seg_stress ELSE NULL END,
+        CASE WHEN COALESCE(one_way,'tf') = 'tf' THEN GREATEST(tf_int_stress, tf_seg_stress) ELSE NULL END
+FROM    neighborhood_ways;

--- a/src/analysis/import/import_osm.sh
+++ b/src/analysis/import/import_osm.sh
@@ -20,6 +20,8 @@ echo 'Dropping old tables'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
   -c "DROP TABLE IF EXISTS received.neighborhood_ways;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.neighborhood_ways_carto;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
   -c "DROP TABLE IF EXISTS received.neighborhood_ways_intersections;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
   -c "DROP TABLE IF EXISTS received.neighborhood_relations_ways;"
@@ -244,3 +246,8 @@ psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
     -v tertiary_lanes=1 \
     -f ../stress/stress_lesser_ints.sql
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ../stress/stress_link_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+    -v nb_output_srid="${NB_OUTPUT_SRID}" \
+    -v min_length=50 \
+    -v int_length=15 \
+    -f ../features/ways_carto.sql


### PR DESCRIPTION
## Overview

This addresses one of the top priorities voiced by PFB in the mapping. Adds a table named neighborhood_ways_carto, which can be used for more fine-grained cartographic representation of the stress. Basically, it splits each line segment into three parts: one representing the way, and one on either end representing the intersection. This new table would need to be referenced in place of neighborhood_ways in generating tiles for the traffic stress layer.

It appears the tiles are all generated from the shapefile outputs, so it looks like we would need to be exporting this new table to shapefile as well. The field names to use in the cartographic styles are slightly different. The fields would be FT_STRESS and TF_STRESS.
