### PR TITLE
Switch GPG keyservers used in tilemaker docker build

### DIFF
--- a/src/tilemaker/Dockerfile
+++ b/src/tilemaker/Dockerfile
@@ -22,10 +22,11 @@ RUN set -ex \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --no-tty --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --no-tty --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --no-tty --recv-keys "$key" ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
@@ -42,13 +43,6 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 ENV YARN_VERSION 0.22.0
 
 RUN set -ex \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
-  done \
   && curl -fSL -o yarn.js "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js" \
   && curl -fSL -o yarn.js.asc "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js.asc" \
   && gpg --batch --verify yarn.js.asc yarn.js \


### PR DESCRIPTION
## Overview

Address GPG keyserver timeout issues on `tilemaker` container build.


## Testing Instructions

 * Clean out local docker images
 * `./scripts/update` should succeed reliably without GPG keyserver timeouts


Fixes #630.
