### PR TITLE
Add string formatting to handle single-digit UTM zones

### DIFF
--- a/src/analysis/scripts/detect_utm_zone.py
+++ b/src/analysis/scripts/detect_utm_zone.py
@@ -91,7 +91,7 @@ def get_srid(filename):
     else:
         srid += '6'
 
-    srid += str(utm_zone)
+    srid += '%02d' % utm_zone
     print(srid)
 
 


### PR DESCRIPTION
## Overview

Fixes https://github.com/azavea/pfb-network-connectivity/issues/423 by implementing string formatting when reading the UTM zone of an input shapefile.

### Demo

![screenshot from 2018-02-15 20-56-41](https://user-images.githubusercontent.com/4584258/36291792-c95a435a-1292-11e8-9c1f-36ca8fc787ea.png)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

Run detect_utm_zone.py using [ak.zip](https://github.com/azavea/pfb-network-connectivity/files/1730083/ak.zip)

Also tested with shapefile in UTM zone 10N and verified no regression for 2 digit UTM zones.
