### PR TITLE
Use Terraform image to run infrastructure updates

### DIFF
--- a/deployment/terraform/docker-compose.yml
+++ b/deployment/terraform/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  terraform:
+    image: quay.io/azavea/terraform:0.9.6
+    volumes:
+      - ./:/usr/local/src
+      - $HOME/.aws:/root/.aws:ro
+    environment:
+      - PFB_DEBUG=1
+      - AWS_PROFILE
+      - GIT_COMMIT
+      - PFB_SETTINGS_BUCKET
+      - BATCH_ANALYSIS_JOB_NAME_REVISION
+      - BATCH_TILEMAKER_JOB_NAME_REVISION
+    working_dir: /usr/local/src
+    entrypoint: terraform

--- a/scripts/infra
+++ b/scripts/infra
@@ -58,11 +58,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 popd
 
                 rm -rf .terraform/ terraform.tfstate*
-                terraform init \
+                docker-compose run --rm \
+                    terraform init \
                     -backend-config="bucket=${PFB_SETTINGS_BUCKET}" \
                     -backend-config="key=terraform/state"
 
-                terraform plan \
+                docker-compose run --rm \
+                    terraform plan \
                           -var-file="${PFB_SETTINGS_BUCKET}.tfvars" \
                           -var="git_commit=\"${GIT_COMMIT}\"" \
                           -var="batch_analysis_job_definition_name_revision=${BATCH_ANALYSIS_JOB_NAME_REVISION}" \
@@ -70,7 +72,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                           -out="${PFB_SETTINGS_BUCKET}.tfplan"
                 ;;
             apply)
-                terraform apply "${PFB_SETTINGS_BUCKET}.tfplan"
+                docker-compose run --rm terraform apply "${PFB_SETTINGS_BUCKET}.tfplan"
 
                 popd
                 pushd "${DIR}/.."


### PR DESCRIPTION
# Overview

Builds to develop are failing because I updated Terraform state using Terraform v0.9.6, but the Jenkins box on CI runs v0.9.3. Instead of relying on the Terraform version installed on the host,
run Terraform from a Quay image to ensure that versions are consistent across all environments.

## Testing Instructions

Test this PR by running a deployment manually on your machine:

* Shell into the VM with `vagrant ssh`
* Export required env vars for deployment:

```
export GIT_COMMIT=$(git rev-parse --short HEAD)`
export ENVIRONMENT="staging"`
export PFB_AWS_ECR_ENDPOINT="950872791630.dkr.ecr.us-east-1.amazonaws.com"
export PFB_SETTINGS_BUCKET="staging-pfb-config-us-east-1"
```

* Run `./scripts/infra plan` to plan the deployment (only the task definitions and ECS services should change)
* Run `./scripts/infra apply` to update infrastructure 
