### PR TITLE
Match either 'true' or '1' for USE_TILEGARDEN variable

### DIFF
--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -346,8 +346,10 @@ PFB_ANALYSIS_DESTINATIONS = [
 # Length of time in seconds that S3 pre-signed urls are valid for
 PFB_ANALYSIS_PRESIGNED_URL_EXPIRES = 3600
 
-# Toggle for whether to use the dynamic tileserver or the S3 tiles
-USE_TILEGARDEN = os.getenv('PFB_USE_TILEGARDEN', 'false').lower() == 'true'
+# Toggle for whether to use the dynamic tileserver or the S3 tiles. Terraform casts to integer
+# but not always (https://www.terraform.io/docs/configuration/variables.html#booleans) and
+# in development it'll be a string.
+USE_TILEGARDEN = os.getenv('PFB_USE_TILEGARDEN', 'false').lower() in ('true', '1')
 # Root URL for tile server.
 TILEGARDEN_ROOT = os.getenv('PFB_TILEGARDEN_ROOT')
 if USE_TILEGARDEN and not TILEGARDEN_ROOT:


### PR DESCRIPTION
Turns out Terraform converts 'true' to '1', but [the docs](https://www.terraform.io/docs/configuration/variables.html#booleans) say to keep using 'true' for future compatibility.

So this makes the Django setting that reads it in accept either.

I noticed this because the deployment of #696 made staging switch back to S3 tiles.  I pushed a `test/` branch to confirm that this fixes it.
