### PR TITLE
Add detail compare button

### DIFF
--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -32,12 +32,10 @@
                             <div class="tooltip" data-title="On average, this is how well the bike network gets people to the places they want to go."><i class="icon-info-circled"></i></div>
                         </label>
                     </div>
-                    <div class="column">
+                    <div class="column text-right">
                         <button class="btn btn-default" type="button"
                             ui-sref="places.compare({place1: placeDetail.place.uuid})">Compare
                         </button>
-                    </div>
-                    <div class="column text-right">
                         <div class="dropdown" uib-dropdown is-open="status.isopen"
                             ng-if="placeDetail.downloads">
                           <button id="single-button" type="button" class="btn btn-default btn-s" uib-dropdown-toggle ng-disabled="disabled" id="downloadButton">

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -32,20 +32,25 @@
                             <div class="tooltip" data-title="On average, this is how well the bike network gets people to the places they want to go."><i class="icon-info-circled"></i></div>
                         </label>
                     </div>
+                    <div class="column">
+                        <button class="btn btn-default" type="button"
+                            ui-sref="places.compare({place1: placeDetail.place.uuid})">Compare
+                        </button>
+                    </div>
                     <div class="column text-right">
-
-                    <div class="dropdown" uib-dropdown is-open="status.isopen"
-                        ng-if="placeDetail.downloads">
-                      <button id="single-button" type="button" class="btn btn-default btn-s" uib-dropdown-toggle ng-disabled="disabled" id="downloadButton">
-                        Download <span class="caret"></span>
-                      </button>
-                      <ul class="dropdown-menu" uib-dropdown-menu role="menu"
-                        aria-labelledby="downloadButton">
-                        <li ng-repeat="item in placeDetail.downloads">
-                            <a role="menuitem" href="{{item.url}}"
-                                class="compare-remove">{{item.label}}</a>
-                        </li>
-                      </ul>
+                        <div class="dropdown" uib-dropdown is-open="status.isopen"
+                            ng-if="placeDetail.downloads">
+                          <button id="single-button" type="button" class="btn btn-default btn-s" uib-dropdown-toggle ng-disabled="disabled" id="downloadButton">
+                            Download <span class="caret"></span>
+                          </button>
+                          <ul class="dropdown-menu" uib-dropdown-menu role="menu"
+                            aria-labelledby="downloadButton">
+                            <li ng-repeat="item in placeDetail.downloads">
+                                <a role="menuitem" href="{{item.url}}"
+                                    class="compare-remove">{{item.label}}</a>
+                            </li>
+                          </ul>
+                        </div>
                     </div>
                 </div>
                 <div class="row" ng-if="!placeDetail.lastJobScore">

--- a/src/angularjs/src/styles/components/_button.scss
+++ b/src/angularjs/src/styles/components/_button.scss
@@ -71,7 +71,7 @@
 .btn-default {
   background: #fff;
   border-color: $shade-normal;
-  color: $shade-dark;
+  color: #000;
 
   &:hover, &.hover,
   &:active, &.active, {
@@ -146,7 +146,7 @@
   @include button-states($danger);
 }
 
-/* 
+/*
  * Button Sizes
  */
 .btn-tiny {
@@ -169,7 +169,7 @@
 }
 
 
-/* 
+/*
  * Button actions
  */
 .btn-toggle {
@@ -247,7 +247,7 @@
 }
 
 
-/* 
+/*
  * Button groups
  */
 .btn-group {

--- a/src/angularjs/src/styles/pages/_location.scss
+++ b/src/angularjs/src/styles/pages/_location.scss
@@ -1,5 +1,9 @@
 .location-overview {
 
+    .dropdown {
+      display: inline;
+    }
+
   .metric-details {
     padding: 0 2rem;
     background-color: $shade-light;


### PR DESCRIPTION
## Overview

Add button to header of place detail page that links to compare page.
Current place gets put in first slot of comparison page.

### Demo

![image](https://cloud.githubusercontent.com/assets/960264/26639634/66c5bf38-45f3-11e7-8c10-43217aa60261.png)


### Notes

@designmatty might want to look at this. Default button styling is grey text until hover, which looks somewhat low-contrast on the grey header bar.

Closes #489.