### PR TITLE
Feature/kak/import local anaysis jobs#617

### DIFF
--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -121,9 +121,11 @@ def upload_local_analysis(local_upload_task_uuid):
     except (ObjectDoesNotExist, ValidationError):
         logging.error('No local upload analysis task found for {uuid}.'.format(
                       uuid=local_upload_task_uuid))
+        raise
     except LocalAnalysisFetchException as ex:
         task.status = AnalysisLocalUploadTask.Status.ERROR
         task.error = ex.message
         task.save()
+        raise
     finally:
         shutil.rmtree(tmpdir)

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -3,7 +3,9 @@ import os
 import shutil
 import tempfile
 
-from pfb_analysis.models import AnalysisBatch
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+
+from pfb_analysis.models import AnalysisBatch, AnalysisLocalUploadTask
 from pfb_network_connectivity.utils import download_file
 from users.models import PFBUser
 
@@ -25,3 +27,15 @@ def create_batch_from_remote_shapefile(shapefile_url):
 
 def upload_local_analysis(local_upload_task_uuid):
     logging.warn('TODO: upload local analysis for task {uuid}'.format(uuid=local_upload_task_uuid))
+
+    try:
+        task = AnalysisLocalUploadTask.objects.get(uuid=local_upload_task_uuid)
+    except (ObjectDoesNotExist, ValidationError):
+        logging.error('No local upload analysis task found for {uuid}.'.format(
+                      uuid=local_upload_task_uuid))
+        return
+
+    task.status = AnalysisLocalUploadTask.Status.IMPORTING
+    task.save()
+
+    logging.info('Starting local analysis upload for {uuid}'.format(uuid=local_upload_task_uuid))

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -2,14 +2,37 @@ import logging
 import os
 import shutil
 import tempfile
+import zipfile
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
-from pfb_analysis.models import AnalysisBatch, AnalysisLocalUploadTask
+from pfb_analysis.models import AnalysisBatch, AnalysisJob, AnalysisLocalUploadTask
 from pfb_network_connectivity.utils import download_file
 from users.models import PFBUser
 
 logger = logging.getLogger(__name__)
+
+LOCAL_ANALYSIS_FILES = set((
+    'neighborhood_census_blocks.geojson',
+    'neighborhood_census_blocks.zip',
+    'neighborhood_colleges.geojson',
+    'neighborhood_community_centers.geojson',
+    'neighborhood_connected_census_blocks.csv.zip',
+    'neighborhood_dentists.geojson',
+    'neighborhood_doctors.geojson',
+    'neighborhood_hospitals.geojson',
+    'neighborhood_overall_scores.csv',
+    'neighborhood_parks.geojson',
+    'neighborhood_pharmacies.geojson',
+    'neighborhood_retail.geojson',
+    'neighborhood_schools.geojson',
+    'neighborhood_score_inputs.csv',
+    'neighborhood_social_services.geojson',
+    'neighborhood_supermarkets.geojson',
+    'neighborhood_transit.geojson',
+    'neighborhood_universities.geojson',
+    'neighborhood_ways.zip',
+))
 
 
 def create_batch_from_remote_shapefile(shapefile_url):
@@ -26,7 +49,7 @@ def create_batch_from_remote_shapefile(shapefile_url):
 
 
 def upload_local_analysis(local_upload_task_uuid):
-    logging.warn('TODO: upload local analysis for task {uuid}'.format(uuid=local_upload_task_uuid))
+    logging.info('Starting local analysis upload task {uuid}'.format(uuid=local_upload_task_uuid))
 
     try:
         task = AnalysisLocalUploadTask.objects.get(uuid=local_upload_task_uuid)
@@ -38,4 +61,47 @@ def upload_local_analysis(local_upload_task_uuid):
     task.status = AnalysisLocalUploadTask.Status.IMPORTING
     task.save()
 
