### PR TITLE
clean up places and methodology page

### DIFF
--- a/src/angularjs/src/app/methodology.html
+++ b/src/angularjs/src/app/methodology.html
@@ -8,7 +8,6 @@
         </h2>
         <div class="column-12">
                 <div class="card alternate">
-                    <div class="card-image"></div>
                     <div class="card-details">
                         <p>The Bike Network Analysis (BNA) score is an evolving project to measure how well bike networks connect people with the places they want to go. Because most people are interested in biking only when it's a low-stress option, our maps recognize only low-stress biking connections.</p>
 

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -40,14 +40,12 @@
                         <li ng-repeat="m in compare.metadata"
                             ng-if="place.scores[m.name]">
                             {{ ::m.label }}
-                            <div class="tooltip" title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
+                            <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
                             <span class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
                         </li>
                         <li>
-                            <section>
                                 <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"
                                     class="btn btn-secondary btn-block">View Place</a>
-                            </section>
                         </li>
                     </ul>
                 </div>

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -74,7 +74,7 @@
             if (!ctl.printButton) {
                 ctl.printButton = L.control.mapButton({
                     controlClasses: ['leaflet-control-layers'],
-                    iconClasses: ['icon-print']
+                    iconClasses: ['leaflet-btn icon-print']
                 }, function () {
                     $window.print();
                 }).addTo(ctl.map);

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -35,7 +35,7 @@
                     </div>
                     <div class="column text-right">
 
-                    <div class="btn-group dropdown" uib-dropdown is-open="status.isopen"
+                    <div class="dropdown" uib-dropdown is-open="status.isopen"
                         ng-if="placeDetail.downloads">
                       <button id="single-button" type="button" class="btn btn-default btn-s" uib-dropdown-toggle ng-disabled="disabled" id="downloadButton">
                         Download <span class="caret"></span>
@@ -62,7 +62,7 @@
             <li ng-repeat="m in placeDetail.metadata"
                 ng-if="placeDetail.scores[m.name]">
                 {{ ::m.label }}
-                <div class="tooltip" title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
+                <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
                 <span class="network-score small">{{ ::placeDetail.scores[m.name].score_normalized | number:0 }}</span>
             </li>
         </ul>

--- a/src/angularjs/src/styles/components/_map.scss
+++ b/src/angularjs/src/styles/components/_map.scss
@@ -14,3 +14,16 @@
 .pfb-control-map-button {
   cursor: pointer;
 }
+
+.leaflet-btn {
+  width: 44px;
+  height: 44px;
+
+  &[class*=icon-] {
+    display: block;
+    font-size: 20px;
+    line-height: 44px;
+    text-align: center;
+    color: #000;
+  }
+}

--- a/src/angularjs/src/styles/components/_tooltip.scss
+++ b/src/angularjs/src/styles/components/_tooltip.scss
@@ -8,7 +8,7 @@
   display: inline-block;
 
   &:after {
-    content: attr(title);
+    content: attr(data-title);
     position: absolute;
     top: 50%;
     left: 100%;
@@ -21,7 +21,7 @@
     opacity: 0;
     pointer-events: none;
     font-size: 1.4rem;
-    padding: 4px 10px;
+    padding: 10px 15px;
     font-weight: 400;
     width: auto;
     min-width: 140px;

--- a/src/angularjs/src/styles/pages/_location.scss
+++ b/src/angularjs/src/styles/pages/_location.scss
@@ -1,14 +1,22 @@
 .location-overview {
 
   .metric-details {
-    padding: 1rem 2rem;
+    padding: 0 2rem;
     background-color: $shade-light;
     border-bottom: 1px solid darken($shade-light, 5%);
     position: relative;
-    z-index: 1;
+    z-index: 99;
 
-    .column {
-      padding: 0;
+    .row {
+      margin: 0;
+    }
+
+    .network-score {
+      margin: 0;
+
+      .h3 {
+        margin-left: 1rem;
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

- Cleans up Place page, including sidebar list, print button (not print css) and download dropdown
- Removes image markup from methodology page
- Change tooltip's functionality from using `title` to `data-title`. This was done to prevent the browser's default title hover from showing over the app's tooltip hover interaction.


### Demo
<img width="1333" alt="screen shot 2017-05-22 at 6 05 31 pm" src="https://cloud.githubusercontent.com/assets/1928955/26330434/de4d90b6-3f19-11e7-9084-faf6765e9622.png">


## Testing Instructions

 * Hover tooltips
 * Try downloading from dropdown


- fixes #463
- fixes #462
