### PR TITLE
Expand implementation of tilegarden toggle

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -19,6 +19,7 @@ services:
       - PFB_AWS_BATCH_TILEMAKER_JOB_DEFINITION_NAME
       - PFB_TILEGARDEN_ROOT=http://localhost:9400
       - PFB_TILEGARDEN_CACHE_BUCKET=dev-pfb-tilecache-us-east-1
+      - PFB_USE_TILEGARDEN=true
     volumes:
       - $HOME/.aws:/root/.aws:ro
 

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -152,8 +152,9 @@ data "template_file" "pfb_app_https_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
-    tilegarden_root                              = "${var.tilegarden_root}"
+    tilegarden_root                              = "https://${aws_route53_record.tilegarden.fqdn}"
     tilegarden_cache_bucket                      = "${lower(var.environment)}-pfb-tile-cache-${var.aws_region}}"
+    use_tilegarden                               = "${var.use_tilegarden}"
   }
 }
 
@@ -199,8 +200,9 @@ data "template_file" "pfb_app_async_queue_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
-    tilegarden_root                              = "${var.tilegarden_root}"
+    tilegarden_root                              = "https://${aws_route53_record.tilegarden.fqdn}"
     tilegarden_cache_bucket                      = "${lower(var.environment)}-pfb-tile-cache-${var.aws_region}}"
+    use_tilegarden                               = "${var.use_tilegarden}"
   }
 }
 