-    logging.info('Starting local analysis upload for {uuid}'.format(uuid=local_upload_task_uuid))
+    logging.info('Starting local analysis upload {uuid} from {url}'.format(
+                 uuid=local_upload_task_uuid, url=task.upload_results_url))
+
+    # Download and extract zipfile of results from provided URL
+    tmpdir = tempfile.mkdtemp()
+    try:
+        local_filename = os.path.join(tmpdir, 'analysis_results.zip')
+        download_file(task.upload_results_url, local_filename=local_filename)
+        with zipfile.ZipFile(local_filename, 'r') as zip_handle:
+            zip_handle.extractall(tmpdir)
+        results_files = [filename for filename in os.listdir(tmpdir)]
+        for rfile in results_files:
+            logging.info('Extracted results file: {rfile}'.format(rfile=rfile))
+        missing = LOCAL_ANALYSIS_FILES.difference(set(results_files))
+        if missing:
+            logging.error('Missing expected results files for task {uuid}: {files}'.format(
+                          uuid=local_upload_task_uuid,
+                          files=', '.join(missing)))
+            task.status = AnalysisLocalUploadTask.Status.ERROR
+            task.error = 'Missing expected results files: {files}'.format(files=', '.join(missing))
+            task.save()
+            shutil.rmtree(tmpdir)
+            return
+    except Exception as ex:
+        logging.error('Failed to fetch analysis results for task {uuid} from {url}: {msg}'.format(
+                      uuid=local_upload_task_uuid,
+                      url=task.upload_results_url,
+                      msg=ex.message))
+        task.status = AnalysisLocalUploadTask.Status.ERROR
+        task.error = ex.message
+        task.save()
+        shutil.rmtree(tmpdir)
+        return
+
+    # If we got this far, the expected results files have been extracted successfully
+    # TODO: upload to the expected S3 locations for the job
+    logging.info('Results files extracted for upload task {uuid}'.format(
+                 uuid=local_upload_task_uuid))
+
+    task.job.status = AnalysisJob.Status.COMPLETE
+    task.job.save()
+    task.status = AnalysisLocalUploadTask.Status.COMPLETE
+    task.save()
+    logging.info('Successfully completed upload task {uuid}'.format(uuid=local_upload_task_uuid))

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -44,83 +44,86 @@ def create_batch_from_remote_shapefile(shapefile_url):
         shutil.rmtree(tmpdir)
 
 
+class LocalAnalysisFetchException(Exception):
+    """Holds the message for use as the error on `AnalysisLocalUploadTask` API responses."""
+    pass
+
+
 def upload_local_analysis(local_upload_task_uuid):
-    logging.info('Starting local analysis upload task {uuid}'.format(uuid=local_upload_task_uuid))
 
-    tmpdir = tempfile.mkdtemp()
+    def upload_and_insert_local_results(tmpdir, task):
+        try:
+            logging.info('Results files extracted for upload task {uuid}'.format(
+                         uuid=local_upload_task_uuid))
 
-    def upload_and_insert_local_results(task):
-        logging.info('Results files extracted for upload task {uuid}'.format(
-                     uuid=local_upload_task_uuid))
+            s3_client = boto3.client('s3')
 
-        s3_client = boto3.client('s3')
+            # Upload the files extracted to the tmp dir to the expected S3 locations for the job
+            for results_file in LOCAL_ANALYSIS_FILES:
+                s3_key = '{results_path}/{filename}'.format(results_path=task.job.s3_results_path,
+                                                            filename=results_file)
+                local_file = os.path.join(tmpdir, results_file)
+                s3_client.upload_file(local_file, settings.AWS_STORAGE_BUCKET_NAME, s3_key)
 
-        # upload to the expected S3 locations for the job
+            logging.info('Uploaded results files to S3 in {directory}'.format(
+                directory=task.job.s3_results_path))
 
-        # Upload the files
-        for results_file in LOCAL_ANALYSIS_FILES:
-            s3_key = '{results_path}/{filename}'.format(results_path=task.job.s3_results_path,
-                                                        filename=results_file)
-            local_file = os.path.join(tmpdir, results_file)
-            s3_client.upload_file(local_file, settings.AWS_STORAGE_BUCKET_NAME, s3_key)
+            # Store the neigborhood ways and Census block results back to models
+            logging.info('Importing neighborhood ways and Census blocks back to database')
+            add_results_geoms(task.job)
 
-        logging.info('Uploaded results files to S3 in {directory}'.format(
-            directory=task.job.s3_results_path))
+            # Mark this upload task and its associated analysis job as completed.
+            task.job.status = AnalysisJob.Status.COMPLETE
+            task.job.save()
+            task.status = AnalysisLocalUploadTask.Status.COMPLETE
+            task.save()
+            logging.info('Successfully completed upload task {uuid}'.format(
+                uuid=local_upload_task_uuid))
+        except Exception as ex:
+            logging.error('Failed to upload analysis results for task {uuid}'.format(
+                uuid=local_upload_task_uuid))
+            raise LocalAnalysisFetchException(ex.message)
 
-        # Store the neigborhood ways and Census block results back to models
-        logging.info('Importing neighborhood ways and Census blocks back to database')
-        add_results_geoms(task.job)
+    def download_and_extract_local_results(tmpdir, task):
+        try:
+            local_filename = os.path.join(tmpdir, 'analysis_results.zip')
+            download_file(task.upload_results_url, local_filename=local_filename)
+            with zipfile.ZipFile(local_filename, 'r') as zip_handle:
+                zip_handle.extractall(tmpdir)
+            results_files = [filename for filename in os.listdir(tmpdir)]
 
