### PR TITLE
cleans up all admin facing pages

### DIFF
--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.html
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.html
@@ -2,11 +2,11 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
+    <div class="column-12">
       <h1>Run Analysis</h1>
       <form name="analysisJobCreateForm" novalidate ng-submit="analysisJobCreate.create()">
         <div class="row">
-          <div class="col-sm-4">
+          <div class="column-4">
             <div class="form-group">
               <label for="role">Neighborhood</label>
               <select ng-model="analysisJobCreate.neighborhood"
@@ -16,7 +16,7 @@
               </select>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="column-4">
             <div class="form-group">
               <label for="label">OSM extract URL (optional)</label>
               <input ng-model="analysisJobCreate.osmUrl"
@@ -25,7 +25,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-sm-12">
+          <div class="column-12">
             <button type="submit" ng-disabled="analysisJobCreateForm.$invalid"
                     class="btn-primary btn">Submit Analysis Job</button>
           </div>

--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
+    <div class="column-12">
       <button class="btn btn-danger pull-right"
               ng-click="analysisJobDetail.cancel(analysisJobDetail.job.uuid)">
         <span class="glyphicon glyphicon-ban-circle"></span>
@@ -14,10 +14,8 @@
         Refresh
       </button>
 
+        <a class="btn btn-default" ui-sref="admin.analysis-jobs.list">Go back</a>
       <h1 class="no-margin-top">
-        <a class="btn" ui-sref="admin.analysis-jobs.list">
-          <span class="glyphicon glyphicon-chevron-left"></span>
-        </a>
         Analysis Job
       </h1>
       <table class="table" ng-if="analysisJobDetail.job">

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
+    <div class="column-12">
       <button ng-if="analysisJobList.isAdminUser"
         ui-sref="admin.analysis-jobs.create" class="btn btn-primary pull-right">
         Run Analysis

--- a/src/angularjs/src/app/help/help.html
+++ b/src/angularjs/src/app/help/help.html
@@ -1,16 +1,20 @@
 <pfb-navbar></pfb-navbar>
 
 <div class="container">
-  <div class="row">
-    <div class="help-body col-sm-7 col-sm-offset-1">
+  <div class="row align-center">
+    <div class="help-body column-12">
       <h1>Help</h1>
 
-      <h2 class="help-heading" id="help-topic-one">Authentication</h2>
-      <p>The Account Settings page contains a field for an API token. If no API token exists, click the <code>Refresh</code> link to generate a new token. Once a token is created, authenticating API requests involves supplying the provided token via the <code>Authorization</code> HTTP header. Below is an example using <code>curl</code>:</p>
+      <div class="panel">
+          <div class="panel-body">
+              <h2 class="help-heading" id="help-topic-one">Authentication</h2>
+                  <p>The Account Settings page contains a field for an API token. If no API token exists, click the <code>Refresh</code> link to generate a new token. Once a token is created, authenticating API requests involves supplying the provided token via the <code>Authorization</code> HTTP header. Below is an example using <code>curl</code>:</p>
 
-      <pre class="hljs-wrapper" hljs hljs-language="bash" hljs-interpolate="true">
+                  <pre class="hljs-wrapper" hljs hljs-language="bash" hljs-interpolate="true">
 curl -H "Authorization: Token TOKEN" \
      -X GET "{{help.protocol}}://{{help.host}}/api/boundary-results/"</pre>
+          </div>
+      </div>
    </div>
   </div>
 </div>

--- a/src/angularjs/src/app/login/login.html
+++ b/src/angularjs/src/app/login/login.html
@@ -1,28 +1,34 @@
 <div class="container">
-  <div class="row">
-    <div class="col-sm-12">
+  <div class="row align-center stack-xs">
+    <div class="column-4">
       <div class="login">
