### PR TITLE
[ WIP ] Configure CloudFront proxy for Tilegarden

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -17,6 +17,7 @@ services:
       - PFB_AWS_BATCH_TILEMAKER_JOB_QUEUE_NAME
       - PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME_REVISION
       - PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME
+      - PFB_TILEGARDEN_ROOT=http://localhost:9400
     volumes:
       - $HOME/.aws:/root/.aws:ro
 

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -152,7 +152,7 @@ data "template_file" "pfb_app_https_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
-    tilegarden_root                              = "${cloudfront_distribution.tilegarden.domain_name}"
+    tilegarden_root                              = "https://${aws_cloudfront_distribution.tilegarden.domain_name}"
   }
 }
 
@@ -198,7 +198,7 @@ data "template_file" "pfb_app_async_queue_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
-    tilegarden_root                              = "${cloudfront_distribution.tilegarden.domain_name}"
+    tilegarden_root                              = "https://${aws_cloudfront_distribution.tilegarden.domain_name}"
   }
 }
 
@@ -237,7 +237,7 @@ data "template_file" "pfb_app_management_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
-    tilegarden_root                              = "${cloudfront_distribution.tilegarden.domain_name}"
+    tilegarden_root                              = "https://${aws_cloudfront_distribution.tilegarden.domain_name}"
   }
 }
 

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -152,6 +152,7 @@ data "template_file" "pfb_app_https_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
+    tilegarden_root                              = "${cloudfront_distribution.tilegarden.domain_name}"
   }
 }
 
@@ -197,6 +198,7 @@ data "template_file" "pfb_app_async_queue_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
+    tilegarden_root                              = "${cloudfront_distribution.tilegarden.domain_name}"
   }
 }
 
@@ -235,6 +237,7 @@ data "template_file" "pfb_app_management_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
+    tilegarden_root                              = "${cloudfront_distribution.tilegarden.domain_name}"
   }
 }
 

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -49,5 +49,6 @@ resource "aws_cloudfront_distribution" "tilegarden" {
 
   viewer_certificate {
     cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
   }
 }

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -1,0 +1,53 @@
+resource "aws_cloudfront_distribution" "tilegarden" {
+  origin {
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+    }
+
+    domain_name = "${var.tilegarden_api_gateway_domain_name}"
+    origin_path = "/latest"
+    origin_id   = "tilegardenOrigin${title(var.environment)}EastId"
+
+    custom_header {
+      name  = "Accept"
+      value = "image/png"
+    }
+  }
+
+  price_class     = "PriceClass_100"
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "${var.project} (${var.environment})"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "tilegardenOrigin${title(var.environment)}EastId"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = "300"               # Five minutes
+    max_ttl                = "86400"             # One day
+  }
+
+  restrictions {
+    "geo_restriction" {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -94,6 +94,10 @@
       {
         "name": "PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME_REVISION",
         "value": "${batch_tilemaker_job_definition_name_revision}"
+      },
+      {
+        "name": "PFB_TILEGARDEN_ROOT",
+        "value": "${tilegarden_root}"
       }
     ],
     "logConfiguration": {

--- a/deployment/terraform/task-definitions/django-q.json
+++ b/deployment/terraform/task-definitions/django-q.json
@@ -77,6 +77,10 @@
         {
           "name": "PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME_REVISION",
           "value": "${batch_tilemaker_job_definition_name_revision}"
+        },
+        {
+            "name": "PFB_TILEGARDEN_ROOT",
+            "value": "${tilegarden_root}"
         }
       ],
       "logConfiguration": {

--- a/deployment/terraform/task-definitions/management.json
+++ b/deployment/terraform/task-definitions/management.json
@@ -76,6 +76,10 @@
       {
         "name": "PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME_REVISION",
         "value": "${batch_tilemaker_job_definition_name_revision}"
+      },
+      {
+        "name": "PFB_TILEGARDEN_ROOT",
+        "value": "${tilegarden_root}"
       }
     ],
     "logConfiguration": {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -157,3 +157,5 @@ variable "aws_cloudwatch_logs_policy_arn" {
 variable "pfb_app_alb_ingress_cidr_block" {
   type = "list"
 }
+
+variable "tilegarden_api_gateway_domain_name" {}

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -347,6 +347,6 @@ PFB_ANALYSIS_DESTINATIONS = [
 PFB_ANALYSIS_PRESIGNED_URL_EXPIRES = 3600
 
 # Root URL for tile server.
-# TODO (probably with issue #595): this is the development answer. For staging/production
-#      we'll have to supply the URL of the actual deployed CloudFront distribution.
-TILEGARDEN_ROOT = 'http://localhost:9400'
+TILEGARDEN_ROOT = os.getenv('PFB_TILEGARDEN_ROOT')
+if not TILEGARDEN_ROOT:
+    raise ImproperlyConfigured('env.PFB_TILEGARDEN_ROOT is required')

--- a/src/tilegarden/package.json
+++ b/src/tilegarden/package.json
@@ -22,6 +22,9 @@
   "files": [
     "dist"
   ],
+  "jest": {
+    "transform": {}
+  },
   "scripts": {
     "build-all-xml": "./scripts/build-all-xml.sh src/config src/config",
     "deploy": "yarn compile && claudia update --no-optional-dependencies ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}}",


### PR DESCRIPTION
## Overview

This PR wires up a CloudFront proxy for Tilegarden and puts the finishing touches on the Django/Terraform config in order to get Tilegarden serving tiles on staging.

### Demo

_TK after testing the deployment on staging._

## Testing Instructions

_TK after testing the deployment on staging._

Closes #594 #624 #625
