### PR TITLE
Closes #461: Add map legend for blocks/ways

### DIFF
--- a/src/angularjs/src/app/leaflet/map-legend.control.js
+++ b/src/angularjs/src/app/leaflet/map-legend.control.js
@@ -1,0 +1,35 @@
+(function() {
+
+    // Custom private Leaflet control implements a simple legend for all map layers
+    L.Control.Legend = L.Control.extend({
+        initialize: function (options) {
+            L.Util.setOptions(this, options);
+            var labels = options.labels;
+            if (!(labels && labels.length)) {
+                throw 'L.Control.Legend requires a labels array';
+            }
+            var colors = options.colors;
+            if (!(colors && colors.length)) {
+                throw 'L.Control.Legend requires a colors array';
+            }
+            if (labels.length !== colors.length) {
+                throw 'L.Control.Legend requires colors and labels to be the same size';
+            }
+            this.colors = colors;
+            this.labels = labels;
+        },
+        onAdd: function () {
+            var div = L.DomUtil.create('div', 'leaflet-control-layers pfb-control-legend');
+            for (var i = 0; i < this.colors.length; i++) {
+                div.innerHTML +=
+                    '<i style="background:' + this.colors[i] + '"></i> ' + this.labels[i] + '<br>';
+            }
+            return div;
+        }
+    });
+    if (!L.control.legend) {
+        L.control.legend = function (opts) {
+            return new L.Control.Legend(opts);
+        }
+    }
+})();

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -1,10 +1,23 @@
 (function() {
 
     /* @ngInject */
-    function PlaceMapController($filter, $http, $sanitize, $q, $window, MapConfig, Neighborhood) {
+    function PlaceMapController($log, $filter, $http, $sanitize, $q, $window, MapConfig, Neighborhood) {
         var ctl = this;
         ctl.map = null;
         ctl.layerControl = null;
+
+        ctl.legends = {
+            census_blocks: {
+                position: 'bottomright',
+                colors: ['#e2231a', '#c92433', '#b1264d', '#982766', '#802980', '#664396', '#4c5eac', '#3378c2', '#1993d8', '#00aeef'],
+                labels: ['0 - 6', '6 - 12', '12 - 18', '18 - 24', '24 - 30', '30 - 36', '36 - 42', '42 - 48', '48 - 54', '54 - 100']
+            },
+            ways: {
+                position: 'bottomright',
+                colors: ['#00aeef', '#e2231a'],
+                labels: ['Low Stress', 'High Stress']
+            }
+        }
 
         ctl.$onInit = function () {
             ctl.mapOptions = {
@@ -33,8 +46,26 @@
             }
         };
 
+        ctl.onLayerAdd = function (event) {
+            var layer = event.layer;
+            var legend = layer.legend;
+            if (legend) {
+                legend.addTo(ctl.map);
+            }
+        }
+
+        ctl.onLayerRemove = function (event) {
+            var layer = event.layer;
+            var legend = layer.legend;
+            if (legend) {
+                legend.remove();
+            }
+        }
+
         ctl.onMapReady = function (map) {
             ctl.map = map;
+            ctl.map.on('layeradd', ctl.onLayerAdd);
+            ctl.map.on('layerremove', ctl.onLayerRemove);
 
             // in case map layers set before map was ready, add layers now map is ready to go
             if (ctl.pfbPlaceMapLayers) {
@@ -89,6 +120,12 @@
                 var layer = L.tileLayer(layerObj.url, {
                     maxZoom: MapConfig.conusMaxZoom
                 });
+
+                // Add legend object to layer so it can be toggled in layer event handler
+                var legendOptions = ctl.legends[layerObj.name];
+                if (legendOptions) {
+                    layer.legend = L.control.legend(legendOptions);
+                }
                 // Desired default view is showing the network, so add that to the map
                 if (layerObj.name === 'ways') {
                     ctl.map.addLayer(layer);

--- a/src/angularjs/src/styles/components/_map.scss
+++ b/src/angularjs/src/styles/components/_map.scss
@@ -27,3 +27,17 @@
     color: #000;
   }
 }
+
+.pfb-control-legend {
+  padding: 5px;
+  line-height: 18px;
+  color: #555;
+
+  i {
+    width: 18px;
+    height: 18px;
+    float: left;
+    margin-right: 8px;
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Overview

Adds map legend for ways and blocks overlays as requested in #461 

### Demo

![screen shot 2017-05-30 at 14 39 53](https://cloud.githubusercontent.com/assets/1818302/26600385/defe749a-4549-11e7-9b4d-f0c66ae5a20d.png)
![screen shot 2017-05-30 at 14 40 00](https://cloud.githubusercontent.com/assets/1818302/26600383/defcf5ca-4549-11e7-9572-d286c1dea8c5.png)
![screen shot 2017-05-30 at 14 40 08](https://cloud.githubusercontent.com/assets/1818302/26600384/defd7d42-4549-11e7-89a1-4874a7f0ea7f.png)

### Notes

Map logic in the place map directive continues to be a bit janky, but it didn't feel like there was a great way to clean this up with the changes here.

## Testing Instructions

 * Toggle all of the different map layers on/off as desired. Legends should properly show when ways/blocks layers are active, and disappear otherwise.

Closes #461 
