### PR TITLE
Add None option to Destinations layer picker

### DIFF
--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -138,6 +138,12 @@
             });
 
             $q.all(destLayerPromises).then(function (layers) {
+                if (!ctl.destinationsNoneLayer && layers && layers.length) {
+                    var noneLayer = L.geoJSON({type:'FeatureCollection', features: []});
+                    ctl.destinationsNoneLayer = noneLayer
+                    ctl.layerControl.addOverlay(ctl.destinationsNoneLayer, 'None', 'Destinations');
+                    ctl.map.addLayer(ctl.destinationsNoneLayer);
+                }
                 _.forEach(_.sortBy(layers, 'label'), function (layer) {
                     ctl.layerControl.addOverlay(layer.layer, layer.label, 'Destinations');
                 });


### PR DESCRIPTION
## Overview

Add a "None" layer option to the Destinations layer group so that a user can toggle the display of destinations. This option is selected by default.


### Demo

![screen shot 2017-08-02 at 14 56 18](https://user-images.githubusercontent.com/1818302/28889681-c62ca998-7792-11e7-93c7-95f88ec3c2eb.png)


### Notes

So that we do not mess up the order in which the layer groups draw in the picker, we have to ensure that we add the "None" layer immediately before the remaining destinations layers. The group layer control doesn't give us a way to specify a particular order.

Opened:
https://github.com/ismyrnow/leaflet-groupedlayercontrol/issues/54

## Testing Instructions

 * View a completed analysis job's detail page. Ensure you can select the "None" destination option and that it displays no results.

Closes #542 
