### PR TITLE
Write tiles to S3 cache

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -18,6 +18,7 @@ services:
       - PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME_REVISION
       - PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME
       - PFB_TILEGARDEN_ROOT=http://localhost:9400
+      - PFB_TILEGARDEN_CACHE_BUCKET=dev-pfb-tilecache-us-east-1
     volumes:
       - $HOME/.aws:/root/.aws:ro
 

--- a/scripts/clear-tile-cache
+++ b/scripts/clear-tile-cache
@@ -2,14 +2,16 @@
 
 set -e
 
-BUCKET_NAME=$(docker-compose run --rm tilegarden bash -c 'echo -n $PFB_TILEGARDEN_CACHE_BUCKET')
+DEFAULT_BUCKET_NAME=$(docker-compose run --rm tilegarden bash -c 'echo -n $PFB_TILEGARDEN_CACHE_BUCKET')
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0") [--list]
+         "Usage: $(basename "$0") [--list] [BUCKET]
 
-Removes all cached tiles (that is, all files) from the configured S3 bucket:
-    $BUCKET_NAME
+Removes all cached tiles (that is, all files) from the configured S3 cache bucket:
+    $DEFAULT_BUCKET_NAME
+
+The target bucket can be overridden by passing a different bucket name as an argument.
 
 With the --list option, lists and summarizes the contents before asking for confirmation.
 "
@@ -20,7 +22,16 @@ then
     if [ "${1:-}" = "--help" ]; then
         usage
         exit
-    elif [ "${1:-}" = "--list" ]; then
+    fi
+
+    if [ "${1:-}" = "--list" ]; then
+        SHOW_LIST=true
+        shift
+    fi
+
+    BUCKET_NAME="${1:-$DEFAULT_BUCKET_NAME}"
+
+    if [ $SHOW_LIST ]; then
         aws s3 ls --recursive --summarize "s3://${BUCKET_NAME}"
         echo ""
     fi

--- a/scripts/clear-tile-cache
+++ b/scripts/clear-tile-cache
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+BUCKET_NAME=$(docker-compose run --rm tilegarden bash -c 'echo -n $PFB_TILEGARDEN_CACHE_BUCKET')
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") [--list]
+
+Removes all cached tiles (that is, all files) from the configured S3 bucket:
+    $BUCKET_NAME
+
+With the --list option, lists and summarizes the contents before asking for confirmation.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+        exit
+    elif [ "${1:-}" = "--list" ]; then
+        aws s3 ls --recursive --summarize "s3://${BUCKET_NAME}"
+        echo ""
+    fi
+
+    echo "This will delete all files from the '$BUCKET_NAME' S3 bucket."
+
+    read -r -p "Are you sure? [y/N] " response
+    response=${response,,}    # tolower
+    if [[ "$response" =~ ^(yes|y)$ ]]
+    then
+        aws s3 rm --recursive "s3://${BUCKET_NAME}"
+    fi
+fi

--- a/src/tilegarden/.env.dev
+++ b/src/tilegarden/.env.dev
@@ -1,5 +1,7 @@
+AWS_PROFILE
 PFB_DB_HOST=database.service.pfb.internal
 PFB_DB_DATABASE=pfb
 PFB_DB_PASSWORD=pfb
 PFB_DB_PORT=5432
 PFB_DB_USER=pfb
+PFB_TILEGARDEN_CACHE_BUCKET=dev-pfb-tilecache-us-east-1

