### PR TITLE
Implement section headers for alphabetical/pop sorting

### DIFF
--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -72,9 +72,10 @@
 
             The stick headers are probably only needed when sorting alphabetically. -->
     <div class="sidebar-scrollable" id="scrollHeaders">
-        <section>
+        <section ng-repeat="s in placeList.sections">
+            <div class="section-title" title="{{ ::s }}" ng-if="s !== 'SKIPHEADER'">{{ ::s }}</div>
             <!-- Duplicate .result div for each result. -->
-            <div class="result" ng-repeat="neighborhood in placeList.places track by neighborhood.uuid">
+            <div class="result" ng-repeat="neighborhood in placeList.places[s] track by neighborhood.uuid">
                 <a ui-sref="places.detail({uuid: '{{neighborhood.uuid}}' })" class="result-link"></a>
                 <div class="result-left">
 


### PR DESCRIPTION
## Overview

Implements section headers in place list view for the alphabetical and population sort options.

### Demo

<img width="500" alt="screen shot 2017-05-31 at 14 11 27" src="https://cloud.githubusercontent.com/assets/1818302/26649162/f3c0b28e-4612-11e7-9ef2-72ff68336391.png">
<img width="498" alt="screen shot 2017-05-31 at 14 11 39" src="https://cloud.githubusercontent.com/assets/1818302/26649160/f3bcb4b8-4612-11e7-8a4d-11f4cdb86138.png">
<img width="499" alt="screen shot 2017-05-31 at 14 12 05" src="https://cloud.githubusercontent.com/assets/1818302/26649161/f3bde7e8-4612-11e7-8ddf-167cd684647d.png">


### Notes

Section headers are sorted alphabetically before rendering, which works for the two options we're using for now ('Large', 'Medium', 'Small', 'Unknown' sorts in the proper order). Would need to implement an additional option if we needed to sort the headers in some other way.

The lodash groupBy documentation states that 'the order of grouped values is determined by the order they occur in collection, so original sort order within a section is preserved through the groupBy for when we later render each place.

Use of a special key for not displaying a section header is a bit janky, but wasn't sure of a better way to allow for some sort options to show headers and some to not do so without extensive use of ifs in the template.

## Testing Instructions

Ensure you have more than one or two valid places, then select each of the sort options. The headers should display as expected.

Closes #326 
