### PR TITLE
Use Docker Compose to remove terraform state in scripts/infra

### DIFF
--- a/scripts/infra
+++ b/scripts/infra
@@ -57,7 +57,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 echo "Tilemaker Task Name:Revision -- ${BATCH_TILEMAKER_JOB_NAME_REVISION}"
                 popd
 
-                rm -rf .terraform/ terraform.tfstate*
+                docker-compose run --rm \
+                    --entrypoint rm \
+                    terraform -rf .terraform/ terraform.tfstate*
+
                 docker-compose run --rm \
                     terraform init \
                     -backend-config="bucket=${PFB_SETTINGS_BUCKET}" \


### PR DESCRIPTION
## Overview

Previously, calls to `rm -rf .terraform` during `scripts/infra` on CI were being run as the Jenkins user. This would often fail because the `.terraform` directory had been created by a Docker Compose call, and so was owned by `root`. Use Docker Compose to remove the directory to avoid permissions errors.

### Notes

* See [this build](http://urbanappsci.internal.azavea.com/job/azavea/job/pfb-network-connectivity/job/develop/255/) for an example of the bug.

## Testing Instructions

* `ssh` into the Jenkins instance
* Run `sudo su - jenkins`
* `cd` into the `develop` workspace
* Run `cd deployment/terraform`
* Run `rm -rf .terraform` and confirm the command throws a permissions error
* Copy and run the command from the diff in this PR and confirm that the directory gets deleted

Connects #633 
