### PR TITLE
Feature/kak/indent subscores#457

### DIFF
--- a/src/angularjs/src/app/components/scoremetadata.service.js
+++ b/src/angularjs/src/app/components/scoremetadata.service.js
@@ -8,6 +8,47 @@
 (function() {
     'use strict';
 
+    /**
+     Sort metrics in metadata by category, with total first in the category.
+     Add subscoreClass property to metrics that should be indented under the total.
+     */
+    function orderCategories(response) {
+        var metadata = [];
+
+        // remove overall score and group into categories
+        var groupedMetadata = _.chain(response).reject(function(m) {
+            return m.name === 'overall_score';
+        }).groupBy('category').value();
+
+        // sort by category name (note population category is blank string and sorts to top)
+        var categories = _.keys(groupedMetadata).sort();
+
+        // Build metadata array, sorted by category.
+        // Category total metric comes first within a category, if it exists.
+        // If it does exist, the other metrics within its category have a special property added,
+        // 'subscoreClass', which can be used to format sub-scores under the total.
+        _.each(categories, function(category) {
+            var metrics = groupedMetadata[category];
+            var totalMetric = _.remove(metrics, function(metric) {
+                return metric.label && metric.label.indexOf(' Total') > -1;
+            });
+
+            if (totalMetric && totalMetric.length) {
+                totalMetric = totalMetric[0]; // remove returns an array
+                metadata.push(totalMetric);
+                _.each(metrics, function(metric) {
+                    metric.subscoreClass = 'subscore';
+                    metadata.push(metric);
+                });
+            } else {
+                _.each(metrics, function(metric) {
+                    metadata.push(metric);
+                });
+            }
+        });
+        return metadata;
+    }
+
     /* @ngInject */
     function ScoreMetadata($http) {
         return {
@@ -17,7 +58,7 @@
         function query() {
             return $http.get('/api/score_metadata/', {cache: true}).then(function (response) {
                 var metadata = response.data || [];
-                return _.filter(metadata, function (m) { return m.name !== 'overall_score'; });
+                return orderCategories(metadata);
             });
         }
     }

--- a/src/angularjs/src/app/components/scoremetadata.service.js
+++ b/src/angularjs/src/app/components/scoremetadata.service.js
@@ -17,7 +17,7 @@
         function query() {
             return $http.get('/api/score_metadata/', {cache: true}).then(function (response) {
                 var metadata = response.data || [];
-                return _.filter(metadata, function (m) { return m.name !== "overall_score" });
+                return _.filter(metadata, function (m) { return m.name !== 'overall_score'; });
             });
         }
     }

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -36,7 +36,8 @@
             // do not display any place until all places have been retrieved
             $q.all(promises).then(function(results) {
                 // first element is the metadata; rest are the places
-                ctl.metadata = _.head(results);
+                ctl.metadata = _.chain(results).head().groupBy('category').value();
+                $log.debug(ctl.metadata);
 
                 ctl.places = _.drop(results);
             }, function(error) {

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -35,8 +35,27 @@
 
             // do not display any place until all places have been retrieved
             $q.all(promises).then(function(results) {
-                // first element is the metadata; rest are the places
-                ctl.metadata = _.chain(results).head().groupBy('category').value();
+                // first element in results is the metadata; rest are the places
+                var groupedMetadata = _.chain(results).head().groupBy('category').value();
+                ctl.metadata = [];
+                _.each(groupedMetadata, function(metrics) {
+                    var totalMetric = _.remove(metrics, function(metric) {
+                        return metric.label && metric.label.indexOf('Total') > -1;
+                    });
+
+                    if (totalMetric && totalMetric.length) {
+                        totalMetric = totalMetric[0]; // remove returns an array
+                        ctl.metadata.push(totalMetric);
+                        _.each(metrics, function(metric) {
+                            metric.subscoreClass = 'subscore';
+                            ctl.metadata.push(metric);
+                        });
+                    } else {
+                        _.each(metrics, function(metric) {
+                            ctl.metadata.push(metric);
+                        });
+                    }
+                });
                 $log.debug(ctl.metadata);
 
                 ctl.places = _.drop(results);

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -38,9 +38,12 @@
                 // first element in results is the metadata; rest are the places
                 var groupedMetadata = _.chain(results).head().groupBy('category').value();
                 ctl.metadata = [];
-                _.each(groupedMetadata, function(metrics) {
+                var categories = _.keys(groupedMetadata).sort();
+                $log.debug(categories);
+                _.each(categories, function(category) {
+                    var metrics = groupedMetadata[category];
                     var totalMetric = _.remove(metrics, function(metric) {
-                        return metric.label && metric.label.indexOf('Total') > -1;
+                        return metric.label && metric.label.indexOf(' Total') > -1;
                     });
 
                     if (totalMetric && totalMetric.length) {

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -36,31 +36,7 @@
             // do not display any place until all places have been retrieved
             $q.all(promises).then(function(results) {
                 // first element in results is the metadata; rest are the places
-                var groupedMetadata = _.chain(results).head().groupBy('category').value();
-                ctl.metadata = [];
-                var categories = _.keys(groupedMetadata).sort();
-                $log.debug(categories);
-                _.each(categories, function(category) {
-                    var metrics = groupedMetadata[category];
-                    var totalMetric = _.remove(metrics, function(metric) {
-                        return metric.label && metric.label.indexOf(' Total') > -1;
-                    });
-
-                    if (totalMetric && totalMetric.length) {
-                        totalMetric = totalMetric[0]; // remove returns an array
-                        ctl.metadata.push(totalMetric);
-                        _.each(metrics, function(metric) {
-                            metric.subscoreClass = 'subscore';
-                            ctl.metadata.push(metric);
-                        });
-                    } else {
-                        _.each(metrics, function(metric) {
-                            ctl.metadata.push(metric);
-                        });
-                    }
-                });
-                $log.debug(ctl.metadata);
-
+                ctl.metadata = _.head(results);
                 ctl.places = _.drop(results);
             }, function(error) {
                 $log.error('Failed to retrieve places to compare:');

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -37,15 +37,13 @@
                             pfb-thumbnail-map-place="place.neighborhood.uuid"></pfb-thumbnail-map>
                     </div>
                     <ul class="metric-list">
-                        <span ng-repeat="(category, metrics) in compare.metadata">
-                            <li><h2>{{ ::category }}</h2></li>
-                            <li ng-repeat="m in metrics"
-                                ng-if="place.scores[m.name]">
-                                {{ ::m.label }}
-                                <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
-                                <span class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
-                            </li>
-                        </span>
+                        <li ng-repeat="m in compare.metadata"
+                            ng-if="place.scores[m.name]"
+                            ng-class="m.subscoreClass">
+                            {{ ::m.label }}
+                            <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
+                            <span class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
+                        </li>
                         <li>
                             <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"
                                 class="btn btn-secondary btn-block">View Place</a>

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -37,15 +37,18 @@
                             pfb-thumbnail-map-place="place.neighborhood.uuid"></pfb-thumbnail-map>
                     </div>
                     <ul class="metric-list">
-                        <li ng-repeat="m in compare.metadata"
-                            ng-if="place.scores[m.name]">
-                            {{ ::m.label }}
-                            <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
-                            <span class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
-                        </li>
+                        <span ng-repeat="(category, metrics) in compare.metadata">
+                            <li><h2>{{ ::category }}</h2></li>
+                            <li ng-repeat="m in metrics"
+                                ng-if="place.scores[m.name]">
+                                {{ ::m.label }}
+                                <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
+                                <span class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
+                            </li>
+                        </span>
                         <li>
-                                <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"
-                                    class="btn btn-secondary btn-block">View Place</a>
+                            <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"
+                                class="btn btn-secondary btn-block">View Place</a>
                         </li>
                     </ul>
                 </div>

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -59,7 +59,8 @@
         </section>
         <ul class="metric-list">
             <li ng-repeat="m in placeDetail.metadata"
-                ng-if="placeDetail.scores[m.name]">
+                ng-if="placeDetail.scores[m.name]"
+                ng-class="m.subscoreClass">
                 {{ ::m.label }}
                 <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
                 <span class="network-score small">{{ ::placeDetail.scores[m.name].score_normalized | number:0 }}</span>

--- a/src/angularjs/src/styles/components/_metrics.scss
+++ b/src/angularjs/src/styles/components/_metrics.scss
@@ -10,6 +10,10 @@
     margin: 0;
     border-top: 1px solid #ddd;
     font-size: 1.8rem;
+
+    &.subscore {
+        padding-left: 4rem;
+    }
   }
 
   .network-score {


### PR DESCRIPTION
## Overview

Modify display of scores lists on comparison page and places detail page:
 - sort metrics into category
 - alphabetize by category
 - list 'total' score for category, if it exists, first
 - if 'total' exists, indent other metrics (sub-scores) listed below it


### Demo

Top of places detail:
![image](https://cloud.githubusercontent.com/assets/960264/26646349/3dfbfdfe-4609-11e7-8e29-2389238427b8.png)

Bottom of comparison page list:

![image](https://cloud.githubusercontent.com/assets/960264/26646383/5e406a50-4609-11e7-8208-9f129d940b88.png)


### Notes

One category is an empty string, and so sorts first (population and the 'people' score.)

Identifying the category total metric relies on finding 'Total', preceded by a space, in the metric label; the space is required because one of the metrics is called 'Total Population', which does not represent a summary metric for its category.


Closes #457
