### PR TITLE
Upgrade Django to 1.11

### DIFF
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -1,7 +1,7 @@
 # Note: the Django and psycopg2 versions are repeated in requirements.txt for the benefit
 # of the analysis container. The base container and requirements file versions should be kept
 # in sync.
-FROM quay.io/azavea/django:1.10.3
+FROM quay.io/azavea/django:1.11-python2.7-slim
 
 MAINTAINER Azavea
 

--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -2,7 +2,7 @@ import logging
 
 from django.db.models import Q
 
-from rest_framework import filters
+from django_filters import rest_framework as filters
 import django_filters
 
 from .models import AnalysisJob, AnalysisJobStatusUpdate, Neighborhood

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -8,10 +8,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import connection, DataError
 from django.utils.text import slugify
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
-from rest_framework.filters import DjangoFilterBackend, OrderingFilter
+from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import (AllowAny, IsAuthenticatedOrReadOnly)
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -66,10 +66,10 @@ INSTALLED_APPS = [
 
     # 3rd party
     'django_extensions',
-    'django_filters',
     'localflavor',
     'rest_framework',
     'rest_framework.authtoken',
+    'django_filters',
     'storages',
     'watchman',
 
@@ -223,7 +223,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'DEFAULT_FILTER_BACKENDS': [
-        'rest_framework.filters.DjangoFilterBackend',
+        'django_filters.rest_framework.DjangoFilterBackend',
         'rest_framework.filters.OrderingFilter'
     ],
     'PAGE_SIZE': 20

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -7,9 +7,9 @@ psycopg2==2.7.4
 boto3==1.6.7
 django-amazon-ses==0.3.2
 django-extensions==2.0.5
-django-filter==1.0.2
+django-filter==1.1.0
 django-localflavor==2.0
-djangorestframework==3.6.2
+djangorestframework==3.7.7
 django-storages==1.6.5
 django-watchman==0.15.0
 fiona==1.7.11

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,17 +1,17 @@
 # Django and psycopg2 are included in the django base container but repeated here
 # so that the analysis container will know to install them. These should be kept
 # in sync with the versions in the base container.
-Django==1.10.7
-psycopg2==2.7.1
+Django==1.11.11
+psycopg2==2.7.4
 
-djangorestframework==3.6.2
+boto3==1.6.7
+django-amazon-ses==0.3.2
+django-extensions==2.0.5
 django-filter==1.0.2
-boto3==1.4.4
-fiona==1.7.4
-django-amazon-ses==0.3.0
-django-extensions==1.7.9
-django-localflavor==1.4.1
-django-storages==1.5.2
-django-watchman==0.12
-requests==2.13.0
-us==0.9.1
+django-localflavor==2.0
+djangorestframework==3.6.2
+django-storages==1.6.5
+django-watchman==0.15.0
+fiona==1.7.11
+requests==2.18.4
+us==1.0.0

--- a/src/django/users/views.py
+++ b/src/django/users/views.py
@@ -8,11 +8,12 @@ from django.contrib.auth import (
 from django.core.mail import send_mail
 from django.core.signing import TimestampSigner, BadSignature
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import ValidationError
-from rest_framework.filters import DjangoFilterBackend, OrderingFilter
+from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView


### PR DESCRIPTION
## Overview

Bumps Django to the next minor version, 1.11, and updates Python dependencies.

### Demo

Looks the same.  Also, I destroyed my instance so I don't have many neighborhoods...
![image](https://user-images.githubusercontent.com/6598836/37610208-608f85c8-2b75-11e8-8850-f5fa4c7810ae.png)

### Notes

Re Django:
- The Azavea Django base container comes in two flavors for 1.11, "-slim" and "-alpine". I picked "-slim" because it comes with `gcc` installed, which is necessary for installing fiona.
- As the comment indicates, the Django and psycopg2 versions in the requirements file are used by other containers that install Django to push status updates to the Django container via management commands. This updates those versions to keep them in sync with what's installed in the base Django container.

Re dependencies:
- For `django-amazon-ses`, moving to version 1.0.0 would require some changes, so I upgraded to the last version before that (0.3.2).
- For everything else in this commit, I checked changelogs and didn't see any concerns, so they're at the latest versions.
- Django Rest Framework required some small adjustment--some functionality that was previously part of DRF was moved into `django-filters`.

## Testing Instructions

- Run `scripts/update`.  It should fully rebuild the Django container, since the base image changed, and partially rebuild the `analysis` and `tilemaker` containers, since they pull in the requirements file.
- Everything should work as before.  This project doesn't have much in the way of automated testing.  I clicked around the user-facing and admin-facing sites and ran an analysis (by making the neighborhood and job in the admin-facing site then running the commands from the container log).

Resolves #553.
