### PR TITLE
Feature/kak/cancel q tasks#671

### DIFF
--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -131,7 +131,10 @@ class AnalysisBatchViewSet(ViewSet):
             ClientMethod='get_object',
             Params={'Bucket': settings.AWS_STORAGE_BUCKET_NAME, 'Key': key}
         )
-        async('pfb_analysis.tasks.create_batch_from_remote_shapefile', url, ack_failure=True)
+        async('pfb_analysis.tasks.create_batch_from_remote_shapefile',
+            url,
+            group='create_analysis_batch',
+            ack_failure=True)
 
         return Response({
             'shapefile_url': url,
@@ -174,7 +177,10 @@ class AnalysisLocalUploadTaskViewSet(mixins.CreateModelMixin,
                                          created_by=user, modified_by=user)
         obj = serializer.save(job=job, created_by=user, modified_by=user)
 
-        async('pfb_analysis.tasks.upload_local_analysis', obj.uuid, ack_failure=True)
+        async('pfb_analysis.tasks.upload_local_analysis',
+            obj.uuid,
+            group='import_analysis_job',
+            ack_failure=True)
 
 
 class NeighborhoodViewSet(ModelViewSet):

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -131,7 +131,7 @@ class AnalysisBatchViewSet(ViewSet):
             ClientMethod='get_object',
             Params={'Bucket': settings.AWS_STORAGE_BUCKET_NAME, 'Key': key}
         )
-        async('pfb_analysis.tasks.create_batch_from_remote_shapefile', url)
+        async('pfb_analysis.tasks.create_batch_from_remote_shapefile', url, ack_failure=True)
 
         return Response({
             'shapefile_url': url,
@@ -174,7 +174,7 @@ class AnalysisLocalUploadTaskViewSet(mixins.CreateModelMixin,
                                          created_by=user, modified_by=user)
         obj = serializer.save(job=job, created_by=user, modified_by=user)
 
-        async('pfb_analysis.tasks.upload_local_analysis', obj.uuid)
+        async('pfb_analysis.tasks.upload_local_analysis', obj.uuid, ack_failure=True)
 
 
 class NeighborhoodViewSet(ModelViewSet):


### PR DESCRIPTION
## Overview

Remove failed `django-q` tasks from the task queue, instead of retrying indefinitely. Applies to both analysis import tasks and batch analysis job tasks.

## Demo

A single task failing in the logs:
![image](https://user-images.githubusercontent.com/960264/51624077-1d1ab600-1f08-11e9-92d0-91f927d2dacc.png)


### Notes

Limiting the number of retries to a low number might be preferable to limiting to one attempt, in case of some intermittent failure. However, `django-q` appears to not offer retry attempt count limits as a feature.

Tasks that fail currently have their related Django model object marked with `ERROR` status, but the `django-q` task would continue to retry, even after calling `delete` on the queue task. This change will not stop any existing failing queued tasks from continuing to retry, but will cause new tasks to not retry after failure.


## Testing Instructions

 * Create an analysis upload task that will fail (as with a URL that is not a zip file) from the DRF admin [here](http://localhost:9200/api/local_upload_tasks/)
 * `django-q` should log the task failure, once
 * No retries with the same new queue task name should appear in the logs


Fixes #671
