### PR TITLE
removes about, adds active states to navbar

### DIFF
--- a/src/angularjs/src/app/components/footer/footer.html
+++ b/src/angularjs/src/app/components/footer/footer.html
@@ -8,12 +8,12 @@
         </div>
         <nav class="footer-right">
             <a ui-sref="places.list">All places</a>
-            <a ui-sref="home">About</a>
-            <a href="http://www.peopleforbikes.org/placesforbikes/pages/bike-network-analysis" target="_blank">How can I get a BNA for my place?</a>
             <a ui-sref="methodology">Methodology</a>
-            <a href="http://www.peopleforbikes.org/" target="_blank">PeopleForBikes</a>
             <a ng-if="footer.loggedIn" ui-sref="login" ng-click="footer.logout()">Sign Out</a>
             <a ng-if="!footer.loggedIn" ui-sref="login">Sign In</a>
+            <br>
+            <a href="http://www.peopleforbikes.org/placesforbikes/pages/bike-network-analysis" target="_blank">How can I get a BNA for my place?</a>
+            <a href="http://www.peopleforbikes.org/" target="_blank">PeopleForBikes</a>
         </nav>
     </div>
 </footer>

--- a/src/angularjs/src/app/components/navbar/navbar.html
+++ b/src/angularjs/src/app/components/navbar/navbar.html
@@ -11,9 +11,8 @@
     <div class="navbar-right">
       <nav>
         <span ng-if="!navbar.admin">
-          <a ui-sref="places.list">All places</a>
-          <a ui-sref="home">About</a>
-          <a ui-sref="methodology">Methodology</a>
+          <a ui-sref="places.list" ui-sref-active="active">All places</a>
+          <a ui-sref="methodology" ui-sref-active="active">Methodology</a>
           <a href="http://www.peopleforbikes.org/placesforbikes/pages/bike-network-analysis"
             target="_blank">Feedback</a>
           <a href="http://www.peopleforbikes.org/" target="_blank">PeopleForBikes</a>

--- a/src/angularjs/src/styles/layout/_navbar.scss
+++ b/src/angularjs/src/styles/layout/_navbar.scss
@@ -27,6 +27,11 @@
       &:hover {
         color: $link-color;
       }
+
+      &.active {
+        color: $link-color;
+        box-shadow: 0 2px 0 0 $link-color;
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview
This PR will remove the about link from the navbar and the footer. There are also active states for the links in the navbar.


### Demo
<img width="1315" alt="screen shot 2017-05-24 at 10 52 27 am" src="https://cloud.githubusercontent.com/assets/1928955/26409767/83ebe38c-406f-11e7-9bee-d198a723a3c1.png">


Fixes #450
