### PR TITLE
Zoom to all places on landing page map and remove 'Nationwide'

### DIFF
--- a/src/angularjs/src/app/home/neighborhood-map.directive.js
+++ b/src/angularjs/src/app/home/neighborhood-map.directive.js
@@ -29,6 +29,7 @@
                     onEachFeature: onEachFeature
                 });
                 map.addLayer(ctl.neighborhoodLayer);
+                map.fitBounds(ctl.neighborhoodLayer.getBounds());
             });
 
             function onEachFeature(feature, layer) {

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -6,7 +6,7 @@
     <div class="card pfb-stripe">
         <div class="card-details">
             <div class="overview-total">{{ ctl.count || "--" }}</div>
-            <div class="overview-total-label">Places Nationwide</div>
+            <div class="overview-total-label">Places</div>
             <a ui-sref="places.list" class="btn btn-primary">Find your Place
                 <i class="icon-arrow-right"></i>
             </a>


### PR DESCRIPTION
## Overview

To support non-US cities, makes the map on the home page zoom to include all features and removes the word "Nationwide" from the caption.

Turns out we already have places in AK, HI, and PR, which makes it zoom pretty wide even without international cities.

### Demo

![image](https://user-images.githubusercontent.com/6598836/52569624-a0307d00-2ddf-11e9-9d11-873e819a5f3c.png)


### Notes

- As you can see in the screenshot above, it likes to cut off the northernmost marker. I tried adding padding to prevent that, but it zoomed out too far.  I didn't try to tune the padding or pursue it further because it seems like not that big a deal to me.
- I tried briefly to find any other spots where the US-only assumption is encoded in a user-visible way, but didn't come up with any.

## Testing Instructions

Load the home page.  The map should zoom to fit all the neighborhoods you have defined in your database.

Resolves #704
