### PR TITLE
Verify OSM caching, switch the 'waiting on lockfile' message to INFO level

### DIFF
--- a/src/analysis/scripts/download_osm_extract.py
+++ b/src/analysis/scripts/download_osm_extract.py
@@ -66,7 +66,7 @@ def wait_for_lockfile(bucket, state_abbrev):
     for attempt in xrange(LOCKFILE_POLLING_ATTEMPTS):
         if read_from_s3(bucket, key) is None:
             return None
-        logger.debug('Lockfile exists for {}, waiting'.format(state_abbrev))
+        logger.info('Lockfile exists for {}, waiting'.format(state_abbrev))
         sleep(LOCKFILE_POLLING_INTERVAL)
     total_time = LOCKFILE_POLLING_INTERVAL * (LOCKFILE_POLLING_ATTEMPTS - 1) / 60
     raise Exception('Lockfile for {} not deleted after {} minutes'.format(state_abbrev, total_time))


### PR DESCRIPTION
I verified that OSM caching works correctly on staging, per issue #567.

First, I spun up 2 more worker instances for a total of 3 (there was one running already). Then I created jobs, through the "Run Analysis" form on the admin site, for:
- Stockton, CA
- Bakersfield, CA
- Madison, WI
- Colorado Springs, CO

The first started immediately on the preexisting worker, the next two shortly thereafter once the additional workers had finished initializing yet, and the last ran after the first had finished.  The Stockton job downloaded the California OSM extract to S3 and the Bakersfield job downloaded it from S3 about 4 minutes later.  The WI and CO jobs downloaded their respective OSM extracts from Geofabrik and uploaded them to S3.

After all that was done, to trigger the download locking logic, I deleted the CA extract from S3 then submitted three California jobs as close together as I could.  Here are the relevant log snippets:
First:
![image](https://user-images.githubusercontent.com/6598836/39631859-6c53835c-4f81-11e8-8aec-af64d9af0e84.png)
Second:
![image](https://user-images.githubusercontent.com/6598836/39631870-74dbb666-4f81-11e8-9b15-6a25ac129283.png)
Third:
![image](https://user-images.githubusercontent.com/6598836/39631879-79d81fa6-4f81-11e8-9be7-349be4a3c1ff.png)

The first wrote a lockfile at 13:16:37 then after the 30-second lockfile safety window, download the extract from Geofabrik (which took just under a minute) and uploaded it to S3 (which took seconds), finishing and deleting the lockfile at 13:18:07.  The second and third jobs got to the step at 13:16:41 and 13:17:14 while the lockfile from the first job was still in the S3 bucket.  The way the timing lined up with the 60-second lockfile polling interval, the first job ended up waiting 120s while the second waited only 60s before downloading the extract from S3 and continuing.

The reason this is a PR rather than just a write-up is that this convinced me that it's worth writing to the log to make it clear that a job is waiting on an extract download lockfile.  Making deductions by analyzing the timing is a bother and not as reliable.  The log message was already in the script, but at DEBUG loglevel, so this bumps it up to INFO, where the analysis runs.

## Testing Instructions

This is an issue comment that became a PR due to a +4/-5-character change.  If you really wanted to see that change in action, though, you could do so by following the testing instructions on PR #564 but leaving off the `-v` option from the `download_osm_extract.py` commands, observing that it still prints the "Lockfile exists" message when applicable.

Resolves #567.