### PR TITLE
Add Job ID to shapefile export

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     build:
       context: ./src/nginx
       dockerfile: Dockerfile
+    depends_on:
+      - django
     ports:
       - "9200:443"
     links:

--- a/src/analysis/scripts/utils.sh
+++ b/src/analysis/scripts/utils.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+function import_geometries_for_job() {
+    if [ -n "${PFB_JOB_ID}" ];
+    then
+        /opt/pfb/django/manage.py import_results_shapefiles "${PFB_JOB_ID}"
+    fi
+}
+
 function update_status() {
     # Usage:
     #    update_status STATUS [step [message]]

--- a/src/django/pfb_analysis/management/commands/import_results_shapefiles.py
+++ b/src/django/pfb_analysis/management/commands/import_results_shapefiles.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 CENSUS_BLOCK_LAYER_MAPPING = {
     'geom': 'POLYGON',
-    'overall_score': 'OVERALL_SC'
+    'overall_score': 'OVERALL_SC',
+    'job': { 'uuid': 'JOB_ID' },
 }
 
 NEIGHBORHOOD_WAYS_LAYER_MAPPING = {
@@ -29,7 +30,8 @@ NEIGHBORHOOD_WAYS_LAYER_MAPPING = {
     'xwalk': 'XWALK',
     'ft_bike_in': 'FT_BIKE_IN',
     'tf_bike_in': 'TF_BIKE_IN',
-    'functional': 'FUNCTIONAL'
+    'functional': 'FUNCTIONAL',
+    'job': { 'uuid': 'JOB_ID' },
 }
 
 


### PR DESCRIPTION
## Overview

This PR Includes job id in the shapefile import management
command and runs the command during analysis export.

This will slow down analysis jobs but not signficantly.

Jobs should run far enough apart that it doesn't lead
to excessive DB load during a large analysis run (but
this is untested).

While inefficient because we need to re-download the
shapefile we just uploaded, the shapefile sizes aren't
huge and it's cleaner than attempting to include
custom logic in bash to directly copy data from the
analysis DB to the app DB.

### Demo

#### Django job

![screen shot 2018-11-29 at 9 44 01 am](https://user-images.githubusercontent.com/1818302/49229387-5ed12980-f3bb-11e8-866f-0d0223e7e39d.png)

#### Local job

![screen shot 2018-11-29 at 9 42 03 am](https://user-images.githubusercontent.com/1818302/49229375-5842b200-f3bb-11e8-8d41-85fa27180739.png)

## Testing Instructions

Checkout branch then rebuild analysis VM with `docker-compose build analysis`.

Trigger a new job via the PFB web admin UI, then run the job via the command printed to the docker console. It should succeed, and you should have NeighborhoodWaysResults and CensusBlocksResults objects with the Job ID you just ran in your django DB. This can be checked by running `./scripts/django-manage shell_plus` then:
```
CensusBlocksResults.objects.filter(job='<job_uuid>').count()
NeighborhoodWaysResults.objects.filter(job='<job_uuid>').count()
```

You should also test that local analysis jobs disconnected from the Django site still work correctly. The JOB_ID field will still be added to the output shapefiles, but it will be blank for all rows.

An example run:
```
NB_OUTPUT_DIR=/data/outputs/test-run-local-job-id ./scripts/run-local-analysis 'https://andrew-pfb
-storage-us-east-1.s3.amazonaws.com/neighborhood_boundaries/root/PA/germantown.zip' PA 42
```

Closes #601 
