### PR TITLE
Display N/A for missing scores

### DIFF
--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -38,11 +38,13 @@
                     </div>
                     <ul class="metric-list">
                         <li ng-repeat="m in compare.metadata"
-                            ng-if="place.scores[m.name]"
                             ng-class="m.subscoreClass">
                             {{ ::m.label }}
                             <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
-                            <span class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
+                            <span ng-if="place.scores[m.name]"
+                                class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
+                            <span ng-if="!place.scores[m.name]"
+                                class="network-score small">N/A</span>
                         </li>
                         <li>
                             <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"


### PR DESCRIPTION
## Overview

On comparison page, display N/A for missing results instead of hiding the list item.
Lines up results visually, and also fixes issue with relative map heights differing.

### Before:
List element for missing scores would be hidden, causing results to not line up and map to appear taller (here, 'Trails' is missing from the score list on the right):

![before_scores](https://user-images.githubusercontent.com/960264/27094467-26aea096-5038-11e7-9254-829ef4aeff49.png)
![before_maps](https://user-images.githubusercontent.com/960264/27094476-29d099c8-5038-11e7-8255-895432acc16c.png)

### After:

![image](https://user-images.githubusercontent.com/960264/27094555-714c060c-5038-11e7-8852-1eb19ed637e4.png)

![after_maps](https://user-images.githubusercontent.com/960264/27094527-50840ffa-5038-11e7-8e66-1b718f916e14.png)


## Testing Instructions

* Log in to django console and delete a score result for a completed analysis
* Requires first saving result object, deleting key, then saving result object back (do not delete directly)
* Compare city with deleted result against one or two cities with complete results; should line up

Deleting one result at the console:
```
>>> g.overall_scores['recreation_trails']
{u'score_original': 0.0, u'score_normalized': 0.0}
>>> s = g.overall_scores                     
>>> del s['recreation_trails']
>>> g.overall_scores = s
>>> g.save() 
>>> g.overall_scores['recreation_trails']
Traceback (most recent call last):
  File "<console>", line 1, in <module>
KeyError: 'recreation_trails'
```

Closes #502. Fixes #456.
