### PR TITLE
Fix invisible admin pagination buttons

### DIFF
--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -34,12 +34,12 @@
         </tbody>
       </table>
       <div class="buttons-pagination">
-        <button class="btn-success btn" ng-click="analysisJobList.getPrev()"
+        <button class="btn-default btn" ng-click="analysisJobList.getPrev()"
                 ng-disabled="!analysisJobList.hasPrev">
 
           Newer
         </button>
-        <button class="btn-success btn" ng-click="analysisJobList.getNext()"
+        <button class="btn-default btn" ng-click="analysisJobList.getNext()"
                 ng-disabled="!analysisJobList.hasNext">
           Older
         </button>

--- a/src/angularjs/src/app/neighborhoods/list/neighborhoods-list.html
+++ b/src/angularjs/src/app/neighborhoods/list/neighborhoods-list.html
@@ -37,12 +37,12 @@
         </tbody>
       </table>
       <div class="buttons-pagination">
-        <button class="btn-success btn" ng-click="neighborhoodList.getPrev()"
+        <button class="btn-default btn" ng-click="neighborhoodList.getPrev()"
                 ng-disabled="!neighborhoodList.hasPrev">
 
           Newer
         </button>
-        <button class="btn-success btn" ng-click="neighborhoodList.getNext()"
+        <button class="btn-default btn" ng-click="neighborhoodList.getNext()"
                 ng-disabled="!neighborhoodList.hasNext">
           Older
         </button>

--- a/src/angularjs/src/app/users/list/users-list.html
+++ b/src/angularjs/src/app/users/list/users-list.html
@@ -21,11 +21,11 @@
         </tbody>
       </table>
       <!-- Paginate after 10 records; hide pagination when fewer than 10 records. -->
-        <button class="btn-success btn" ng-click="userList.getPrev()"
+        <button class="btn-default btn" ng-click="userList.getPrev()"
                 ng-disabled="!userList.hasPrev">
           Previous
         </button>
-        <button class="btn-success btn" ng-click="userList.getNext()"
+        <button class="btn-default btn" ng-click="userList.getNext()"
                 ng-disabled="!userList.hasNext">
           Next
         </button>


### PR DESCRIPTION
## Overview

It turns out fixing a style syntax error in [PR 655](https://github.com/azavea/pfb-network-connectivity/pull/655/files#diff-5645138bbcfd38020bf72c8203017f60L43) caused that style to start getting applied, but when combined with the fact that the pagination buttons in the admin were getting the default
`color` style from `btn` (because they were using a non-existent `btn-success` class), made them all but disappear.

This changes the class to `btn-default`, which is the same one used by the pagination buttons on the public-facing site.

### Demo

![image](https://user-images.githubusercontent.com/6598836/51701118-c3d18600-1fde-11e9-865a-36a81b3557f3.png)

## Testing Instructions

 Go to http://localhost:9301/#/admin/neighborhoods/, http://localhost:9301/#/admin/analysis-jobs/, and http://localhost:9301/#/admin/users/.  There should be pagination buttons at the bottom that are dark if active or lighter if disabled but clearly visible either way.

Resolves #674.
