### PR TITLE
Do not require Census blocks GeoJSON to import

### DIFF
--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -23,7 +23,6 @@ DESTINATION_ANALYSIS_FILES = set(['neighborhood_{}.geojson'.format(destination)
 OVERALL_SCORES_FILE = 'neighborhood_overall_scores.csv'
 
 OTHER_RESULTS_FILES = set([
-    'neighborhood_census_blocks.geojson',
     'neighborhood_score_inputs.csv',
     'neighborhood_ways.zip',
     'neighborhood_census_blocks.zip',


### PR DESCRIPTION
## Overview

Fixes round-trip export/import of results by not requiring the GeoJSON version of the Census blocks results, which are imported instead as the Shapefile version; the GeoJSON file, though present in the local analysis results directory on the host machine, is not available for download through the UI.


## Notes

I'm not sure why the GeoJSON file is present, and so I'm not entirely confident that it is redundant for import.


## Testing

 - Download the files from the web admin UI page for a completed analysis job on production or staging
 - Zip the files together and upload them to a publicly accessible URL
 - Locally (on this branch) create an import task pointing to the zipped results file
 - Import should succeed and display results that match the original

Closes #687.
