### PR TITLE
Add analysis import admin UI

### DIFF
--- a/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
+++ b/src/angularjs/src/app/analysis-jobs/detail/analysis-jobs-detail.html
@@ -14,7 +14,7 @@
         Refresh
       </button>
 
-        <a class="btn btn-default" ui-sref="admin.analysis-jobs.list">Go back</a>
+      <a class="btn btn-default" ui-sref="admin.analysis-jobs.list">Go back</a>
       <h1 class="no-margin-top">
         Analysis Job
       </h1>

--- a/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.controller.js
@@ -1,0 +1,45 @@
+/**
+ * @ngdoc controller
+ * @name pfb.analysisJobs.import.controller:AnalysisJobImportController
+ *
+ * @description
+ * Controller for importing analysis results for a job run elsewhere
+ *
+ */
+(function() {
+    'use strict';
+
+    /** @ngInject */
+    function AnalysisJobImportController($log, $state, $filter, toastr, Neighborhood, AnalysisJobImport) {
+        var ctl = this;
+
+        function initialize() {
+            ctl.neighborhoods = Neighborhood.all().$promise.then(function(data) {
+                ctl.neighborhoods = data.results;
+            });
+        }
+
+        initialize();
+
+        ctl.import = function() {
+            var submitToast = toastr.info('Submitting analysis import. Please wait...',
+                                          {autoDismiss: false});
+
+            var job = new AnalysisJobImport({
+                neighborhood: ctl.neighborhood.uuid,
+                upload_results_url: ctl.url
+            });
+            job.$save().then(function() {
+                toastr.clear(submitToast);
+                toastr.success('Successfully submitted analysis import job');
+                $state.go('admin.analysis-jobs.list');
+            }).catch(function(error) {
+                toastr.clear(submitToast);
+                toastr.error('Error submitting analysis import job: ' + error);
+            });
+        };
+    }
+    angular
+        .module('pfb.analysisJobs.import')
+        .controller('AnalysisJobImportController', AnalysisJobImportController);
+})();

--- a/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.controller.js
@@ -10,7 +10,7 @@
     'use strict';
 
     /** @ngInject */
-    function AnalysisJobImportController($log, $state, $filter, toastr, Neighborhood, AnalysisJobImport) {
+    function AnalysisJobImportController($state, toastr, Neighborhood, AnalysisJobImport) {
         var ctl = this;
 
         function initialize() {

--- a/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.html
+++ b/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.html
@@ -1,0 +1,39 @@
+<pfb-navbar></pfb-navbar>
+
+<div class="container">
+  <div class="row">
+    <div class="column-12">
+      <h1>Import Analysis Results</h1>
+      <form name="analysisJobImportForm" novalidate ng-submit="analysisJobImport.import()">
+        <div class="row">
+          <div class="column-12">
+            <div class="form-group">
+                <label for="neighborhood">Neighborhood</label>
+                <select ng-model="analysisJobImport.neighborhood"
+                        ng-options="neighborhood as neighborhood.label for neighborhood
+                        in analysisJobImport.neighborhoods track by neighborhood.uuid"
+                        class="form-control" id="neighborhood" type="text" required>
+                </select>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="column-12">
+            <div class="form-group">
+                <label for="url">Results Zip File URL</label>
+                <input ng-model="analysisJobImport.url"
+                       ngf-pattern="'.zip'" class="column-12"
+                       type="url" name="url" required>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="column-12">
+            <button type="submit" ng-disabled="analysisJobImportForm.$invalid"
+                    class="btn-primary btn">Submit Analysis Results Import</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/angularjs/src/app/analysis-jobs/import/module.js
+++ b/src/angularjs/src/app/analysis-jobs/import/module.js
@@ -1,0 +1,4 @@
+(function () {
+    'use strict';
+    angular.module('pfb.analysisJobs.import', []);
+ })();

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -4,6 +4,10 @@
   <div class="row">
     <div class="column-12">
       <button ng-if="analysisJobList.isAdminUser"
+        ui-sref="admin.analysis-jobs.import" class="btn btn-primary pull-right">
+        Import Analysis
+      </button>
+      <button ng-if="analysisJobList.isAdminUser"
         ui-sref="admin.analysis-jobs.create" class="btn btn-primary pull-right">
         Run Analysis
       </button>

--- a/src/angularjs/src/app/analysis-jobs/module.js
+++ b/src/angularjs/src/app/analysis-jobs/module.js
@@ -5,5 +5,6 @@
                    ['pfb.analysisJobs.constants',
                     'pfb.analysisJobs.list',
                     'pfb.analysisJobs.create',
-                    'pfb.analysisJobs.detail']);
+                    'pfb.analysisJobs.detail',
+                    'pfb.analysisJobs.import']);
 })();

--- a/src/angularjs/src/app/components/analysis-jobs/analysis-jobs.service.js
+++ b/src/angularjs/src/app/components/analysis-jobs/analysis-jobs.service.js
@@ -51,7 +51,26 @@
         return module;
     }
 
+    /**
+     * @ngdoc service
+     * @name pfb.analysis-jobs.AnalysisJob:AnalysisJobImport
+     *
+     * @description
+     * Resource for import tasks for analysis jobs
+     */
+    /* @ngInject */
+    function AnalysisJobImport($resource) {
+
+        return $resource('/api/local_upload_tasks/', {uuid: '@uuid'}, {
+            'query': {
+                method: 'GET',
+                isArray: false
+            }
+        });
+    }
+
     angular.module('pfb.components.analysis-jobs')
         .factory('AnalysisJob', AnalysisJob)
-        .factory('AnalysisJobStatuses', AnalysisJobStatuses);
+        .factory('AnalysisJobStatuses', AnalysisJobStatuses)
+        .factory('AnalysisJobImport', AnalysisJobImport);
 })();

--- a/src/angularjs/src/app/index.route.js
+++ b/src/angularjs/src/app/index.route.js
@@ -133,6 +133,12 @@
                 controllerAs: 'analysisJobCreate',
                 templateUrl: 'app/analysis-jobs/create/analysis-jobs-create.html'
             })
+            .state('admin.analysis-jobs.import', {
+                url: 'import/',
+                controller: 'AnalysisJobImportController',
+                controllerAs: 'analysisJobImport',
+                templateUrl: 'app/analysis-jobs/import/analysis-jobs-import.html'
+            })
             .state('admin.analysis-jobs.detail', {
                 url: ':uuid/',
                 controller: 'AnalysisJobDetailController',


### PR DESCRIPTION
## Overview

Add view at /admin/analysis-jobs/import to import
existing analysis results.


### Demo

New button:

![image](https://user-images.githubusercontent.com/960264/51553200-3fe19780-1e40-11e9-927b-0eff2eef6fcc.png)


Page:
![image](https://user-images.githubusercontent.com/960264/51553156-2b050400-1e40-11e9-8b52-857ee4ed2e76.png)


## Testing Instructions

 * Go to admin UI analysis job page [here](http://localhost:9301/#/admin/analysis-jobs/)
 * Click to import analysis should go to new import page
 * Should be able to start analysis import
 * Should redirect to analysis job list page after submit


Closes #647.