-        <img class="logo" src="assets/images/people-for-bikes-icon.svg" alt="PfB Logo">
-        <form name="loginForm" novalidate ng-submit="login.login()">
-          <div class="form-group">
-            <label for="email">Email</label>
-            <input class="form-control"
-                   ng-model="login.email"
-                   id="email"
-                   type="text" required>
-          </div>
-          <div class="form-group">
-            <label for="password">Password</label>
-            <input class="form-control" ng-model="login.password" id="password" type="password" required>
-          </div>
-          <div class="form-action">
-            <button class="btn btn-primary btn-block" ng-disabled="loginForm.$invalid"
-                    type="submit">Sign In</button>
-            <div class="link-block">
-              <a class="secondary-link" ui-sref="request-password-reset">Reset Password</a>
+        <div class="row align-center stack-xs">
+            <div class="column-4 text-center">
+                <img class="logo" src="assets/images/people-for-bikes-icon.svg" alt="PfB Logo">
             </div>
+        </div>
+        <form name="loginForm" novalidate ng-submit="login.login()" class="panel">
+            <div class="panel-body">
+              <div class="form-group">
+                <label for="email">Email</label>
+                <input class="form-control"
+                       ng-model="login.email"
+                       id="email"
+                       type="text" required>
+              </div>
+              <div class="form-group">
+                <label for="password">Password</label>
+                <input class="form-control" ng-model="login.password" id="password" type="password" required>
+              </div>
+              <div class="form-action">
+                <button class="btn btn-primary btn-block" ng-disabled="loginForm.$invalid"
+                        type="submit">Sign In</button>
+              </div>
           </div>
         </form>
+        <div class="link-block">
+                  <a class="secondary-link" ui-sref="request-password-reset">Reset Password</a>
+                </div>
       </div>
     </div>
   </div>

--- a/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
+++ b/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
@@ -1,53 +1,45 @@
 <pfb-navbar></pfb-navbar>
 
 <div class="container">
-  <div class="row">
-    <div class="col-md-10 col-md-push-1">
+  <div class="row align-center">
+    <div class="column-10">
       <h1>Create Neighborhood</h1>
-      <form name="neighborhoodCreateForm" novalidate ng-submit="neighborhoodCreate.create()">
-        <div class="row">
-          <div class="col-sm-4">
-            <div class="form-group">
-              <label for="file">File</label>
-              <input ngf-select ng-model="neighborhoodCreate.file"
-                     ngf-pattern="'.zip'" ngf-accept="'.zip'"
-                     type="file" name="file" required>
-            </div>
-          </div>
-          <div class="col-sm-4">
-            <div class="form-group">
-              <label for="label">Label</label>
-              <input ng-model="neighborhoodCreate.label"
-                     class="form-control" id="label"
-                     type="text">
-            </div>
-          </div>
-          <div class="col-sm-4">
-            <div class="form-group">
-              <label for="role">State</label>
-              <select ng-model="neighborhoodCreate.state"
-                      ng-options="state as state.name for state in neighborhoodCreate.states
-                      track by state.abbr"
-                      class="form-control" id="role" type="text" required>
-              </select>
-            </div>
-          </div>
-          <div class="col-sm-4">
-            <div class="form-group">
-              <label for="role">Visibility</label>
-              <select ng-init="neighborhoodCreate.visibility = 'public'"
-                      ng-model="neighborhoodCreate.visibility"
-                      ng-options="v[0] as v[1] for v in neighborhoodCreate.visibilities"
-                      class="form-control" id="role" type="text">
-              </select>
-            </div>
-          </div>
+      <form name="neighborhoodCreateForm" novalidate ng-submit="neighborhoodCreate.create()" class="panel">
+        <div class="panel-body">
+        <div class="form-group">
+          <label for="file">File</label>
+          <input ngf-select ng-model="neighborhoodCreate.file"
+                 ngf-pattern="'.zip'" ngf-accept="'.zip'"
+                 type="file" name="file" required>
+        </div>
+        <div class="form-group">
+          <label for="label">Label</label>
+          <input ng-model="neighborhoodCreate.label"
+                 class="form-control" id="label"
+                 type="text">
+        </div>
+        <div class="form-group">
+          <label for="role">State</label>
+          <select ng-model="neighborhoodCreate.state"
+                  ng-options="state as state.name for state in neighborhoodCreate.states
+                  track by state.abbr"
+                  class="form-control" id="role" type="text" required>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="role">Visibility</label>
+          <select ng-init="neighborhoodCreate.visibility = 'public'"
+                  ng-model="neighborhoodCreate.visibility"
+                  ng-options="v[0] as v[1] for v in neighborhoodCreate.visibilities"
+                  class="form-control" id="role" type="text">
+          </select>
         </div>
         <div class="row">
