### PR TITLE
Add legend for Bike Infrastructure

### DIFF
--- a/src/angularjs/src/app/components/map/map.constants.js
+++ b/src/angularjs/src/app/components/map/map.constants.js
@@ -39,7 +39,7 @@
         },
         bike_infrastructure: {
             position: 'bottomright',
-            colors: ['#00aeef', '#005e83', '#005e83', '#006b3e'],
+            colors: ['#8c54de', '#5072f5', '#44a3a6', '#15bf50'],
             labels: ['Lane', 'Buffered Lane', 'Track', 'Off-Street Paths'],
             title: 'Bike Infrastructure'
         },

--- a/src/angularjs/src/app/components/map/map.constants.js
+++ b/src/angularjs/src/app/components/map/map.constants.js
@@ -37,6 +37,12 @@
             labels: ['0 - 6', '6 - 12', '12 - 18', '18 - 24', '24 - 30', '30 - 36', '36 - 42', '42 - 48', '48 - 54', '54 - 100'],
             title: 'BNA Score'
         },
+        bike_infrastructure: {
+            position: 'bottomright',
+            colors: ['#00aeef', '#005e83', '#005e83', '#006b3e'],
+            labels: ['Lane', 'Buffered Lane', 'Track', 'Off-Street Paths'],
+            title: 'Bike Infrastructure'
+        },
         ways: {
             position: 'bottomright',
             colors: ['#00aeef', '#e2231a'],


### PR DESCRIPTION
## Overview

Adds legend for the new Bike Infrastructure layer

### Demo

![screen shot 2017-07-12 at 12 46 04](https://user-images.githubusercontent.com/1818302/28129153-55465bb8-6700-11e7-803e-a3839941043d.png)


### Notes

For now, this is a trivial change, but it doesn't implement the white dashed line for "Track" paths. If PFB wants that styling, we'll need to address that separately.

## Testing Instructions

- If you haven't already run a tile generation step to generate tiles for the bike infrastructure layer, do so.
- Toggle the bike infrastructure layer on via the neighborhood detail view


Closes #505, Connects #521
