### PR TITLE
Deploy Tilegarden instance to staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ node_modules/
 npm-debug.log
 
 .sass-cache/
+
+# Tilegarden configs
+src/tilegarden/.env
+src/tilegarden/claudia.json

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,3 +23,9 @@ services:
     build:
       context: ./src
       dockerfile: tilemaker/Dockerfile
+
+  tilegarden:
+    env_file: ./src/tilegarden/.env
+    volumes:
+      # scripts/infra will download this config file before mounting the volume.
+      - ./src/tilegarden/claudia.json:/opt/pfb/tilegarden/claudia.json

--- a/scripts/infra
+++ b/scripts/infra
@@ -71,6 +71,17 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 ;;
             apply)
                 terraform apply "${PFB_SETTINGS_BUCKET}.tfplan"
+
+                popd
+                pushd "${DIR}/.."
+
+                aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/tilegarden/.env" "./src/tilegarden/.env"
+                aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/tilegarden/claudia.json" "./src/tilegarden/claudia.json"
+
+                docker-compose \
+                    -f docker-compose.yml \
+                    -f docker-compose.test.yml \
+                    run --rm --entrypoint yarn tilegarden deploy
                 ;;
             *)
                 echo "ERROR: I don't have support for that Terraform subcommand!"

--- a/src/tilegarden/.env.example
+++ b/src/tilegarden/.env.example
@@ -1,0 +1,28 @@
+# Import values from local environment
+# If you want to set them specifically, change them to assignments
+AWS_PROFILE
+
+# Name of the lambda function
+PROJECT_NAME=
+
+# Function config information
+## REQUIRED ##
+LAMBDA_REGION=
+
+## OPTIONAL ##
+# name of role associated with this lambda function
+#LAMBDA_ROLE=role-name
+# Amount of time in seconds your lambdas will wait before timing out
+# Increase this value if your tile requests are timing out
+#LAMBDA_TIMEOUT=15
+# Memory in MB allocated to your lambda functions
+# Increase this value if you plan on rendering vector tiles
+#LAMBDA_MEMORY=128
+# The following VPC (Virtual Private Cloud) settings should be used if you
+# need your lambdas to be able to connect to other AWS resources,
+# e.g. an RDS instance, and should match the subnets/security groups used
+# for those resources.
+# VPC Subnets that your lambdas should use (comma separated list)
+#LAMBDA_SUBNETS=subnet1,subnet2,subnet...N
+# VPC Security Groups that your lambdas should use (comma separated list)
+#LAMBDA_SECURITY_GROUPS=group1,group2,group...N

--- a/src/tilegarden/package.json
+++ b/src/tilegarden/package.json
@@ -32,7 +32,7 @@
     "local": "yarn build-all-xml && node --inspect=0.0.0.0:9229 -- node_modules/claudia-local-api/bin/claudia-local-api --abbrev 300 --api-module src/api | bunyan -o short",
     "parse-id": "jq -r '.api.id' claudia.json > .api-id",
     "test": "eslint src && jest --coverage",
-    "compile": "yarn build-all-xml && ncc src -o dist && mkdir -p dist/xml && cp src/config/*.xml dist/xml/"
+    "compile": "yarn build-all-xml && mkdir -p dist && cp src/*.js dist && cp -R src/util dist/util && mkdir -p dist/xml && cp src/config/*.xml dist/xml/"
   },
   "devDependencies": {
     "bunyan": "^1.8.12",
@@ -42,7 +42,6 @@
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.12.0",
     "jest": "^23.2.0",
-    "@zeit/ncc": "^0.1.16",
     "nodemon": "^1.17.5",
     "rewire": "^4.0.1"
   },

--- a/src/tilegarden/scripts/template-vars.js
+++ b/src/tilegarden/scripts/template-vars.js
@@ -6,8 +6,6 @@
 
 const fs = require('fs')
 
-const envPrefix = process.env.NODE_ENV === 'production' ? 'PROD_' : 'DEV_'
-
 fs.readFile(process.argv[2], 'utf-8', function (err, out) {
     if (err) process.stderr.write(err)
     else {


### PR DESCRIPTION
## Overview

Configure Tilegarden for multi-environment deployments, and stand up an instance in staging. In addition, modify CI scripts to include Tilegarden deployments.

Note that this PR doesn't wire up the app with Tilegarden, since that's blocked by #594 and #624. I opened up #625 to keep track of that work.

### Demo

Visit https://2fjf2aov9f.execute-api.us-east-1.amazonaws.com/latest to see a bare instance of Tilegarden:

<img width="822" alt="screen shot 2018-12-12 at 4 54 55 pm" src="https://user-images.githubusercontent.com/14170650/49901252-b0070180-fe2e-11e8-8adc-f0c6934de2c7.png">

### Notes

* `./scripts/infra` runs the deployment with Claudia based on config files retrieved from S3 remote state, so it should publish deployments for staging and production separately.

## Testing Instructions

You can test the PR by running a manual deployment of Tilegarden to staging. If you'd like to go the extra mile and confirm that your code changes get reflected on staging, edit the Tilegarden source code (perhaps to change the `usage` text that displays on the root endpoint) before running this deployment.

* Shell into the VM with `vagrant ssh`
* Run `./scripts/update` to make sure your images are up to date
* Comment out the following line in `./scripts/infra` (since we don't want to actually run Terraform updates):

https://github.com/azavea/pfb-network-connectivity/blob/92d506ee7e77b0729a9dbafe33afde7b61ec86bc/scripts/infra#L73

* Run `export GIT_COMMIT=latest` (the value can be anything, `./scripts/infra` just expects this variable to be set)
* Run `export PFB_SETTINGS_BUCKET=staging-pfb-config-us-east-1`
* Run `./scripts/infra apply`
* Confirm that the deployment succeeds, and visit the URL that gets printed to the console to hit the staging endpoint

Closes #595.