-          <div class="col-sm-12">
+          <div class="column-12">
             <button type="submit" ng-disabled="neighborhoodCreateForm.$invalid"
                     class="btn-primary btn">Create Neighborhood</button>
           </div>
+        </div>
         </div>
       </form>
     </div>

--- a/src/angularjs/src/app/neighborhoods/list/neighborhoods-list.html
+++ b/src/angularjs/src/app/neighborhoods/list/neighborhoods-list.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
+    <div class="column-12">
       <button ng-if="neighborhoodList.isAdminUser"
         ui-sref="admin.neighborhoods.create" class="btn btn-primary pull-right">
         Upload Neighborhood

--- a/src/angularjs/src/app/organizations/detail/organizations-detail.html
+++ b/src/angularjs/src/app/organizations/detail/organizations-detail.html
@@ -2,26 +2,18 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
-        <div class="row">
-            <div class="col-sm-8 col-sm-offset-2">
-                <h1 ng-if="!org.editing">Add Organization</h1>
-                <h1 ng-if="org.editing">Edit Organization</h1>
-            </div>
-        </div>
-      <form name="orgForm" novalidate ng-submit="org.saveOrg()">
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
+    <div class="column-2"></div>
+    <div class="column-8">
+        <h1 ng-if="!org.editing">Add Organization</h1>
+        <h1 ng-if="org.editing">Edit Organization</h1>
+      <form name="orgForm" novalidate ng-submit="org.saveOrg()" class="panel">
+        <div class="panel-body">
             <div class="form-group">
               <label for="name">Name</label>
               <input ng-model="org.org.name"
                      class="form-control"
                      id="name" type="text" required>
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
             <div class="form-group">
               <label for="type">Type</label>
               <select ng-model="org.org.orgType"
@@ -29,16 +21,15 @@
                 <option ng-repeat="(value, key) in org.orgTypes" value="{{value}}">{{key}}</option>
               </select>
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
-            <button type="submit" ng-disabled="userForm.$invalid && !ctl.isAdminUser"
-                    class="btn-primary btn">
-              <span ng-if="!org.editing">Add Organization</span>
-              <span ng-if="org.editing">Save Changes</span>
-            </button>
-          </div>
+            <div class="row">
+              <div class="column-12">
+                <button type="submit" ng-disabled="userForm.$invalid && !ctl.isAdminUser"
+                        class="btn-primary btn">
+                  <span ng-if="!org.editing">Add Organization</span>
+                  <span ng-if="org.editing">Save Changes</span>
+                </button>
+              </div>
+            </div>
         </div>
       </form>
     </div>

--- a/src/angularjs/src/app/organizations/list/organizations-list.html
+++ b/src/angularjs/src/app/organizations/list/organizations-list.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
+    <div class="column-12">
       <button ui-sref="admin.organizations.create" class="btn btn-primary pull-right">New Organization</button>
       <h1 class="no-margin-top">Organization Management</h1>
       <table class="table">

--- a/src/angularjs/src/app/password-reset/request/password-reset-request.html
+++ b/src/angularjs/src/app/password-reset/request/password-reset-request.html
@@ -1,23 +1,29 @@
 <div class="container">
