### PR TITLE
Modify VM NFS mount options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,9 @@ PFB_SHARED_FOLDER_TYPE = ENV.fetch("PFB_SHARED_FOLDER_TYPE", "nfs")
 
 if PFB_SHARED_FOLDER_TYPE == "nfs"
   if Vagrant::Util::Platform.linux? then
-    PFB_MOUNT_OPTIONS = ['rw', 'vers=4', 'tcp', 'nolock']
+    PFB_MOUNT_OPTIONS = ['rw', 'vers=3', 'tcp', 'nolock', 'actimeo=1']
   else
-    PFB_MOUNT_OPTIONS = ['vers=3', 'udp']
+    PFB_MOUNT_OPTIONS = ['vers=3', 'udp', 'actimeo=1']
   end
 else
   if ENV.has_key?("PFB_MOUNT_OPTIONS")


### PR DESCRIPTION
## Overview

Use NFS v3 when mounting the share on a linux host.
Matches mount options used in other projects.

Fixes #596.


## Testing Instructions

 * NFS share should still mount on other hosts
 * NFS share should mount on recent Ubuntu hosts
