### PR TITLE
Expanding bikeable service roads to include 'bicycle'='yes'

### DIFF
--- a/src/analysis/features/functional_class.sql
+++ b/src/analysis/features/functional_class.sql
@@ -58,8 +58,8 @@ UPDATE  neighborhood_ways
 SET     functional_class = 'path'
 FROM    neighborhood_osm_full_line osm
 WHERE   neighborhood_ways.osm_id = osm.osm_id
-AND     osm.highway='service'
-AND     osm.bicycle='designated';
+AND     osm.highway = 'service'
+AND     osm.bicycle IN ('yes', 'designated');
 
 UPDATE  neighborhood_ways
 SET     functional_class = 'living_street'


### PR DESCRIPTION
## Overview

Currently the BNA only considers roads with the functional class "service" to be bikeable roads if they include the tag bicycle='designated'. We'd like to include the value 'yes' as an acceptable alternative to 'designated'. 

### Notes

I have not tested this change because I am running into the same issues running the BNA locally as noted in #685.