### PR TITLE
Add Google Analytics snippet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure("2") do |config|
     # Ubuntu trusty base box already has system python + pip installed, no need to reinstall here
     ansible.install = true
     ansible.install_mode = "pip"
-    ansible.version = "2.2.1"
+    ansible.version = "2.2.1.0"
   end
 
   config.vm.provider :virtualbox do |v|

--- a/src/angularjs/.eslintrc
+++ b/src/angularjs/.eslintrc
@@ -11,7 +11,8 @@
     "URI": true,
     "_": true,
     "L": true,
-    "inject": true
+    "inject": true,
+    "gtag": true
   },
   "rules": {
     "angular/controller-as-vm": [2, "ctl"],

--- a/src/angularjs/src/app/index.run.js
+++ b/src/angularjs/src/app/index.run.js
@@ -6,8 +6,16 @@
     .run(runBlock);
 
   /** @ngInject */
-  function runBlock() {
-
+  function runBlock($rootScope, $window) {
+    // Ignore on-watch rule, since we're attaching to $rootScope
+    /*eslint angular/on-watch: 0*/
+    $rootScope.$on('$stateChangeSuccess', function ($event, toState) {
+      var event = {
+        'app_name': 'PFB BNA Score',
+        'screen_name': toState.name,
+        'environment': $window.location.hostname
+      }
+      gtag('event', 'screen_view', event);
+    });
   }
-
 })();

--- a/src/angularjs/src/index.html
+++ b/src/angularjs/src/index.html
@@ -52,5 +52,13 @@
     <!-- endinject -->
     <!-- endbuild -->
 
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script src="https://www.googletagmanager.com/gtag/js?id=UA-13226656-9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-13226656-9');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Overview

Adds snippet, which by default sends a page view on load. Also added a basic handler to send a screen view event when the user successfully navigations to different app views. This event includes an "environment", determined by `$window.location.hostname`, since we don't have any sort of multi-environment configuration setup in this app.

### Demo

![screen shot 2018-02-27 at 9 05 40 am](https://user-images.githubusercontent.com/1818302/36733058-7011dc54-1b9d-11e8-8948-a0625bd44932.png)

### Notes

A commit snuck in to fixup Ansible provisioning on Vagrant. Let me know if that causes issues.

## Testing Instructions

1. Disable any ad blocker you may have configured in your browser
1. Load the page.
1. Filter your dev tools network tab by "Images" and ensure you see a bunch of `collect` requests fired like in the screenshot above.
1. If you have an ad blocker installed, re-enable it
1. Repeat steps 2 + 3 and verify that there are no application JS errors, although you may see a "BLOCKED BY CLIENT" error for the google tag manager script load. This is normal and expected.

Merge pending PFB confirmation of results populating in their Analytics dashboard.


Closes #551 