### PR TITLE
Add flag for crosswalks

### DIFF
--- a/src/analysis/features/functional_class.sql
+++ b/src/analysis/features/functional_class.sql
@@ -38,7 +38,8 @@ WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway IN ('cycleway','path');
 
 UPDATE  neighborhood_ways
-SET     functional_class = 'path'
+SET     functional_class = 'path',
+        xwalk = 1
 FROM    neighborhood_osm_full_line osm
 WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway = 'footway'

--- a/src/analysis/import/prepare_tables.sql
+++ b/src/analysis/import/prepare_tables.sql
@@ -74,6 +74,7 @@ ALTER TABLE neighborhood_ways ADD COLUMN ft_seg_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN ft_int_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN tf_seg_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN tf_int_stress INT;
+ALTER TABLE neighborhood_ways ADD COLUMN xwalk INT;
 
 -- indexes
 CREATE INDEX idx_neighborhood_ways_osm ON neighborhood_ways (osm_id);


### PR DESCRIPTION
## Overview

Adds a column named xwalk to neighborhood_ways to identify crosswalks that should not be rendered as paths in the existing facilities layer.. A value of 1 indicates a crosswalk.

## Testing Instructions

 * Create a new analysis
 * Check neighborhood_ways to make sure there's a column named xwalk

Necessary to complete https://github.com/azavea/pfb-network-connectivity/issues/519