-  <div class="row">
-    <div class="col-sm-12">
+  <div class="row align-center stack-xs">
+    <div class="column-4">
       <div class="login">
-        <img class="logo" src="assets/images/people-for-bikes-icon.svg" alt="PfB Logo">
-        <form name="PWRequestForm" novalidate ng-submit="pw.requestReset()">
-          <h1 class="h2">Request Password Reset</h1>
-          <p>Check your email for password reset instructions</p>
-          <div class="form-group">
-            <label for="email">Email</label>
-            <input class="form-control" required id="email" ng-model="pw.email" type="text">
-          </div>
-          <div class="form-action">
-            <button class="btn btn-primary btn-block" ng-disabled="PWRequestForm.$invalid"
-                    type="submit">Reset password</button>
-            <div class="link-block">
-              <a class="secondary-link" ui-sref="login">Return to Sign In</a>
+        <div class="row align-center stack-xs">
+            <div class="column-4 text-center">
+                <img class="logo" src="assets/images/people-for-bikes-icon.svg" alt="PfB Logo">
             </div>
+        </div>
+        <form name="PWRequestForm" novalidate ng-submit="pw.requestReset()" class="panel">
+        <div class="panel-body">
+              <h1 class="h2">Request Password Reset</h1>
+              <p>Check your email for password reset instructions</p>
+              <div class="form-group">
+                <label for="email">Email</label>
+                <input class="form-control" required id="email" ng-model="pw.email" type="text">
+              </div>
+              <div class="form-action">
+                <button class="btn btn-primary btn-block" ng-disabled="PWRequestForm.$invalid"
+                        type="submit">Reset password</button>
+              </div>
           </div>
         </form>
+        <div class="link-block">
+            <a class="secondary-link" ui-sref="login">Return to Sign In</a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/angularjs/src/app/password-reset/reset/password-reset.html
+++ b/src/angularjs/src/app/password-reset/reset/password-reset.html
@@ -1,22 +1,30 @@
 <div class="container">
-  <div class="row">
-    <div class="col-sm-12">
+  <div class="row align-center stack-xs">
+    <div class="column-4">
       <div class="login">
-        <img class="logo" src="assets/images/people-for-bikes-icon.svg" alt="PfB Logo">
-        <form name="PWResetForm" novalidate ng-submit="pw.resetPassword()">
-          <h1 class="h2">Reset Password</h1>
-          <div class="form-group">
-            <label for="password">New Password</label>
-            <input class="form-control" required id="password" ng-model="pw.password" type="password">
-            <label for="password-confirm">Confirm Password</label>
-            <input class="form-control" required id="password-confirm" ng-model="pw.passwordConfirm" type="password">
-          </div>
-          <div class="form-action">
-            <button class="btn btn-primary btn-block" ng-disabled="PWResetForm.$invalid || pw.formSubmitted || pw.passwordConfirm !== pw.password"
-                    type="submit">Reset Password</button>
-            <div class="link-block">
-              <a class="secondary-link" ui-sref="login">Return to Sign In</a>
+        <div class="row align-center stack-xs">
+            <div class="column-4 text-center">
+                <img class="logo" src="assets/images/people-for-bikes-icon.svg" alt="PfB Logo">
             </div>
+        </div>
+        <form name="PWResetForm" novalidate ng-submit="pw.resetPassword()" class="panel">
+        <div class="panel-body">
+              <h1 class="h2">Reset Password</h1>
+              <div class="form-group">
+                <label for="password">New Password</label>
+                <input class="form-control" required id="password" ng-model="pw.password" type="password">
+              </div>
+              <div class="form-group">
+                <label for="password-confirm">Confirm Password</label>
+                <input class="form-control" required id="password-confirm" ng-model="pw.passwordConfirm" type="password">
+            </div>
+              <div class="form-action">
+                <button class="btn btn-primary btn-block" ng-disabled="PWResetForm.$invalid || pw.formSubmitted || pw.passwordConfirm !== pw.password"
+                        type="submit">Reset Password</button>
+                <div class="link-block">
+                  <a class="secondary-link" ui-sref="login">Return to Sign In</a>
+                </div>
+              </div>
           </div>
         </form>
       </div>

