### PR TITLE
Tweak bike infrastructure legend text

### DIFF
--- a/src/angularjs/src/app/components/map/map.constants.js
+++ b/src/angularjs/src/app/components/map/map.constants.js
@@ -40,7 +40,7 @@
         bike_infrastructure: {
             position: 'bottomright',
             colors: ['#8c54de', '#5072f5', '#44a3a6', '#15bf50'],
-            labels: ['Lane', 'Buffered Lane', 'Track', 'Off-Street Paths'],
+            labels: ['Conventional Lane', 'Buffered Lane', 'Protected Lane', 'Off-Street Path'],
             title: 'Bike Infrastructure'
         },
         ways: {


### PR DESCRIPTION
## Overview

See title.

### Demo

![screen shot 2017-08-02 at 14 59 24](https://user-images.githubusercontent.com/1818302/28889913-80f8dc42-7793-11e7-8532-81d5dba33e68.png)

## Testing Instructions

 * On bike detail page, set the overlay to "Bike Infrastructure" and ensure the legend matches the text requested in #543 


Closes #543 