@@ -239,8 +241,9 @@ data "template_file" "pfb_app_management_ecs_task" {
     batch_analysis_job_definition_name_revision  = "${var.batch_analysis_job_definition_name_revision}"
     batch_tilemaker_job_queue_name               = "${var.batch_tilemaker_job_queue_name}"
     batch_tilemaker_job_definition_name_revision = "${var.batch_tilemaker_job_definition_name_revision}"
-    tilegarden_root                              = "${var.tilegarden_root}"
+    tilegarden_root                              = "https://${aws_route53_record.tilegarden.fqdn}"
     tilegarden_cache_bucket                      = "${lower(var.environment)}-pfb-tile-cache-${var.aws_region}}"
+    use_tilegarden                               = "${var.use_tilegarden}"
   }
 }
 

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -102,6 +102,10 @@
       {
         "name": "PFB_TILEGARDEN_CACHE_BUCKET",
         "value": "${tilegarden_cache_bucket}"
+      },
+      {
+        "name": "PFB_USE_TILEGARDEN",
+        "value": "${use_tilegarden}"
       }
     ],
     "logConfiguration": {

--- a/deployment/terraform/task-definitions/django-q.json
+++ b/deployment/terraform/task-definitions/django-q.json
@@ -85,6 +85,10 @@
         {
           "name": "PFB_TILEGARDEN_CACHE_BUCKET",
           "value": "${tilegarden_cache_bucket}"
+        },
+        {
+          "name": "PFB_USE_TILEGARDEN",
+          "value": "${use_tilegarden}"
         }
       ],
       "logConfiguration": {

--- a/deployment/terraform/task-definitions/management.json
+++ b/deployment/terraform/task-definitions/management.json
@@ -84,6 +84,10 @@
       {
         "name": "PFB_TILEGARDEN_CACHE_BUCKET",
         "value": "${tilegarden_cache_bucket}"
+      },
+      {
+        "name": "PFB_USE_TILEGARDEN",
+        "value": "${use_tilegarden}"
       }
     ],
     "logConfiguration": {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -135,10 +135,6 @@ variable "batch_ecs_image_minimum_cleanup_age" {
   default = "30m"
 }
 
-variable "tilegarden_root" {
-  default = ""
-}
-
 # Django
 variable "django_env" {}
 
@@ -162,9 +158,12 @@ variable "pfb_app_alb_ingress_cidr_block" {
   type = "list"
 }
 
-# CloudFront distribution
+# Tilegarden tiler
 variable "tilegarden_api_gateway_domain_name" {}
 
 variable "cloudfront_price_class" {
   default = "PriceClass_100"
+}
+variable "use_tilegarden" {
+  default = true
 }

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -116,9 +116,14 @@ def upload_local_analysis(local_upload_task_uuid):
         load_scores(task.job, local_scores_file, 'score_id', None)
 
         # Mark this upload task and its associated analysis job as completed.
-        task.job.update_status(AnalysisJob.Status.COMPLETE)
         task.status = AnalysisLocalUploadTask.Status.COMPLETE
         task.save()
+
+        if settings.USE_TILEGARDEN:
+            task.job.update_status(AnalysisJob.Status.COMPLETE)
+        else:
+            task.job.generate_tiles()
+
         logging.info('Successfully completed upload task {uuid}'.format(
             uuid=local_upload_task_uuid))
     except (ObjectDoesNotExist, ValidationError):

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -346,5 +346,9 @@ PFB_ANALYSIS_DESTINATIONS = [
 # Length of time in seconds that S3 pre-signed urls are valid for
 PFB_ANALYSIS_PRESIGNED_URL_EXPIRES = 3600
 
-# Root URL for tile server. If unset, reverts to using uploaded S3 tile URLs
+# Toggle for whether to use the dynamic tileserver or the S3 tiles
+USE_TILEGARDEN = os.getenv('PFB_USE_TILEGARDEN', 'false').lower() == 'true'
+# Root URL for tile server.
 TILEGARDEN_ROOT = os.getenv('PFB_TILEGARDEN_ROOT')
+if USE_TILEGARDEN and not TILEGARDEN_ROOT:
+    raise ImproperlyConfigured('env.PFB_TILEGARDEN_ROOT is required when USE_TILEGARDEN is true')


### PR DESCRIPTION
## Overview

As noted on #694, there are advantages to being able to easily switch between the tilemaker/S3 tiler and Tilegarden.  Also, per https://github.com/azavea/pfb-network-connectivity/issues/611#issuecomment-454157314, there was a bit more to do to fully integrate Tilegarden.

This switches the toggling behavior to use a new variable, `PFB_USE_TILEGARDEN`, and changes the analysis model to check it to determine both what tile URLs to send to the front-end and what to do after its analysis job runs--generate tiles with `tilemaker` if Tilegarden is disabled, mark the job complete if it's enabled.

This should make it easy to stay with `tilemaker` (by setting the variable to `false`), use Tilegarden immediately (by setting it to `true`), or start with the former then switch to the latter.  The geometry import at the end of the analysis is not conditional, so even if `USE_TILEGARDEN` is false, any new analysis runs will still have their geometries imported, so nothing extra needs to be done to use Tilegarden for their tiles.
The one scenario that this doesn't fully enable is activating Tilegarden, running new jobs, then reverting to the S3 tile source.  The tiles for jobs run with `USE_TILEGARDEN` set to true will not have been generated.

### Notes

- The ugliest part of this (in my opinion, anyway) is the special case in `AnalysisJob.update_status`.  If we were intending to keep the `tilemaker` option available forever, it would probably be worth doing the work of passing the information into the analysis container that there's not going to be a tiling job so it should end with COMPLETE rather than EXPORTED.  But as things stand now, I don't think it's worth the trouble.

## Testing Instructions

- With `PFB_USE_TILEGARDEN=true` in `common.yml` (which this sets as the default):
   - The tile URLs for your places should point to the configured TILEGARDEN_ROOT
   - If you [kick off an analysis](http://localhost:9301/#/admin/analysis-jobs/create/), the log output will show the "Can't actually run development analysis jobs on AWS. Try this:" message with the command to run locally, but won't include the "Can't actually run development tiling jobs on AWS. Try this:" message.
   - If you run the analysis command, it will get all the way to COMPLETE and show up on your site, with working tiles.
- If you change `PFB_USE_TILEGARDEN=false` in `common.yml` and restart your instance:
   - The tile URLs for your places should point to S3
   - If you [kick off an analysis](http://localhost:9301/#/admin/analysis-jobs/create/), the log output *will* include the "Can't actually run development tiling jobs on AWS. Try this:" message and tilemaker command.
   - If you run the analysis command, it will succeed and leave the job in EXPORTED status, so it won't show up on your site.  If you then run the `tilemaker` command, it will set the job to COMPLETE when it's done, at which point it should show up on your site, with tiles coming from S3.

Connects #694.
