### PR TITLE
Fix comparison places not on current page being lost

### DIFF
--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -183,6 +183,7 @@
             // Read out pre-set places to compare from the URL. Keep this state in the URL
             // so user can navigate between places list and comparison without losing selections.
             var uuidsToCompare = [$stateParams.place1, $stateParams.place2, $stateParams.place3];
+            _.remove(uuidsToCompare, function(placeId) { return placeId.length === 0; });
 
             AnalysisJob.query(params).$promise.then(function(data) {
 
@@ -192,11 +193,6 @@
                     neighborhood.modifiedAt = obj.modifiedAt;
                     neighborhood.overall_score = obj.overall_score;
                     neighborhood.population_total = obj.population_total;
-
-                    if (_.includes(uuidsToCompare, neighborhood.uuid)) {
-                        addPlaceToCompare(neighborhood);
-                    }
-
                     return neighborhood;
                 });
                 setMapPlaces(places);
@@ -219,6 +215,17 @@
                     ctl.hasPrev = false;
                     prevParams = {};
                 }
+
+                // Fetch places to compare; not all may be in the current page of `places`
+                _.map(uuidsToCompare, function(uuid) {
+                    Neighborhood.query({uuid: uuid}).$promise.then(function(obj) {
+                        var neighborhood = new Neighborhood(obj);
+                        neighborhood.modifiedAt = obj.modifiedAt;
+                        neighborhood.overall_score = obj.overall_score;
+                        neighborhood.population_total = obj.population_total;
+                        addPlaceToCompare(neighborhood);
+                    });
+                });
             });
         }
 


### PR DESCRIPTION
## Overview

Separately request neighborhood data for comparison places.
Fixes comparison places not in current page of places on list view being lost on reloading list view.


### Notes

Original issue cannot be reproduced locally without having more than one page of analysis results to display.


## Testing Instructions

 * `./scripts/update`
 * Visit front-end site at dynamically loaded port (not nginx) http://localhost:9301
 * Navigate between comparison page, details, and list, adding places to compare
 * Reload list page with places to compare set
 * Comparison place list in list view should be retained as expected


Fixes #523 