--- a/src/tilegarden/.eslintrc.json
+++ b/src/tilegarden/.eslintrc.json
@@ -4,15 +4,17 @@
   },
   "extends": "airbnb-base",
   "rules": {
-    "semi": [2, "never"],
-    "no-unexpected-multiline": 2,
-    "indent": ["error", 4],
-    "max-len": ["error", 100, { "ignoreComments": true}],
-    "quotes": ["error", "single"],
     "camelcase": 2,
-    "vars-on-top": 2,
-    "strict": 2,
+    "indent": ["error", 4],
+    "import/no-extraneous-dependencies": ["error", {"optionalDependencies": true}],
+    "no-console": 0,
+    "no-unexpected-multiline": 2,
+    "max-len": ["error", 100, { "ignoreComments": true}],
     "max-statements": ["error", 50],
-    "import/no-extraneous-dependencies": ["error", {"optionalDependencies": true}]
+    "object-curly-newline": ["error", { "consistent": true }],
+    "quotes": ["error", "single"],
+    "semi": [2, "never"],
+    "strict": 2,
+    "vars-on-top": 2
   }
 }

--- a/src/tilegarden/src/api.js
+++ b/src/tilegarden/src/api.js
@@ -3,6 +3,7 @@
  */
 
 const APIBuilder = require('claudia-api-builder')
+const aws = require('aws-sdk')
 
 const { imageTile, createMap } = require('./tiler')
 const HTTPError = require('./util/error-builder')
@@ -71,6 +72,40 @@ const handleError = (e) => {
     )
 }
 
