### PR TITLE
Build the django-q container in scripts/update

### DIFF
--- a/scripts/server
+++ b/scripts/server
@@ -25,7 +25,7 @@ then
     else
         pushd ..
 
-        docker-compose up nginx django django-q angularjs tilegarden
+        docker-compose up --build nginx django django-q angularjs tilegarden
 
         popd
     fi

--- a/scripts/update
+++ b/scripts/update
@@ -69,7 +69,7 @@ then
     else
         pushd ..
 
-        docker-compose build database django angularjs analysis tilemaker tilegarden
+        docker-compose build database django angularjs analysis tilemaker tilegarden django-q
 
         run_database_migrations
         run_data_fixtures


### PR DESCRIPTION
## Overview

Previously, the `django-q` service was being built implicitly by the call to `docker-compose up` in `scripts/server`, and was missing from the list of images to build in `scripts/update`.

Adjust `scripts/update` to build this service explicitly, and alter `scripts/server` to run `docker-compose up --build` so that it will always build fresh images before running the dev server.
 
## Notes

- For more context on these changes, see https://github.com/azavea/pfb-network-connectivity/issues/616#issuecomment-446320036.

## Testing Instructions

* Shell into the VM with `vagrant ssh`
* Remove the `django-q` image with `docker rmi django-q:latest`
* Run `./scripts/update` and confirm that `django-q:latest` gets built
* Run `./scripts/server` and confirm that `docker-compose up` rebuilds all images before running the services

Fixes #616.