### PR TITLE
Mask imported Census blocks to neighborhood bounds

### DIFF
--- a/src/django/pfb_analysis/management/commands/import_results_shapefiles.py
+++ b/src/django/pfb_analysis/management/commands/import_results_shapefiles.py
@@ -92,6 +92,14 @@ def add_results_geoms(job):
 
     import_shapefile(job, 'neighborhood_census_blocks.zip',
                      CensusBlocksResults, CENSUS_BLOCK_LAYER_MAPPING)
+
+    # Mask imported Census block results to neighborhood bounds to exclude null results
+    # out of bounds, as all nulls are read as zeroes from the shapefile, and so
+    # indistinguishable from actual zero scores.
+    CensusBlocksResults.objects.filter(job=job,
+                                       overall_score=0,
+                                       geom__disjoint=job.neighborhood.geom).delete()
+
     import_shapefile(job, 'neighborhood_ways.zip',
                      NeighborhoodWaysResults, NEIGHBORHOOD_WAYS_LAYER_MAPPING)
 


### PR DESCRIPTION
## Overview

Exclude null readings from the shapefile interpreted as zeroes by removing any Census block results
outside the neighborhood bounds with a zero overall score (actually should be null).

Workaround for `LayerMapping` not distinguishing between unset/null and zero in the shapefile.
Shapefiles do not officially support null representation.


### Demo

Lower Manhattan analysis with water blocks removed. Zero-scored blocks in the interior have been preserved, as have Census blocks with scores not entirely within the neighborhood bounds.

![image](https://user-images.githubusercontent.com/960264/49672528-73579680-fa39-11e8-8411-32ce0ed7c864.png)


### Notes

On inspecting the shapefile on a host with GDAL 2.2 and the latest `fiona` version, nulls appear to be correctly recognized. However, in the docker container, they were not (all read as zeroes). Using `fiona` presents other drawbacks as well: it's significantly slower, fails to recognize the input EPSG, and requires much more manipulation for building model objects, as it doesn't provide the `LayerMapping` conveniences.


## Testing Instructions

 * `./scripts/update`
 * Re-run shapefile import task: `./scripts/django-manage import_results_shapefiles`
 * Check tiled Census block layers on the front end


Fixes #612.

