### PR TITLE
Add state abbrev and organization to boundary_file path

### DIFF
--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -39,7 +39,10 @@ SIMPLIFICATION_TOLERANCE_LESS = 0.0001
 
 def get_neighborhood_file_upload_path(instance, filename):
     """ Upload each boundary file to its own directory """
-    return 'neighborhood_boundaries/{0}/{1}'.format(instance.name, os.path.basename(filename))
+    return 'neighborhood_boundaries/{0}/{1}/{2}{3}'.format(slugify(instance.organization.name),
+                                                           instance.state_abbrev,
+                                                           instance.name,
+                                                           os.path.splitext(filename)[1])
 
 
 def simplify_geom(geom):


### PR DESCRIPTION
## Overview

This ensures that uploaded boundary files are unique on
the same set of parameters as the Neighborhood
'unique_together' constraint.

### Demo

![screen shot 2017-07-20 at 15 08 03](https://user-images.githubusercontent.com/1818302/28434504-893e3342-6d5d-11e7-8ede-0b37cf375a0f.png)
![screen shot 2017-07-20 at 15 09 26](https://user-images.githubusercontent.com/1818302/28434505-8940c6de-6d5d-11e7-8cd4-38108539238f.png)
![screen shot 2017-07-20 at 15 09 34](https://user-images.githubusercontent.com/1818302/28434506-89420d8c-6d5d-11e7-89c1-c71fbbc41808.png)

### Notes

Once merged, I'll be deleting and recreating the set of neighborhoods that exhibited this behavior on production, likely first thing Monday am. Existing neighborhoods will remain unaffected, this will only affect new neighborhoods created moving forward.

Although its likely safe in the case of UUIDField, the
Django docs state:
"In most cases, this object will not have been saved to
the database yet, so it might not yet have a value for
its primary key"


## Testing Instructions

 Create a new Neighborhood via the admin UI with the same name as another neighborhood, but a different state or organization. Login to S3 and note that the new neighborhood did not clobber the pre-existing neighborhood of the same label.