--- a/src/angularjs/src/app/users/detail/users-detail.html
+++ b/src/angularjs/src/app/users/detail/users-detail.html
@@ -2,46 +2,30 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
-        <div class="row">
-            <div class="col-sm-8 col-sm-offset-2">
-                <h1 ng-if="!user.editing">Add User</h1>
-                <h1 ng-if="user.editing">Edit User</h1>
-            </div>
-        </div>
-      <form name="userForm" novalidate ng-submit="user.saveUser()">
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
+    <div class="column-2"></div>
+    <div class="column-8">
+        <h1 ng-if="!user.editing">Add User</h1>
+        <h1 ng-if="user.editing">Edit User</h1>
+      <form name="userForm" novalidate ng-submit="user.saveUser()" class="panel">
+          <div class="panel-body">
             <div class="form-group">
               <label for="email">Email</label>
               <input ng-model="user.user.email"
                      class="form-control"
                      id="email" type="text" required>
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
             <div class="form-group">
               <label for="firstname">First Name</label>
               <input ng-model="user.user.firstName"
                      class="form-control" id="firstname"
                      type="text">
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
             <div class="form-group">
               <label for="lastname">Last Name</label>
               <input ng-model="user.user.lastName"
                      class="form-control" id="lastname"
                      type="text">
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
             <div class="form-group">
               <label for="role">Role</label>
               <select name="role" ng-model="user.user.role"
@@ -50,10 +34,6 @@
                 <option ng-repeat="(key, value) in user.roleOptions" value="{{key}}">{{value}}</option>
               </select>
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
             <div ng-if="user.organizations" class="form-group">
               <label for="organization">Organization</label>
               <select name="organization" ng-model="user.user.organization"
@@ -63,31 +43,30 @@
                         value="{{key}}">{{value.name}}</option>
               </select>
             </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-8 col-sm-offset-2">
             <div class="form-group" ng-if="user.user.uuid">
               <label for="organization">API Token <a ng-click="user.createToken()" href="">Refresh</a></label>
               <input ng-model="user.token" ng-readonly="true" class="form-control" type="text" size="34">
             </div>
-          </div>
-          <div class="col-xs-8 col-sm-offset-2">
-            <button type="submit" ng-disabled="userForm.$invalid && !ctl.isAdminUser && !userForm.$dirty || userForm.organization.$error.required || userForm.role.$error.required"
-                    class="btn-primary btn">
-              <span ng-if="!user.user.uuid">Add User</span>
-              <span ng-if="user.user.uuid">Save Changes</span>
-            </button>
-            <button
-                type="button"
-                ng-if="user.user.uuid"
-                ng-click="user.setUserActive(!user.user.isActive)"
-                ng-disabled="ctl.isAdminUser || user.loggedInUsername === user.user.username"
-                class="btn-danger btn">
-              <span ng-if="!user.user.isActive">Activate User</span>
-              <span ng-if="user.user.isActive">Deactivate User</span>
-            </button>
-          </div>
+
+            <div class="row">
+              <div class="column-12">
+              <button type="submit" ng-disabled="userForm.$invalid && !ctl.isAdminUser && !userForm.$dirty || userForm.organization.$error.required || userForm.role.$error.required"
+                        class="btn-primary btn">
+                  <span ng-if="!user.user.uuid">Add User</span>
+                  <span ng-if="user.user.uuid">Save Changes</span>
+                </button>
+                <button
+                    type="button"
+                    ng-if="user.user.uuid"
+                    ng-click="user.setUserActive(!user.user.isActive)"
+                    ng-disabled="ctl.isAdminUser || user.loggedInUsername === user.user.username"
+                    class="btn-danger btn">
+                  <span ng-if="!user.user.isActive">Activate User</span>
+                  <span ng-if="user.user.isActive">Deactivate User</span>
+                </button>
+              </div>
+            </div>
+        </div>
       </form>
     </div>
   </div>

