### PR TITLE
Removing pedestrian paths and fixing one-way evaluation

### DIFF
--- a/src/analysis/features/lanes.sql
+++ b/src/analysis/features/lanes.sql
@@ -15,7 +15,7 @@ SET     ft_lanes =
                                     ),
                                     1       -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND one_way = 'ft'
+                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    array_length(
                                     regexp_split_to_array(
                                         osm."turn:lanes",
@@ -25,9 +25,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:forward" IS NOT NULL
                         THEN    substring(osm."lanes:forward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way = 'ft'
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         tf_lanes =
@@ -39,7 +39,7 @@ SET     ft_lanes =
                                             ),
                                             1       -- only one dimension
                                         )
-                            WHEN osm."turn:lanes" IS NOT NULL AND one_way = 'tf'
+                            WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" = '-1'
                                 THEN    array_length(
                                             regexp_split_to_array(
                                                 osm."turn:lanes",
@@ -49,9 +49,9 @@ SET     ft_lanes =
                                         )
                             WHEN osm."lanes:backward" IS NOT NULL
                                 THEN    substring(osm."lanes:backward" FROM '\d+')::INT
-                            WHEN osm."lanes" IS NOT NULL AND one_way = 'tf'
+                            WHEN osm."lanes" IS NOT NULL AND osm."oneway" = '-1'
                                 THEN    substring(osm."lanes" FROM '\d+')::INT
-                            WHEN osm."lanes" IS NOT NULL
+                            WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
                                 THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                             END,
         ft_cross_lanes =
@@ -66,7 +66,7 @@ SET     ft_lanes =
                                     ),
                                     1               -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND one_way = 'ft'
+                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    array_length(
                                     array_remove(
                                         regexp_split_to_array(
@@ -79,9 +79,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:forward" IS NOT NULL
                         THEN    substring(osm."lanes:forward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way = 'ft'
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         tf_cross_lanes =
@@ -96,7 +96,7 @@ SET     ft_lanes =
                                     ),
                                     1               -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND one_way = 'tf'
+                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" = '-1'
                         THEN    array_length(
                                     array_remove(
                                         regexp_split_to_array(
@@ -109,9 +109,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:backward" IS NOT NULL
                         THEN    substring(osm."lanes:backward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way = 'tf'
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = '-1'
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         twltl_cross_lanes =

--- a/src/analysis/features/lanes.sql
+++ b/src/analysis/features/lanes.sql
@@ -15,7 +15,7 @@ SET     ft_lanes =
                                     ),
                                     1       -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
+                    WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'ft'
                         THEN    array_length(
                                     regexp_split_to_array(
                                         osm."turn:lanes",
@@ -25,9 +25,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:forward" IS NOT NULL
                         THEN    substring(osm."lanes:forward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
+                    WHEN osm."lanes" IS NOT NULL AND one_way_car = 'ft'
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
+                    WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         tf_lanes =
@@ -39,7 +39,7 @@ SET     ft_lanes =
                                             ),
                                             1       -- only one dimension
                                         )
-                            WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" = '-1'
+                            WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'tf'
                                 THEN    array_length(
                                             regexp_split_to_array(
                                                 osm."turn:lanes",
@@ -49,9 +49,9 @@ SET     ft_lanes =
                                         )
                             WHEN osm."lanes:backward" IS NOT NULL
                                 THEN    substring(osm."lanes:backward" FROM '\d+')::INT
-                            WHEN osm."lanes" IS NOT NULL AND osm."oneway" = '-1'
+                            WHEN osm."lanes" IS NOT NULL AND one_way_car = 'tf'
                                 THEN    substring(osm."lanes" FROM '\d+')::INT
-                            WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
+                            WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
                                 THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                             END,
         ft_cross_lanes =
@@ -66,7 +66,7 @@ SET     ft_lanes =
                                     ),
                                     1               -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
+                    WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'ft'
                         THEN    array_length(
                                     array_remove(
                                         regexp_split_to_array(
@@ -79,9 +79,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:forward" IS NOT NULL
                         THEN    substring(osm."lanes:forward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
+                    WHEN osm."lanes" IS NOT NULL AND one_way_car = 'ft'
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
+                    WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         tf_cross_lanes =
@@ -96,7 +96,7 @@ SET     ft_lanes =
                                     ),
                                     1               -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" = '-1'
+                    WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'tf'
                         THEN    array_length(
                                     array_remove(
                                         regexp_split_to_array(
@@ -109,9 +109,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:backward" IS NOT NULL
                         THEN    substring(osm."lanes:backward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = '-1'
+                    WHEN osm."lanes" IS NOT NULL AND one_way_car = 'tf'
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = NULL
+                    WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         twltl_cross_lanes =

--- a/src/analysis/import/import_osm.sh
+++ b/src/analysis/import/import_osm.sh
@@ -165,6 +165,9 @@ echo 'Clipping OSM source data to boundary + buffer'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
     -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" \
     -f ./clip_osm.sql
+echo 'Removing paths that prohibit bicycles'
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+-c "DELETE FROM neighborhood_osm_full_line WHERE bicycle='no' and highway='path';"
 echo 'Setting values on road segments'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ../features/one_way.sql
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ../features/width_ft.sql


### PR DESCRIPTION
## Overview

These changes:
(1) Remove paths from the data set if they are tagged "bicycle=no". These are primarily pedestrian paths. By removing them from the data set, they are not scored and are not visualized.
(2) Corrects errors in the 'lanes.sql' script. Due to syntax errors, lanes for one-way streets were being calculated by taking the total lane count and dividing it by two. This led to lanes being counted in both directions for one-way streets and incorrect stress designations as a result.

### Demo

(1) Before: Pedestrian paths included in a section of Boulder, CO
<img width="743" alt="boulder_pedpath" src="https://user-images.githubusercontent.com/13860074/47092155-9a38df80-d1e3-11e8-84ed-e8d13e7c436a.png">

After: Pedestrian paths removed
<img width="743" alt="boulder_nopedpath" src="https://user-images.githubusercontent.com/13860074/47092180-ad4baf80-d1e3-11e8-83cb-882a9412f2bf.png">

(2)
Before: One-way segments with error in logic, resulting in the circled area having a mix of high and low stress segments. These segments of Folsom St. in Boulder (between Pearl St. and Spruce St.) are each one-way and have two or three lanes of traffic adjacent to a bike lane with a speed limit of 30 mph.
![folsom_oneway_bef](https://user-images.githubusercontent.com/13860074/47092898-3fa08300-d1e5-11e8-97cb-b10d3ddc2089.png)

After: One-way segments with corrected logic, resulting in the highlighted area having only high stress segments.
![folsom_oneway_aft](https://user-images.githubusercontent.com/13860074/47093021-7d9da700-d1e5-11e8-98a0-f3d4be1194ce.png)


## Testing Instructions

* Run analysis for Boulder, CO with changes
* Compare BNA for Boulder on public website with results
* Outcome: Walking trails are removed
* Outcome: Folsom Street north of Pearl St. changes from low and high stress segments to only high stress segments