### PR TITLE
Improve organization of claudia configs for easier deploys

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -126,14 +126,7 @@ and they will be passed in during deployment.
 
 ### 3. Deploy a new Tilegarden instance with Claudia
 
-Before deploying your instance, `touch` a file that Claudia can use to save
-deployment metadata:
-
-```
-$ touch ./src/tilegarden/claudia.json
-```
-
-Next, use the Tilegarden Node scripts in the VM to deploy a new Tilegarden instance:
+Use the Tilegarden Node scripts in the VM to deploy a new Tilegarden instance:
 
 ```
 vagrant@pfb-network-connectivity:/vagrant$ docker-compose \
@@ -150,7 +143,7 @@ file to the remote state bucket so that CI can update Tilegarden automatically:
 
 ```
 $ aws s3 cp ./src/tilegarden/.env s3://<remote-state-bucket>/tilegarden/.env
-$ aws s3 cp ./src/tilegarden/claudia.json s3://<remote-state-bucket>/tilegarden/claudia.json
+$ aws s3 cp ./src/tilegarden/claudia/claudia.json s3://<remote-state-bucket>/tilegarden/claudia.json
 ```
 
 In addition, edit the remote Terraform variables in `terraform.tfvars` for your

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,5 +27,4 @@ services:
   tilegarden:
     env_file: ./src/tilegarden/.env
     volumes:
-      # scripts/infra will download this config file before mounting the volume.
-      - ./src/tilegarden/claudia.json:/opt/pfb/tilegarden/claudia.json
+      - ./src/tilegarden/claudia:/opt/pfb/tilegarden/claudia

--- a/scripts/infra
+++ b/scripts/infra
@@ -81,7 +81,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 pushd "${DIR}/.."
 
                 aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/tilegarden/.env" "./src/tilegarden/.env"
-                aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/tilegarden/claudia.json" "./src/tilegarden/claudia.json"
+                aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/tilegarden/claudia.json" "./src/tilegarden/claudia/claudia.json"
 
                 docker-compose \
                     -f docker-compose.yml \

--- a/src/tilegarden/.gitignore
+++ b/src/tilegarden/.gitignore
@@ -1,2 +1,5 @@
 # Compiled config files
 src/config/*.xml
+
+# Claudia configs
+claudia/

--- a/src/tilegarden/package.json
+++ b/src/tilegarden/package.json
@@ -24,9 +24,9 @@
   ],
   "scripts": {
     "build-all-xml": "./scripts/build-all-xml.sh src/config src/config",
-    "deploy": "yarn compile && claudia update --no-optional-dependencies ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} ${PFB_TILEGARDEN_CACHE_BUCKET:+--set-env PFB_TILEGARDEN_CACHE_BUCKET=${PFB_TILEGARDEN_CACHE_BUCKET}}",
-    "deploy-new": "yarn compile && claudia create --no-optional-dependencies --api-module dist/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} ${PFB_TILEGARDEN_CACHE_BUCKET:+--set-env PFB_TILEGARDEN_CACHE_BUCKET=${PFB_TILEGARDEN_CACHE_BUCKET}} && yarn parse-id",
-    "destroy": "claudia destroy",
+    "deploy": "yarn compile && claudia update --config claudia/claudia.json --no-optional-dependencies ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} ${PFB_TILEGARDEN_CACHE_BUCKET:+--set-env PFB_TILEGARDEN_CACHE_BUCKET=${PFB_TILEGARDEN_CACHE_BUCKET}}",
+    "deploy-new": "yarn compile && claudia create --config claudia/claudia.json --no-optional-dependencies --api-module dist/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} ${PFB_TILEGARDEN_CACHE_BUCKET:+--set-env PFB_TILEGARDEN_CACHE_BUCKET=${PFB_TILEGARDEN_CACHE_BUCKET}} && yarn parse-id",
+    "destroy": "claudia destroy --config claudia/claudia.json",
     "dev": "nodemon -e js,mss,json,mml,mss --ignore dist/ --ignore '*.temp.mml' --exec yarn local",
     "lint": "eslint src",
     "local": "yarn build-all-xml && node --inspect=0.0.0.0:9229 -- node_modules/claudia-local-api/bin/claudia-local-api --abbrev 300 --api-module src/api | bunyan -o short",


### PR DESCRIPTION
## Overview

Instead of mounting the Claudia config file directly into the Tilegarden container during deployments, move it into its own directory and mount that directory instead. This allows Docker to create the directory if it doesn't exist yet, which lets us simplify initial deployments of new Tilegarden instances.

See:

* https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only

## Testing Instructions

### Test standing up new instance

* Shell into the VM
* Pull down the staging `.env` file from S3:

```console
$ aws s3 cp s3://staging-pfb-config-us-east-1/tilegarden/.env ./src/tilegarden/.env
```

* Edit `.env` file to change `PROJECT_NAME` to something different for testing, e.g. `pfbTilegardenTestingNewConfig`
* Create new test Tilegarden instance:

```console
vagrant@pfb-network-connectivity:/vagrant$ docker-compose \
                                             -f docker-compose.yml \
                                             -f docker-compose.test.yml \
                                             run --rm --entrypoint yarn \
                                             tilegarden deploy-new
```

* Confirm that Claudia created a new config file in `src/tilegarden/claudia/claudia.json`
* Destroy the new test instance:

```console
vagrant@pfb-network-connectivity:/vagrant$ docker-compose \
                                             -f docker-compose.yml \
                                             -f docker-compose.test.yml \
                                             run --rm --entrypoint yarn \
                                             tilegarden destroy
```

### Test that updates continue to work

* Edit `scripts/infra` to comment out line 78, so that you don't update Terraform-managed infrastructure:

```bash
# docker-compose run --rm terraform apply "${PFB_SETTINGS_BUCKET}.tfplan"
```

* Run a fresh `apply` cycle to push an update to the staging Tilegarden instance:

```console
vagrant@pfb-network-connectivity:/vagrant$ export GIT_COMMIT=latest
vagrant@pfb-network-connectivity:/vagrant$ export PFB_SETTINGS_BUCKET=staging-pfb-config-us-east-1
vagrant@pfb-network-connectivity:/vagrant$ ./scripts/infra apply
```

* Make sure that `apply` runs cleanly

Closes #660.