--- a/src/angularjs/src/app/users/list/users-list.html
+++ b/src/angularjs/src/app/users/list/users-list.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-10 col-md-push-1">
+    <div class="column-12">
       <button ui-sref="admin.users.create" class="btn btn-primary pull-right">New User</button>
       <h1 class="no-margin-top">User Management</h1>
       <table class="table">

--- a/src/angularjs/src/styles/components/_form.scss
+++ b/src/angularjs/src/styles/components/_form.scss
@@ -36,14 +36,14 @@ label {
 
   // Placeholders
   &::-moz-placeholder {
-    color: $shade-light;
+    color: $shade-normal;
     opacity: 1;
   }
   &:-ms-input-placeholder {
-    color: $shade-light;
+    color: $shade-normal;
   }
   &::-webkit-input-placeholder {
-    color: $shade-light;
+    color: $shade-normal;
   }
 
   // Unstyle the caret on `<select>`s in IE10+.

--- a/src/angularjs/src/styles/components/_panel.scss
+++ b/src/angularjs/src/styles/components/_panel.scss
@@ -1,0 +1,9 @@
+.panel {
+    background-color: #fff;
+    position: relative;
+    border: 1px solid #ddd;
+}
+
+.panel-body {
+    padding: 1.5rem;
+}

--- a/src/angularjs/src/styles/components/_table.scss
+++ b/src/angularjs/src/styles/components/_table.scss
@@ -1,0 +1,61 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #ddd;
+  margin-bottom: 1rem;
+
+  thead {
+    text-align: left;
+
+    th, td {
+      font-weight: 600;
+    }
+  }
+
+  tbody {
+    text-align: left;
+
+    > tr:hover {
+      background-color: #f3f3f3;
+    }
+  }
+
+  th,
+  td {
+    border-bottom: 1px solid #ddd;
+    padding: 2rem 1.5rem;
+  }
+}
+
+.table-responsive {
+  overflow: auto;
+  white-space: nowrap;
+}
+
+.table-mobile-stacked {
+  @include respond-to(xs) {
+
+    thead {
+      display: none;
+    }
+
+    tr {
+      border-bottom: 1px solid #ddd;
+    }
+
+    tbody [data-th] {
+      display: block;
+      text-align: right;
+      border: none;
+      padding: 1rem;
+
+      &:before {
+        content: attr(data-th);
+        font-weight: 600;
+        display: inline-block;
+        margin-right: 1rem;
+        float: left;
+      }
+    }
+  }
+}

--- a/src/angularjs/src/styles/index.scss
+++ b/src/angularjs/src/styles/index.scss
@@ -40,6 +40,8 @@
   "components/nav",
   "components/network-score",
   "components/map",
+  "components/panel",
+  "components/table",
   "components/tooltip";
 
 /**


### PR DESCRIPTION
## Overview

This PR attempts to cleanup all admin pages including auth pages, user management, etc.
Tables and panel styling have been added to the scss.
Removes all reference to bootstrap grid system since we aren't using it.


### Demo
<img width="1130" alt="screen shot 2017-05-22 at 5 24 31 pm" src="https://cloud.githubusercontent.com/assets/1928955/26329462/63907b30-3f15-11e7-95c0-8fb57c151f98.png">
<img width="484" alt="screen shot 2017-05-22 at 5 36 30 pm" src="https://cloud.githubusercontent.com/assets/1928955/26329461/638cc45e-3f15-11e7-83f3-10966c1bf14a.png">


## Testing Instructions

 * View login and password reset pages
 * View all admin pages


Connects #305
