### PR TITLE
Enable Tilegarden tiler and add job_id filtering

### DIFF
--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -557,8 +557,8 @@ class AnalysisJob(PFBModel):
     def tile_urls(self):
         return [{
             'name': layer,
-            'url': self._s3_url_for_result_resource('tiles/neighborhood_{}'.format(layer) +
-                                                    '/{z}/{x}/{y}.png')
+            'url': (settings.TILEGARDEN_ROOT + '/tile/{z}/{x}/{y}.png' +
+                    '?config={layer}'.format(layer=layer))
         } for layer in ['ways', 'census_blocks', 'bike_infrastructure']]
 
     @property

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -557,7 +557,8 @@ class AnalysisJob(PFBModel):
     def tile_urls(self):
         return [{
             'name': layer,
-            'url': (settings.TILEGARDEN_ROOT + '/tile/{z}/{x}/{y}.png' +
+            'url': (settings.TILEGARDEN_ROOT + '/tile/{job_id}/'.format(job_id=self.uuid) +
+                    '{z}/{x}/{y}.png' +
                     '?config={layer}'.format(layer=layer))
         } for layer in ['ways', 'census_blocks', 'bike_infrastructure']]
 

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -557,9 +557,12 @@ class AnalysisJob(PFBModel):
     def tile_urls(self):
         return [{
             'name': layer,
-            'url': (settings.TILEGARDEN_ROOT + '/tile/{job_id}/'.format(job_id=self.uuid) +
-                    '{z}/{x}/{y}.png' +
-                    '?config={layer}'.format(layer=layer))
+            'url': '{root}/tile/{job_id}/{layer}/{tile_template}'.format(
+                root=settings.TILEGARDEN_ROOT,
+                job_id=self.uuid,
+                layer=layer,
+                tile_template='{z}/{x}/{y}.png',
+            )
         } for layer in ['ways', 'census_blocks', 'bike_infrastructure']]
 
     @property

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -340,3 +340,8 @@ PFB_ANALYSIS_DESTINATIONS = [
 ]
 # Length of time in seconds that S3 pre-signed urls are valid for
 PFB_ANALYSIS_PRESIGNED_URL_EXPIRES = 3600
+
+# Root URL for tile server.
+# TODO (probably with issue #595): this is the development answer. For staging/production
+#      we'll have to supply the URL of the actual deployed CloudFront distribution.
+TILEGARDEN_ROOT = 'http://localhost:9400'

--- a/src/tilegarden/src/api.js
+++ b/src/tilegarden/src/api.js
@@ -31,6 +31,11 @@ const processCoords = (req) => {
     return { z, x, y }
 }
 
+const getPositionalFilters = (req) => {
+    const { x, y, z, ...remainder } = req.pathParams
+    return remainder
+}
+
 // Returns a properly formatted list of layers
 // or an empty list if there are none
 const processLayers = (req) => {
@@ -65,14 +70,15 @@ const handleError = (e) => {
 
 // Get tile for some zxy bounds
 api.get(
-    '/tile/{z}/{x}/{y}',
+    '/tile/{job_id}/{z}/{x}/{y}',
     (req) => {
         try {
             const { z, x, y } = processCoords(req)
+            const filters = getPositionalFilters(req)
             const layers = processLayers(req)
             const configOptions = processConfig(req)
 
-            return imageTile(createMap(z, x, y, layers, configOptions))
+            return imageTile(createMap(z, x, y, filters, layers, configOptions))
                 .then(img => new APIBuilder.ApiResponse(img, IMAGE_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {

--- a/src/tilegarden/src/api.js
+++ b/src/tilegarden/src/api.js
@@ -32,6 +32,7 @@ const processCoords = (req) => {
 }
 
 const getPositionalFilters = (req) => {
+    /* eslint-disable-next-line object-curly-newline */
     const { x, y, z, ...remainder } = req.pathParams
     return remainder
 }

--- a/src/tilegarden/src/api.js
+++ b/src/tilegarden/src/api.js
@@ -33,7 +33,7 @@ const processCoords = (req) => {
 
 const getPositionalFilters = (req) => {
     /* eslint-disable-next-line object-curly-newline */
-    const { x, y, z, ...remainder } = req.pathParams
+    const { x, y, z, config, ...remainder } = req.pathParams
     return remainder
 }
 
@@ -52,7 +52,7 @@ const processLayers = (req) => {
 // Parses out the configuration specifications
 const processConfig = req => ({
     s3bucket: req.queryString.s3bucket,
-    config: req.queryString.config,
+    config: req.pathParams.config,
 })
 
 // Create new lambda API
@@ -71,7 +71,7 @@ const handleError = (e) => {
 
 // Get tile for some zxy bounds
 api.get(
-    '/tile/{job_id}/{z}/{x}/{y}',
+    '/tile/{job_id}/{config}/{z}/{x}/{y}',
     (req) => {
         try {
             const { z, x, y } = processCoords(req)

--- a/src/tilegarden/src/tiler.js
+++ b/src/tilegarden/src/tiler.js
@@ -13,6 +13,7 @@ const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 
 const filterVisibleLayers = require('./util/layer-filter')
+const addParamFilters = require('./util/param-filter')
 const bbox = require('./util/bounding-box')
 const HTTPError = require('./util/error-builder')
 
@@ -76,7 +77,7 @@ const fetchMapFile = (options) => {
  * @param y
  * @returns {Promise<mapnik.Map>}
  */
-module.exports.createMap = (z, x, y, layers, configOptions) => {
+module.exports.createMap = (z, x, y, filters, layers, configOptions) => {
     // Create a webmercator map with specified bounds
     const map = new mapnik.Map(TILE_WIDTH, TILE_HEIGHT)
     map.bufferSize = 64
@@ -84,6 +85,7 @@ module.exports.createMap = (z, x, y, layers, configOptions) => {
     // Load map specification from xml string
     return fetchMapFile(configOptions)
         .then(xml => filterVisibleLayers(xml, layers))
+        .then(xml => addParamFilters(xml, filters))
         .then(xml => new Promise((resolve, reject) => {
             map.fromString(xml, (err, result) => {
                 if (err) {

--- a/src/tilegarden/src/tiler.js
+++ b/src/tilegarden/src/tiler.js
@@ -12,10 +12,11 @@ const aws = require('aws-sdk')
 const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 
-const filterVisibleLayers = require('./util/layer-filter')
 const addParamFilters = require('./util/param-filter')
 const bbox = require('./util/bounding-box')
+const filterVisibleLayers = require('./util/layer-filter')
 const HTTPError = require('./util/error-builder')
+const { parseXml, buildXml } = require('./util/xml-tools')
 
 const TILE_HEIGHT = 256
 const TILE_WIDTH = 256
@@ -84,8 +85,10 @@ module.exports.createMap = (z, x, y, filters, layers, configOptions) => {
 
     // Load map specification from xml string
     return fetchMapFile(configOptions)
-        .then(xml => filterVisibleLayers(xml, layers))
-        .then(xml => addParamFilters(xml, filters))
+        .then(parseXml)
+        .then(xmlJsObj => filterVisibleLayers(xmlJsObj, layers))
+        .then(xmlJsObj => addParamFilters(xmlJsObj, filters))
+        .then(buildXml)
         .then(xml => new Promise((resolve, reject) => {
             map.fromString(xml, (err, result) => {
                 if (err) {

--- a/src/tilegarden/src/util/param-filter.js
+++ b/src/tilegarden/src/util/param-filter.js
@@ -1,25 +1,22 @@
+/**
+ * Defines a function that accepts a config XML converted to an object and returns the same
+ * with col=value filters applied to each layer's "table" value.
+ */
+
 const sqlString = require('sql-escape-string')
-const { promisify } = require('util')
-const xml2js = require('xml2js')
 
-const xmlParser = new xml2js.Parser()
-const xmlBuilder = new xml2js.Builder()
-
-// Make an async-friendly version of the parser
-const parsePromise = promisify(xmlParser.parseString)
-
-// Escape col but replace outer '-s with "-s to make a delimited identifier
+// Helper function to escape col but replace outer '-s with "-s to make a delimited identifier
 const processCol = col => `"${sqlString(col).slice(1, -1)}"`
 
-// Smashes the parameters and values together into a series of SQL conditions, ANDed
+// Combine parameters and values into a series of SQL conditions, ANDed
 function composeFilterQuery(filters) {
     return Object.entries(filters)
-                 .map(entry => `${processCol(entry[0])} = ${sqlString(entry[1])}`)
-                 .join(' AND ')
+        .map(entry => `${processCol(entry[0])} = ${sqlString(entry[1])}`)
+        .join(' AND ')
 }
 
-// Replaces the "table" for each layer definition, which defines the query, with the original
-// value wrapped in a further filtering query
+// Replace the "table" for each layer definition (which can be a table name or a SELECT query)
+// with the original value wrapped in a further filtering query
 function applyFilterQuery(xmlJson, filterQuery) {
     xmlJson.Map.Layer.forEach((layer) => {
         // Get the <Datasource><Parameter name="table"> element, which contains the default query
@@ -34,11 +31,9 @@ function applyFilterQuery(xmlJson, filterQuery) {
     return xmlJson
 }
 
-async function addParamFilters(xmlString, filters) {
-    const xmlJson = await parsePromise(xmlString)
+function addParamFilters(xmlJsObj, filters) {
     const filterQuery = composeFilterQuery(filters)
-    const filteredJson = applyFilterQuery(xmlJson, filterQuery)
-    return xmlBuilder.buildObject(filteredJson)
+    return applyFilterQuery(xmlJsObj, filterQuery)
 }
 
 module.exports = addParamFilters

--- a/src/tilegarden/src/util/param-filter.js
+++ b/src/tilegarden/src/util/param-filter.js
@@ -1,0 +1,44 @@
+const sqlString = require('sql-escape-string')
+const { promisify } = require('util')
+const xml2js = require('xml2js')
+
+const xmlParser = new xml2js.Parser()
+const xmlBuilder = new xml2js.Builder()
+
+// Make an async-friendly version of the parser
+const parsePromise = promisify(xmlParser.parseString)
+
+// Escape col but replace outer '-s with "-s to make a delimited identifier
+const processCol = col => `"${sqlString(col).slice(1, -1)}"`
+
+// Smashes the parameters and values together into a series of SQL conditions, ANDed
+function composeFilterQuery(filters) {
+    return Object.entries(filters)
+                 .map(entry => `${processCol(entry[0])} = ${sqlString(entry[1])}`)
+                 .join(' AND ')
+}
+
+// Replaces the "table" for each layer definition, which defines the query, with the original
+// value wrapped in a further filtering query
+function applyFilterQuery(xmlJson, filterQuery) {
+    xmlJson.Map.Layer.forEach((layer) => {
+        // Get the <Datasource><Parameter name="table"> element, which contains the default query
+        const queryObj = layer.Datasource[0].Parameter.filter(p => p.$.name === 'table')[0]
+
+        // Add the filters onto it
+        const query = `SELECT * FROM ${queryObj._} WHERE ${filterQuery}`
+
+        // Set the new query as the 'table' for the layer
+        queryObj._ = `(${query}) as m`
+    })
+    return xmlJson
+}
+
+async function addParamFilters(xmlString, filters) {
+    const xmlJson = await parsePromise(xmlString)
+    const filterQuery = composeFilterQuery(filters)
+    const filteredJson = applyFilterQuery(xmlJson, filterQuery)
+    return xmlBuilder.buildObject(filteredJson)
+}
+
+module.exports = addParamFilters

--- a/src/tilegarden/src/util/xml-tools.js
+++ b/src/tilegarden/src/util/xml-tools.js
@@ -1,0 +1,25 @@
+/* Helper functions to encapsulate converting to and from XML.
+ *
+ * There's not much here, but it does get reused, and having it centralized should make it
+ * easier to change libraries or settings if necessary.
+ */
+
+const { promisify } = require('util')
+const xml2js = require('xml2js')
+
+// Make an async-friendly version of the parser
+const parsePromise = promisify(xml2js.parseString)
+
+async function parseXml(xmlString) {
+    return parsePromise(xmlString)
+}
+
+function buildXml(xmlJsObj) {
+    const builder = new xml2js.Builder()
+    return builder.buildObject(xmlJsObj)
+}
+
+module.exports = {
+    parseXml,
+    buildXml,
+}

--- a/src/tilegarden/tests/layer-filter.test.js
+++ b/src/tilegarden/tests/layer-filter.test.js
@@ -1,5 +1,6 @@
 const rewire = require('rewire')
 const filterLayers = require('../src/util/layer-filter')
+const { parseXml, buildXml } = require('../src/util/xml-tools')
 const filterer = rewire('../src/util/layer-filter'),
     structureQuery = filterer.__get__('structureQuery')
 
@@ -154,6 +155,12 @@ describe('structureQuery', () => {
     })
 })
 
+async function filterLayersWithParsing(xml, layers) {
+    return parseXml(xml)
+        .then(xmlJsObj => filterLayers(xmlJsObj, layers))
+        .then(buildXml)
+}
+
 describe('filterLayers', () => {
     test('Just a string name', () => {
         const layers = ['PWD']
@@ -175,7 +182,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(expected)
     })
 
     test('Several string names', () => {
@@ -198,7 +205,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(expected)
     })
 
     test('Just an object name', () => {
@@ -221,7 +228,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(expected)
     })
 
     test('Several object names', () => {
@@ -244,7 +251,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(expected)
     })
 
     test('Object name + 1 filter', () => {
@@ -275,7 +282,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(expected)
     })
 
     test('Object name + 2 filters', () => {
@@ -306,7 +313,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(expected)
     })
 
     test('dont filter if layer list is empty', () => {
@@ -319,7 +326,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT"/>
 </Map>`
         expect.assertions(1)
-        return expect(filterLayers(xml, layers)).resolves.toBe(xml)
+        return expect(filterLayersWithParsing(xml, layers)).resolves.toBe(xml)
     })
 
     test('dont filter if there is no layer list', () => {
@@ -331,7 +338,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT"/>
 </Map>`
         expect.assertions(1)
-        return expect(filterLayers(xml)).resolves.toBe(xml)
+        return expect(filterLayersWithParsing(xml)).resolves.toBe(xml)
     })
 
     test('Throw error if a layer doesn\'t exist', () => {
@@ -346,7 +353,7 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).rejects.toBeInstanceOf(Error)
+        return expect(filterLayersWithParsing(xml, layers)).rejects.toBeInstanceOf(Error)
     })
 })
 


### PR DESCRIPTION
## Overview

Switches to using the Tilegarden tiler in development.  Specifically:
- Adds a `job_id` path parameter to the Tilegarden route
- Moves the `config` parameter out of the querystring and into the path
- Changes `AnalysisJob.tile_urls` to return Tilegarden endpoints as tile URLs rather than the S3 ones

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://user-images.githubusercontent.com/6598836/49452511-5445d400-f7af-11e8-9519-b46b7ddae4ab.png)

### Notes

- There was already a syntax for applying arbitrary filters, but it's [pretty complicated](https://github.com/azavea/tilegarden#client-specified-filtering) and relies on querystring parameters, which could [make it hard to add S3 caching](https://github.com/azavea/tilegarden/issues/126#issuecomment-441776311).
- I considered removing the `layers` filtering, since we're not using it, but 1) that would have made these changes particularly hard to reconcile with upstream Tilegarden and 2) it (or a slightly modified version of it) could be something we want to add in the future, e.g. for overlaying multiple geometry layers.
- The code for extracting path parameters uses a list of known parameters that it should ignore and tries to turn any other path parameters into query filters.  This seems a bit weird and brittle, but it also means that multiple paths with different path parameters could easily share the same function.  Passing a list of expected parameters to the function might be more sensible, but it would mean some double-entry (since they're already defined in the route's path pattern).
- Moving `config` from the querystring to the path wasn't called for on the issue, but it was quite easy to do and gets us to the point of the tile URLs being all path, no querystring.
- I wrote on issue #592 that `AnalysisJob.tile_urls` should "be configurable to return either the current S3 URLs or different endpoints", but I don't remember why I said that and it doesn't make much sense to me know.  This just switches to Tilegarden URLs and removes the old ones.
- The red area outside the analysis boundary that I had thought was an overlay of scores from a different analysis turned out to be something else, about which I made issue #612.

## Testing Instructions

- As on PR #610, if you haven't run the migration from PR #600, run that first.  If you don't have any completed analysis jobs at all, you'll need to run one to have some data to look at.
- Run `scripts/setup` or (in the VM) `scripts/update` to build, then `scripts/server`
- Go to the front-end app (http://localhost:9301) and click through to a neighborhood.
- All the tile layers should render.

## Checklist

- [ ] Update https://github.com/azavea/tilegarden/issues/129 with relevant changes (to do after merging when the commits are finalized)

Resolves #592 
Resolves #609 