+/* Uploads a tile to the S3 cache, using its request path as a key
+ *
+ * Does nothing unless there's a CACHE_BUCKET set in the environment.
+ * Returns the Promise<tile> again for chaining.
+ *
+ * Theoretically it should be possible to run the upload in parallel and not make the request
+ * wait for it before returning the tile, but in fact the process gets killed when the main promise
+ * resolves so the upload doesn't manage to finish.
+ */
+const writeToS3 = (tile, req) => {
+    const s3CacheBucket = process.env.PFB_TILEGARDEN_CACHE_BUCKET
+    if (s3CacheBucket) {
+        let key = req.path
+        // API Gateway includes a 'path' property but claudia-local-api currently doesn't
+        // (see https://github.com/azavea/claudia-local-api/issues/1), so this reconstructs it.
+        if (!key) {
+            const { z, x, y, job_id, config } = req.pathParameters
+            const tileType = req.requestContext.resourcePath.split('/')[1]
+            key = `tile/${job_id}/${config}/${z}/${x}/${y}`
+        }
+
+        const upload = new aws.S3().putObject({
+            Bucket: s3CacheBucket,
+            Key: key,
+            Body: tile,
+        })
+        return upload.promise().then(() => {
+            console.debug(`Uploaded tile to S3: ${key}`)
+            return tile
+        })
+    }
+    return new Promise((resolve, reject) => resolve(tile))
+}
+
 // Get tile for some zxy bounds
 api.get(
     '/tile/{job_id}/{config}/{z}/{x}/{y}',
@@ -82,6 +117,7 @@ api.get(
             const configOptions = processConfig(req)
 
             return imageTile(createMap(z, x, y, filters, layers, configOptions))
+                .then(tile => writeToS3(tile, req))
                 .then(img => new APIBuilder.ApiResponse(img, IMAGE_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {

--- a/src/tilegarden/src/api.js
+++ b/src/tilegarden/src/api.js
@@ -88,9 +88,10 @@ const writeToS3 = (tile, req) => {
         // API Gateway includes a 'path' property but claudia-local-api currently doesn't
         // (see https://github.com/azavea/claudia-local-api/issues/1), so this reconstructs it.
         if (!key) {
+            /* eslint-disable camelcase */
             const { z, x, y, job_id, config } = req.pathParameters
-            const tileType = req.requestContext.resourcePath.split('/')[1]
             key = `tile/${job_id}/${config}/${z}/${x}/${y}`
+            /* eslint-enable camelcase */
         }
 
         const upload = new aws.S3().putObject({
@@ -103,7 +104,7 @@ const writeToS3 = (tile, req) => {
             return tile
         })
     }
-    return new Promise((resolve, reject) => resolve(tile))
+    return new Promise(resolve => resolve(tile))
 }
 
 // Get tile for some zxy bounds

--- a/src/tilegarden/src/api.js
+++ b/src/tilegarden/src/api.js
@@ -16,11 +16,11 @@ const HTML_RESPONSE = { success: { contentType: 'text/html' } }
 // Converts a req object to a set of coordinates
 const processCoords = (req) => {
     // Handle url params
-    const z = Number(req.pathParams.z)
-    const x = Number(req.pathParams.x)
+    const z = Number(req.pathParameters.z)
+    const x = Number(req.pathParameters.x)
 
     // strip .png off of y if necessary
-    const preY = req.pathParams.y
+    const preY = req.pathParameters.y
     const y = Number(preY.substr(0, preY.lastIndexOf('.')) || preY)
 
     // Check type of coords
@@ -33,15 +33,17 @@ const processCoords = (req) => {
 
 const getPositionalFilters = (req) => {
     /* eslint-disable-next-line object-curly-newline */
-    const { x, y, z, config, ...remainder } = req.pathParams
+    const { x, y, z, config, ...remainder } = req.pathParameters
     return remainder
 }
 
 // Returns a properly formatted list of layers
 // or an empty list if there are none
 const processLayers = (req) => {
-    if (req.queryString.layers) return JSON.parse(req.queryString.layers)
-    else if (req.queryString.layer || req.queryString.filter || req.queryString.filters) {
+    if (req.queryStringParameters.layers) return JSON.parse(req.queryStringParameters.layers)
+    else if (req.queryStringParameters.layer ||
+             req.queryStringParameters.filter ||
+             req.queryStringParameters.filters) {
         /* eslint-disable-next-line quotes */
         throw HTTPError("Invalid argument, did you mean '&layers='?", 400)
     }
@@ -51,12 +53,12 @@ const processLayers = (req) => {
 
 // Parses out the configuration specifications
 const processConfig = req => ({
-    s3bucket: req.queryString.s3bucket,
-    config: req.pathParams.config,
+    s3bucket: req.queryStringParameters.s3bucket,
+    config: req.pathParameters.config,
 })
 
 // Create new lambda API
-const api = new APIBuilder()
+const api = new APIBuilder({ requestFormat: 'AWS_PROXY' })
 
 // Handles error by returning an API response object
 const handleError = (e) => {

--- a/src/tilegarden/tests/api.test.js
+++ b/src/tilegarden/tests/api.test.js
@@ -6,7 +6,7 @@ const api = rewire('../src/api'),
 describe('processCoords', () => {
     test('properly parses properly formatted coords', () => {
         const req = {
-            pathParams: {
+            pathParameters: {
                 x: '2385',
                 y: '3103.png',
                 z: '13'
@@ -21,14 +21,14 @@ describe('processCoords', () => {
 
     test('parses extensions other than png', () => {
         const req = {
-            pathParams: {
+            pathParameters: {
                 x: '2385',
                 y: '3103.jpg',
                 z: '13'
             }
         }
         const req2 = {
-            pathParams: {
+            pathParameters: {
                 x: '2385',
                 y: '3103.pdf',
                 z: '13'
@@ -48,7 +48,7 @@ describe('processCoords', () => {
 
     test('properly parses coords with no file extension', () => {
         const req = {
-            pathParams: {
+            pathParameters: {
                 x: '2385',
                 y: '3103',
                 z: '13'
@@ -63,7 +63,7 @@ describe('processCoords', () => {
 
     test('throws an error for non-numeral coords', () => {
         const req = {
-            pathParams: {
+            pathParameters: {
                 x: 'eggs',
                 y: 'bacon',
                 z: 'orange_juice'
@@ -76,7 +76,7 @@ describe('processCoords', () => {
 describe('processLayers', () => {
     test('properly parses list of layer', () => {
         const req = {
-            queryString: {
+            queryStringParameters: {
                 layers: '["layer1","layer2","layer3","layer4"]'
             }
         }
@@ -85,7 +85,7 @@ describe('processLayers', () => {
 
     test('properly parses just one layer', () => {
         const req = {
-            queryString: {
+            queryStringParameters: {
                 layers: '["layer"]'
             }
         }
@@ -94,14 +94,14 @@ describe('processLayers', () => {
 
     test('properly parses no fields', () => {
         const req = {
-            queryString: {}
+            queryStringParameters: {}
         }
         expect(processLayers(req)).toEqual([])
     })
 
     test('properly parses a blank field', () => {
         const req = {
-            queryString: {
+            queryStringParameters: {
                 layers: ''
             }
         }


### PR DESCRIPTION
## Overview

Adds a step in the tile generation process where it checks for a `PFB_TILEGARDEN_CACHE_BUCKET` variable in the environment and, if it's set, writes the tile into that bucket, using the request path as the key.

Currently there's no way to serve the tiles from cache.  #634 covers that part.

Also adds a script to clear all files in the configured cache bucket.  I'm not sure that will be the way to do it in deployed environments (where it's harder to get a shell, and where the number of items might make the "change settings to make all objects expire, change settings back" deletion strategy preferable), but it seems useful in development.

### Demo
```
vagrant@pfb-network-connectivity:/vagrant$ aws s3 ls --recursive s3://dev-pfb-tilecache-us-east-1/
2019-01-23 17:00:57        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2103/2894.png
2019-01-23 17:00:56        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2103/2895.png
2019-01-23 17:00:56        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2103/2896.png
2019-01-23 17:00:56        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2103/2897.png
2019-01-23 17:00:57        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2103/2898.png
2019-01-23 17:00:56        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2104/2898.png
2019-01-23 17:00:57        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2105/2898.png
2019-01-23 17:00:57       3395 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2106/2898.png
2019-01-23 17:00:56       4447 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2107/2898.png
2019-01-23 17:00:56        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2108/2898.png
2019-01-23 17:00:57        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/census_blocks/13/2109/2898.png
2019-01-23 17:52:21        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2103/2894.png
2019-01-23 17:52:20        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2103/2895.png
2019-01-23 17:52:20        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2103/2896.png
2019-01-23 17:52:21        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2103/2897.png
2019-01-23 17:52:21        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2103/2898.png
2019-01-23 17:52:19        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2104/2898.png
2019-01-23 17:52:20        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2105/2898.png
2019-01-23 17:52:19       4204 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2106/2898.png
2019-01-23 17:52:19       7566 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2107/2898.png
2019-01-23 17:52:19      16902 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2108/2898.png
2019-01-23 17:52:21        334 tile/80bbb2a8-5399-40f2-95a8-537917f4197c/ways/13/2109/2898.png
```

### Notes

- Since I'm expecting serving from cache to be set up as an S3 Website, the key has to match the full request path exactly.  So the tiles have to go in the root of the bucket, not a subdirectory.  Or possibly there's a way to configure an S3 website to strip off a prefix, and it could be more flexible.  But I didn't manage to find an option like that in my limited looking.
- I don't think it's going to be possible to test the full caching setup locally, since Cloudfront can't use your local machine as an origin.  See 593.
- This also switches to using the `AWS_PROXY` request format for Claudia API Builder. See [docs](https://github.com/claudiajs/claudia-api-builder/blob/v3.0.2/docs/request-object.md#the-api-builder-request-object).
- Unfortunately `claudia-local-api` doesn't fully reproduce the AWS Proxy-style request object (see https://github.com/azavea/claudia-local-api/issues/1).  As noted in the code, this works around that by reconstructing the path from the parameters.

## Testing Instructions

- In the VM, run `./scripts/update` and `./scripts/server`
- Go to a neighborhood in [your dev front-end](http://localhost:9301/#/places////). Make sure the tiles are coming from Tilegarden, not S3 (i.e. that your TILEGARDEN_ROOT variable is set for the container).
- Any tiles you've just generated should now be in the `dev-pfb-tilecache-us-east-1` bucket (you can run `./scripts/clear-tile-cache` to clear out the clutter if it's hard to tell).

Resolves #635 
Resolves #636 