### PR TITLE
Fix bad escape in people score calc on about page

### DIFF
--- a/src/angularjs/src/app/home/home.controller.js
+++ b/src/angularjs/src/app/home/home.controller.js
@@ -24,7 +24,7 @@
         ctl.cities = null;
         ctl.scoreCards = [{
             title: 'People',
-            description: 'Sometimes you want to meet at a friend&#39s house or visit your parents. It is important for bike networks to connect people to each other. Our People measure uses population data from the U.S. Census to determine how well you are connected by bike to the people around you.'
+            description: 'Sometimes you want to meet at a friend\'s house or visit your parents. It is important for bike networks to connect people to each other. Our People measure uses population data from the U.S. Census to determine how well you are connected by bike to the people around you.'
         }, {
             title: 'Opportunity',
             description: 'Jobs and education are critical to ensuring that everyone has opportunities to improve their situation. Our Opportunity measure uses job data from the U.S. Census along with locations of K-12 schools, vocational and technical colleges, and institutes of higher education to evaluate how easily you can access these opportunities by bike.'


### PR DESCRIPTION
## Overview

Fixes bad encoding on home page score cards. HTML encoding doesn't work, presumably due to angular's internal escaping.

### Demo

![screen shot 2017-05-25 at 12 47 45](https://cloud.githubusercontent.com/assets/1818302/26460696/74c3d5e8-4148-11e7-840f-cd16016f1377.png)

Trivial, merging.
