### PR TITLE
Fix local analysis run

### DIFF
--- a/src/analysis/scripts/export_connectivity.sh
+++ b/src/analysis/scripts/export_connectivity.sh
@@ -175,8 +175,6 @@ then
         ec_export_table_csv "${OUTPUT_DIR}" "neighborhood_overall_scores"
         # Send overall_scores to Django app
         update_overall_scores "${OUTPUT_DIR}/neighborhood_overall_scores.csv"
-        # Insert shapefile geometries into Django app DB if we have PFB_JOB_ID
-        PFB_S3_STORAGE_BUCKET="${AWS_STORAGE_BUCKET_NAME}" import_geometries_for_job
 
         if [ -n "${AWS_STORAGE_BUCKET_NAME}" ] && [ -n "${PFB_S3_RESULTS_PATH}" ]
         then
@@ -185,5 +183,8 @@ then
           aws s3 cp --quiet --recursive "${OUTPUT_DIR}" \
             "s3://${AWS_STORAGE_BUCKET_NAME}/${PFB_S3_RESULTS_PATH}"
         fi
+
+        # Insert shapefile geometries into Django app DB if we have PFB_JOB_ID
+        PFB_S3_STORAGE_BUCKET="${AWS_STORAGE_BUCKET_NAME}" import_geometries_for_job
     fi
 fi


### PR DESCRIPTION
## Overview

Do not attempt to download shapefile for re-import before shapefile uploaded to S3.


### Demo

![image](https://user-images.githubusercontent.com/960264/51121746-2c05b800-17e6-11e9-9b8a-1ce61270b74e.png)


### Notes

The geometry re-import added [here](https://github.com/azavea/pfb-network-connectivity/commit/68c9d6e596019e136d2677767e9bbc46a9e5fc28#diff-0d62f360dfca1dcdc47238568110d5a1R179) was attempting to re-import a file from S3 before it got uploaded to S3 in the block below.


## Testing Instructions

 * Start a local analysis job
 * Run the analysis job command output to console
 * Job should complete successfully
 * Analysis results should show in UI as expected


Fixes #637.
