### PR TITLE
Fix port collisions on CI

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -22,10 +22,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         docker-compose run --rm --no-deps tilegarden yarn test
 
         echo "running angularjs linter..."
-        docker-compose run --rm angularjs gulp lint
+        docker-compose run --rm --no-deps angularjs gulp lint
 
         echo "running angularjs build..."
-        docker-compose run --rm angularjs gulp build
+        docker-compose run --rm --no-deps angularjs gulp build
 
         echo "tests finished"
     fi


### PR DESCRIPTION
## Overview

Make sure that the `docker-compose run` commands that call linters make use of the `--no-deps` flag in order to avoid bringing up the Django service and causing port collisions on CI.

## Notes

In https://github.com/azavea/operations/issues/284 we had speculated that the port collision issue might be systemic to our CI config, since it affects both PFB and OAR. However, after looking at the build failures in detail I think that we were running into different issues in both PRs, both caused by separate failures to be careful about which Compose commands allocate ports and which don't. As such, neither PR makes major changes to the way we configure or run Compose on CI. 

## Testing Instructions

 * Start a CI job for this PR by selecting `Build now` on http://urbanappsci.internal.azavea.com/job/azavea/job/pfb-network-connectivity/view/change-requests/job/PR-698/
* At the same time, start a CI job for another PR (e.g. http://urbanappsci.internal.azavea.com/job/azavea/job/pfb-network-connectivity/view/change-requests/job/PR-697/) by selecting `Build now`
* Confirm that both jobs can run coterminously without raising port allocation exceptions

Closes #670, connects https://github.com/azavea/operations/issues/284.
