### PR TITLE
Use pip --ignore-installed flag when installing docker-compose

### DIFF
--- a/deployment/ansible/roles/pfb.docker/tasks/main.yml
+++ b/deployment/ansible/roles/pfb.docker/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install docker-compose
-  pip: name=docker-compose version={{ docker_compose_version }}
+  pip: name=docker-compose
+       version={{ docker_compose_version }}
+       extra_args=--ignore-installed
 
 - name: Add Ansible user to Docker group
   user: name="{{ ansible_user }}"


### PR DESCRIPTION
## Overview

Due to an upstream bug in the `ansible-pip` role (https://github.com/azavea/ansible-pip/issues/12), the VM installs pip 19 instead of pip 9. As of pip 10, pip [no longer has support for uninstalling system packages](https://github.com/pypa/pip/issues/5247), which was preventing it from installing docker-compose. In order to get around this bug, instruct pip to [ignore installed packages](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i) when installing docker-compose, effectively reverting the behavior to what it was in pip 9.

### Notes

* For a detailed discussion of the pip issue, see: https://github.com/pypa/pip/issues/5247 And for the recommended solution, see: https://github.com/blockstack/blockstack-core/issues/504
* It seems like the biggest downside to this approach is that pip isn't really uninstalling the system packages, so you might get import errors in Python. However, we've been installing docker-compose this way from the start of development, so presumably it's a safe enough approach for this project.

## Testing Instructions

 * Clone into a new repo:

```
git clone git@github.com:azavea/pfb-network-connectivity.git pfb-provision
cd pfb-provision
```

* Copy the example Ansible variables:

```
cp deployment/ansible/group_vars/all.example deployment/ansible/group_vars/all
```

* Run `./scripts/server` and confirm that the Ansible provisioner runs successfully

Closes #685.
