### PR TITLE
Hide more from OrgAdmins

### DIFF
--- a/src/django/pfb_network_connectivity/filters.py
+++ b/src/django/pfb_network_connectivity/filters.py
@@ -9,7 +9,7 @@ from rest_framework import filters
 
 from pfb_network_connectivity.permissions import is_admin_org, is_admin
 from pfb_analysis.models import AnalysisJob
-from users.models import Organization
+from users.models import Organization, PFBUser, UserRoles
 
 
 logger = logging.getLogger(__name__)
@@ -30,22 +30,33 @@ class OrgAutoFilterBackend(filters.BaseFilterBackend):
 
 
 class OrgOrAdminAutoFilterBackend(filters.BaseFilterBackend):
-    """Filter that allows non-admin users to see only their own organization's objects."""
+    """Filter that allows non-admin users to see only their own organization's objects.
+
+    Non suer-admin users cannot see admin users.
+    """
 
     def filter_queryset(self, request, queryset, view):
-        if not hasattr(request.user, 'organization') or is_admin_org(request.user):
+        if not hasattr(request.user, 'organization') or is_admin(request.user):
             return queryset
         elif queryset.model == Organization:
             return queryset.filter(uuid=request.user.organization_id)
+        elif queryset.model == PFBUser:
+            queryset = queryset.filter(organization=request.user.organization)
+            return queryset.exclude(role=UserRoles.ADMIN)
         else:
             return queryset.filter(organization=request.user.organization)
 
 
 class SelfUserAutoFilterBackend(filters.BaseFilterBackend):
-    """Filter used on users endpoint to limit queryset to only user if user is not admin."""
+    """Filter used on users endpoint to limit queryset to only user if user is not admin.
+
+    Org admins cannot see full admins.
+    """
 
     def filter_queryset(self, request, queryset, view):
-        if not hasattr(request.user, 'organization') or is_admin_org(request.user):
+        if not hasattr(request.user, 'organization') or is_admin(request.user):
             return queryset
+        elif is_admin_org(request.user):
+            return queryset.exclude(role=UserRoles.ADMIN)
         else:
             return queryset.filter(uuid=request.user.uuid)

--- a/src/django/pfb_network_connectivity/permissions.py
+++ b/src/django/pfb_network_connectivity/permissions.py
@@ -114,14 +114,13 @@ class IsAdminOrSelfOnly(permissions.BasePermission):
         if is_admin(request.user):
             return True
 
-        # org admin users cannot modify full admin users
-        if (request.method not in self.ALLOWED_OBJECT_METHODS and
-                is_org_admin(request.user) and is_admin(obj)):
+        # org admin users cannot view or modify full admin users
+        if is_org_admin(request.user) and is_admin(obj):
             return False
 
-        # org admin users can only modify users within their own organization
-        if is_org_admin(request.user) and users_in_same_organization(request.user, obj):
-            return True
+        # org admin users can only view or modify users within their own organization
+        if is_org_admin(request.user):
+            return users_in_same_organization(request.user, obj)
 
         # read-write only access to one's own user object for non-admin users
         if request.method in self.ALLOWED_OBJECT_METHODS and request.user == obj:


### PR DESCRIPTION
## Overview

Do not allow `OrgAdmins` to view full admins or users outside of its org (already could not modify them).
Do not allow `OrgAdmins` to view other orgs (already could not modify them).


## Testing Instructions

 * Create an `OrgAdmin` user and a second organization
 * Logged in as full admin, can see both organizations and all users
 * Logged in as `OrgAdmin`, cannot see full admin (even if in same org) or users in other organizations
 * Logged in as `OrgAdmin`, can only see own organization

Closes #408.
