### PR TITLE
print styling

### DIFF
--- a/src/angularjs/src/app/components/navbar/navbar.html
+++ b/src/angularjs/src/app/components/navbar/navbar.html
@@ -4,7 +4,7 @@
     <div class="navbar-left">
       <a ui-sref="home" class="brand">
         <img ng-if="navbar.hideName" src="assets/images/people-for-bikes-icon.svg" alt="Places for bikes">
-        <img ng-if="!navbar.hideName" srcset="assets/images/people-for-bikes-logo.svg" alt="Places for bikes">
+        <img ng-if="!navbar.hideName" src="assets/images/people-for-bikes-logo.svg" alt="Places for bikes">
       </a>
     </div>
     <!-- Logo area -->

--- a/src/angularjs/src/styles/base/_print.scss
+++ b/src/angularjs/src/styles/base/_print.scss
@@ -1,16 +1,15 @@
 @media print {
   .navbar {
-    .navbar-right {
-      display: none;
-    }
+    display: none;
   }
 
   .preview-map {
+    top: 0;
     height: 320px;
     width: 100%;
     position: absolute;
-    left: initial;
-    right: initial;
+    left: 0;
+    right: 0;
     bottom: initial;
     display: block !important;
 
@@ -33,6 +32,10 @@
     }
   }
 
+  .location-timestamp {
+    opacity: 1;
+  }
+
   .metric-details {
 
     .column.text-right {
@@ -40,18 +43,23 @@
     }
 
     .network-score {
-      display: flex;
+      display: block;
       flex-direction: column;
       font-size: 30px;
+      margin: 5px;
+      text-align: center;
     }
   }
 
   .sidebar {
     position: relative;
-    top: 320px;
+    margin-top: 320px;
     bottom: initial;
     border: none;
     width: auto;
+    height: auto;
+    display: block;
+    overflow: visible;
 
     .sidebar-header {
       text-align: center;
@@ -73,11 +81,13 @@
     }
 
     .tooltip {
-      float: right;
-      width: 300px;
-      order: 2;
+      float: none;
+      width: 100%;
       height: auto;
-      margin: auto;
+      display: block;
+      margin: 5px auto;
+      text-align: center;
+      color: black;
 
       i {
         display: none;
@@ -100,17 +110,24 @@
       transform: none;
       text-align: center;
       font-style: italic;
+      margin: auto;
+      font-size: 14px;
     }
   }
 
+  .sidebar-scrollable {
+    display: block;
+    overflow: visible;
+    flex: initial;
+  }
+
   .metric-list {
-    display: flex;
+    display: block;
     flex-direction: row;
     flex-wrap: wrap;
 
     li {
-      display: flex;
-      flex-direction: column;
+      display: block;
       text-align: center;
       width: 100%;
       line-height: 1;
@@ -123,5 +140,9 @@
   .tooltip:after,
   .metric-list li {
     page-break-inside: avoid;
+  }
+
+  .row {
+    display: block;
   }
 }

--- a/src/angularjs/src/styles/base/_print.scss
+++ b/src/angularjs/src/styles/base/_print.scss
@@ -1,0 +1,127 @@
+@media print {
+  .navbar {
+    .navbar-right {
+      display: none;
+    }
+  }
+
+  .preview-map {
+    height: 320px;
+    width: 100%;
+    position: absolute;
+    left: initial;
+    right: initial;
+    bottom: initial;
+    display: block !important;
+
+    pfb-place-map {
+      display: block;
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+
+    .map {
+      position: relative !important;
+      width: 100% !important;
+      height: 100% !important;
+      display: block;
+    }
+
+    .leaflet-top {
+      display: none !important;
+    }
+  }
+
+  .metric-details {
+
+    .column.text-right {
+      display: none;
+    }
+
+    .network-score {
+      display: flex;
+      flex-direction: column;
+      font-size: 30px;
+    }
+  }
+
+  .sidebar {
+    position: relative;
+    top: 320px;
+    bottom: initial;
+    border: none;
+    width: auto;
+
+    .sidebar-header {
+      text-align: center;
+
+      .column-8 {
+        width: 100%;
+      }
+
+      .column.text-right {
+        display: none;
+      }
+    }
+
+    .network-score {
+      float: none;
+      height: auto;
+      width: auto;
+      order: -1;
+    }
+
+    .tooltip {
+      float: right;
+      width: 300px;
+      order: 2;
+      height: auto;
+      margin: auto;
+
+      i {
+        display: none;
+      }
+    }
+
+    .tooltip:before {
+      display: none;
+    }
+
+    .tooltip:after {
+      opacity: 1;
+      background: none;
+      color: black;
+      padding: 0;
+      position: relative;
+      top: initial;
+      left: initial;
+      display: block;
+      transform: none;
+      text-align: center;
+      font-style: italic;
+    }
+  }
+
+  .metric-list {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    li {
+      display: flex;
+      flex-direction: column;
+      text-align: center;
+      width: 100%;
+      line-height: 1;
+      padding: 1rem !important;
+    }
+  }
+
+  .network-score,
+  .tooltip,
+  .tooltip:after,
+  .metric-list li {
+    page-break-inside: avoid;
+  }
+}

--- a/src/angularjs/src/styles/components/_metrics.scss
+++ b/src/angularjs/src/styles/components/_metrics.scss
@@ -13,6 +13,7 @@
 
     &.subscore {
         padding-left: 4rem;
+        font-size: 1.4rem;
     }
   }
 

--- a/src/angularjs/src/styles/index.scss
+++ b/src/angularjs/src/styles/index.scss
@@ -52,3 +52,9 @@
   "pages/location",
   "pages/home",
   "pages/mapping";
+
+/**
+ * Print styling
+**/
+@import
+  "base/print";


### PR DESCRIPTION
## Overview

Adds print styling for the place overview page.


### Demo
<img width="1066" alt="screen shot 2017-06-12 at 11 47 48 am" src="https://user-images.githubusercontent.com/1928955/27047505-5c3a921e-4f76-11e7-9af0-36dea5019cab.png">


### Notes
Page breaks might happen in the middle (vertically cut in half) of a word and unfortunately there is no good way to handle those situations.


## Testing Instructions

 * Go to place overview page
 * click on print icon


Connects #454 
