### PR TITLE
Manually install pip before attempting to install packages

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,11 @@ Vagrant.configure("2") do |config|
   end
 
   # Upgrade ssl-related packages so that Ansible will install
+  # If this provisioner is no longer necessary, the install_pip.sh provisioner can be removed
+  # as well.
+  # We need to pre-install pip manually since it isn't installed until the ansible_local
+  # provisioner runs.
+  config.vm.provision "shell", path: 'deployment/vagrant/install_pip.sh'
   config.vm.provision "shell", inline: 'pip install urllib3 pyopenssl ndg-httpsclient pyasn1'
 
   config.vm.provision "ansible_local" do |ansible|

--- a/deployment/vagrant/install_pip.sh
+++ b/deployment/vagrant/install_pip.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Install pip, using the same strategy as described by the Ansible local provisioner docs.
+
+command -v pip
+if [ $? -ne 0 ]; then
+    pushd /tmp
+
+    curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    python get-pip.py
+    pip install -U pip
+
+    $PIP_VERSION=$(pip --version)
+    echo "install_pip.sh: pip $PIP_VERSION installed."
+    popd
+else
+    echo "install_pip.sh: pip is already installed. Skipping."
+fi


### PR DESCRIPTION
## Overview

#581 added a fix for ensuring that local Ansible gets installed correctly, which exposed a new issue where pip isn't installed by default to install the requisite pip packages added to a shell provisioner. This PR adds another shell provisioner that ensures that pip is installed before doing anything else in the VM.

### Notes

The install_pip.sh script installs pip using the same method described by the Ansible local provisioner docs for best compatibility. The Ansible `pip` directive targets `/usr/local/bin/pip2` instead of `/usr/local/bin/pip`, but running a `pip freeze` after provisioning completes shows all packages installed by Ansible, so the versions are correctly associated.

## Testing Instructions

```
vagrant destroy
./scripts/setup
```
Ensure provisioning completes successfully and that you can start a server with `./scripts/server`.

Once provisioning is done, run `vagrant provision` again and ensure that pip isn't reinstalled by the new provisioning shell script.

Closes #582 
