### PR TITLE
Feature/kak/add analysis upload endpoint#618

### DIFF
--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -155,6 +155,12 @@ class AnalysisLocalUploadTaskCreateSerializer(serializers.ModelSerializer):
         validated_data.pop('neighborhood')
         return super(AnalysisLocalUploadTaskCreateSerializer, self).create(validated_data)
 
+    def validate_neighborhood(self, obj):
+        if Neighborhood.objects.filter(uuid=obj).count() != 1:
+            raise serializers.ValidationError(
+                'No matching neighborhood found for UUID {uuid}'.format(uuid=obj))
+        return obj
+
     class Meta:
         model = AnalysisLocalUploadTask
         fields = ('uuid', 'created_at', 'modified_at', 'created_by', 'modified_by',

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import tempfile
@@ -5,6 +6,8 @@ import tempfile
 from pfb_analysis.models import AnalysisBatch
 from pfb_network_connectivity.utils import download_file
 from users.models import PFBUser
+
+logger = logging.getLogger(__name__)
 
 
 def create_batch_from_remote_shapefile(shapefile_url):
@@ -20,5 +23,5 @@ def create_batch_from_remote_shapefile(shapefile_url):
         shutil.rmtree(tmpdir)
 
 
-def upload_local_analysis(analysis_url):
-    pass
+def upload_local_analysis(local_upload_task_uuid):
+    logging.warn('TODO: upload local analysis for task {uuid}'.format(uuid=local_upload_task_uuid))

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -18,3 +18,7 @@ def create_batch_from_remote_shapefile(shapefile_url):
         batch.submit()
     finally:
         shutil.rmtree(tmpdir)
+
+
+def upload_local_analysis(analysis_url):
+    pass

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -167,14 +167,13 @@ class AnalysisLocalUploadTaskViewSet(mixins.CreateModelMixin,
         if not serializer.is_valid():
             return
         neighborhood_id = serializer.validated_data['neighborhood']
-        url = serializer.validated_data['upload_results_url']
         neighborhood = Neighborhood.objects.get(pk=neighborhood_id)
         user = self.request.user
         job = AnalysisJob.objects.create(neighborhood=neighborhood,
                                          created_by=user, modified_by=user)
-        serializer.save(job=job, upload_results_url=url, created_by=user, modified_by=user)
+        obj = serializer.save(job=job, created_by=user, modified_by=user)
 
-        async('pfb_analysis.tasks.upload_local_analysis', url)
+        async('pfb_analysis.tasks.upload_local_analysis', obj.uuid)
 
 
 class NeighborhoodViewSet(ModelViewSet):

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -202,6 +202,10 @@ logging.config.dictConfig({
             'handlers': ['console'],
             'level': DJANGO_LOG_LEVEL,
         },
+        'django_q': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+        },
         'pfb_analysis': {
             'handlers': ['console'],
             'level': DJANGO_LOG_LEVEL,


### PR DESCRIPTION
## Overview

Run a dummy `django-q` task on creating a local analysis upload task in the API.

The endpoint already existed, so this adds some validation and a dummy task.


### Demo

`django-q` processing the upload in the logs:
![image](https://user-images.githubusercontent.com/960264/49959501-c15a1780-fedb-11e8-916a-4fbac7d2f783.png)

Successful POST response:
![image](https://user-images.githubusercontent.com/960264/49959594-02522c00-fedc-11e8-97e3-e4fbbb597f9b.png)

Attempting to POST with a neighborhood UUID that is a valid UUID, but matches no neighborhood:
![image](https://user-images.githubusercontent.com/960264/49959640-26ae0880-fedc-11e8-8fef-c9e15dafdda9.png)


## Testing Instructions

 * Rebuild containers to address #616, if necessary
 * Post a neighborhood UUID and URL to http://localhost:9200/api/local_upload_tasks/
 * Should create an `AnalysisLocalUploadTask` for the matching neighborhood, with the URL
 * `django_q` should log the (dummy) task processing
 * API response should include expected fields and status
 * Attempting to post invalid data should return an appropriate error


Closes #618
