### PR TITLE
Remove unused and incorrect AWS_REGION variable

### DIFF
--- a/deployment/aws-batch/docker-compose.yml
+++ b/deployment/aws-batch/docker-compose.yml
@@ -6,7 +6,6 @@ services:
         context: .
         dockerfile: Dockerfile
       environment:
-        - AWS_REGION=us-east-1
         - AWS_PROFILE=pfb
       volumes:
         - $HOME/.aws:/root/.aws:ro


### PR DESCRIPTION
## Overview

In all environments, we fully configure the AWS
credentials via profile settings. So we don't need to
make the region available separately as an ENV variable.

Note that this variable was also incorrect. The correct
name for the ENV variable to set the region is
AWS_DEFAULT_PROFILE. See:
http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables

Given the above, it seemed best to just remove this ENV var without replacing it with `AWS_DEFAULT_PROFILE`.

## Testing Instructions

Follow the instructions in [deployment/README](./deployment/README.md#terraform) to deploy your current commit to staging. If your `pfb` AWS profile is configured correctly, with the region set in `.aws/config` and your access + secret keys in `.aws/credentials` then the deployment should still succeed, since the param removed here is extraneous.

Connects #555 
