### PR TITLE
Disable concurrent CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 #!groovy
 node {
+
+  properties([disableConcurrentBuilds()])
+  
   try {
     // Checkout the proper revision into the workspace.
     stage('checkout') {


### PR DESCRIPTION
## Overview

Fix docker port allocation issue by only running one build at a time.

Fixes #670.