-        # Mark this upload task and its associated analysis job as completed.
-        task.job.status = AnalysisJob.Status.COMPLETE
-        task.job.save()
-        task.status = AnalysisLocalUploadTask.Status.COMPLETE
-        task.save()
-        logging.info('Successfully completed upload task {uuid}'.format(
-            uuid=local_upload_task_uuid))
+            # Verify all expected results files are in the upload
+            missing = LOCAL_ANALYSIS_FILES.difference(set(results_files))
+            if missing:
+                raise LocalAnalysisFetchException('Missing expected results files: {files}'.format(
+                    files=', '.join(missing)))
+        except Exception as ex:
+            msg = 'Failed to fetch analysis results for task {uuid} from {url}: {msg}'.format(
+                uuid=local_upload_task_uuid, url=task.upload_results_url, msg=ex.message)
+            logging.error(msg)
+            raise LocalAnalysisFetchException(ex.message)
 
     try:
+        logging.info('Starting local analysis upload task {uuid}'.format(
+            uuid=local_upload_task_uuid))
+        tmpdir = tempfile.mkdtemp()
+
+        # First find the upload task to process and mark its status
         task = AnalysisLocalUploadTask.objects.get(uuid=local_upload_task_uuid)
+        task.status = AnalysisLocalUploadTask.Status.IMPORTING
+        task.save()
+
+        # Run the local analysis download, extract, and upload for the task
+        logging.info('Starting local analysis upload {uuid} from {url}'.format(
+                     uuid=local_upload_task_uuid, url=task.upload_results_url))
+        download_and_extract_local_results(tmpdir, task)
+        upload_and_insert_local_results(tmpdir, task)
     except (ObjectDoesNotExist, ValidationError):
         logging.error('No local upload analysis task found for {uuid}.'.format(
                       uuid=local_upload_task_uuid))
-        return
-
-    task.status = AnalysisLocalUploadTask.Status.IMPORTING
-    task.save()
-
-    logging.info('Starting local analysis upload {uuid} from {url}'.format(
-                 uuid=local_upload_task_uuid, url=task.upload_results_url))
-
-    # Download and extract zipfile of results from provided URL
-    try:
-        local_filename = os.path.join(tmpdir, 'analysis_results.zip')
-        download_file(task.upload_results_url, local_filename=local_filename)
-        with zipfile.ZipFile(local_filename, 'r') as zip_handle:
-            zip_handle.extractall(tmpdir)
-        results_files = [filename for filename in os.listdir(tmpdir)]
-
-        # Verify all expected results files are in the upload
-        missing = LOCAL_ANALYSIS_FILES.difference(set(results_files))
-        if missing:
-            logging.error('Missing expected results files for task {uuid}: {files}'.format(
-                          uuid=local_upload_task_uuid,
-                          files=', '.join(missing)))
-            task.status = AnalysisLocalUploadTask.Status.ERROR
-            task.error = 'Missing expected results files: {files}'.format(files=', '.join(missing))
-            task.save()
-            shutil.rmtree(tmpdir)
-            return
-
-        # If we got this far, the expected results files have been extracted successfully
-        upload_and_insert_local_results(task)
-    except Exception as ex:
-        logging.error('Failed to fetch analysis results for task {uuid} from {url}: {msg}'.format(
-                      uuid=local_upload_task_uuid,
-                      url=task.upload_results_url,
-                      msg=ex.message))
+    except LocalAnalysisFetchException as ex:
         task.status = AnalysisLocalUploadTask.Status.ERROR
         task.error = ex.message
         task.save()
+    finally:
         shutil.rmtree(tmpdir)
-        return


### PR DESCRIPTION
## Overview

Extract, validate, and upload local analysis results from provided URL in task.


### Demo

A completed job:

![image](https://user-images.githubusercontent.com/960264/50235510-0f609680-0386-11e9-975f-1bf7dc440e55.png)


Re-imported neighborhood ways and Census blocks for that job:

![pfb_reimported_geo_results_console](https://user-images.githubusercontent.com/960264/50235332-a711b500-0385-11e9-9943-32081fa93338.png)

The files uploaded for the job to S3:

![image](https://user-images.githubusercontent.com/960264/50235599-3a4aea80-0386-11e9-9bb9-f469fda89f92.png)


Error message returned on attempting to upload a zip file missing results:

![pfb_api_task_error_missing_files](https://user-images.githubusercontent.com/960264/50235408-cf99af00-0385-11e9-98b9-52c494eea080.png)


## Testing Instructions

 * Upload local analysis results to a publicly accessible URL (or use [mine](https://s3.amazonaws.com/kat-pfb-storage-us-east-1/germantown_results.zip))
 * Create a local analysis upload task at http://localhost:9200/api/local_upload_tasks/
 * Get the job UUID from the returned upload task JSON
 * Check all 19 results file are on S3 in the results directory named like: `https://s3.console.aws.amazon.com/s3/buckets/{$USER}-pfb-storage-us-east-1/results/{JOB_ID}/`
 * Check in the Django console that Census block and neighborhood ways results exist for the job ID
 * Attempting to create a local analysis upload task with an incomplete/invalid results zip file should return an appropriate error
 * Job and upload task status should match expected stages

Closes #617 
Closes #620 
