### PR TITLE
Enable Lambda warming on Tilegarden function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+- Add Lambda warming for Tilegarden
+
 ## [0.9.0] - 2019-02-14
 
 #### Added

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -136,7 +136,27 @@ vagrant@pfb-network-connectivity:/vagrant$ docker-compose \
                                              tilegarden deploy-new
 ```
 
-### 4. Update remote state for Claudia and Terraform
+### 4. Manually add permissions
+
+The Tilegarden Lambda function needs certain permissions to work. Some are set automatically by
+Claudia, but the ones related to caching and warming aren't (see [issue #710](https://github.com/azavea/pfb-network-connectivity/issues/710)).
+
+After both Terraform and the Tilegarden deploy have run (the former to create the cache bucket,
+the latter to create the executor role), find the IAM role corresponding to your Tilegarden deployment
+(it will be the `PROJECT_NAME` you sent in the `.env` file plus `-executor`) and add two permissions:
+- An S3 policy to allow writing to the cache bucket (currently it just blindly writes, so read
+permissions aren't required, though as long as the policy is restricted to the bucket there's not
+much harm in it granting extra permissions.)
+- A Lambda policy to grant `InvokeFunction`, so that the Lambda function can trigger itself to
+generate concurrent warming invocations.
+
+### 5. Manually add a scheduled warming event
+
+In the [CloudWatch Rules console](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#rules:),
+add a scheduled event to generate warming invocations to prevent users from being subjected to cold starts.
+See [issue #714](https://github.com/azavea/pfb-network-connectivity/issues/714).
+
+### 6. Update remote state for Claudia and Terraform
 
 Once the deployment has completed, upload your `.env` file and Claudia metadata
 file to the remote state bucket so that CI can update Tilegarden automatically:

--- a/src/tilegarden/package.json
+++ b/src/tilegarden/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "claudia-api-builder": "^4.1.0",
+    "lambda-warmer": "^1.1.0",
     "mapnik": "^3.7.2",
     "sql-escape-string": "^1.1.0",
     "winston": "^3.2.1",

--- a/src/tilegarden/yarn.lock
+++ b/src/tilegarden/yarn.lock
@@ -2827,6 +2827,10 @@ kuler@1.0.x:
   dependencies:
     colornames "^1.1.1"
 
+lambda-warmer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lambda-warmer/-/lambda-warmer-1.1.0.tgz#95bdc4aeb8def0091da36e49b80bab56b6b64653"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"


### PR DESCRIPTION
## Overview

Since the Tilegarden Lambda functions are inside a VPC (which they need to be, since they talk to the database), [their cold start times are bad](https://medium.freecodecamp.org/lambda-vpc-cold-starts-a-latency-killer-5408323278dd).  This adds the [`lambda-warmer`](https://github.com/jeremydaly/lambda-warmer) package and configures the Lambda function's entrypoint to handle the type of invocations that trigger it.

I initially did something much more complicated (see [branch](https://github.com/azavea/pfb-network-connectivity/tree/feature/kjh/lambda-warming-endpoint)), involving a warming endpoint that could be triggered from outside and would in turn trigger a `lambda-warmer` event.  This was based on the fact that 
- to be effective, we'll need to have a decent number of workers warmed up and 
- the site doesn't get continuous usage, so keeping the Lambdas warm 24/7 would waste a lot of invocations.

I changed to this simpler strategy when I realized 
- the triggering endpoint would itself incur a cold start delay, so the time from sending the triggering request to the tiler being ready would be double the cold start time, which would be much too long
- keeping a small fleet of Lambda functions warm is really not expensive.  Using [this calculator](https://dashbird.io/lambda-cost-calculator/), with the 512MB memory size and assuming triggering every 15 minutes and the cumulative execution time of all the warming invocations per event adding up to 10 seconds (which I think is reasonable to conservative), it would cost 25 cents per month.

This adds a section to the deployment README about setting up the scheduled warming event.  I'm not sure how to do it in Terraform, and though it doesn't look super complicated, it would create another circular dependency between the Terraform config and the resources produced by the Tilegarden deployment script.  And resolving that seems somewhat complicated.  So I'm adding instructions to do it manually and [an issue](https://github.com/azavea/pfb-network-connectivity/issues/714) to hopefully automate it later.

It also adds a section to the deployment README about manually setting permissions on the executor role, which is issue #710.

### Demo

![image](https://user-images.githubusercontent.com/6598836/52815959-0cc0ab80-306e-11e9-9288-4a0c071b1260.png)

### Notes

A note on warming interval: There are no guarantees or even stated norms for how long a Lambda instance will sit idle before getting destroyed.  People have [done experiments](https://read.acloud.guru/how-long-does-aws-lambda-keep-your-idle-functions-around-before-a-cold-start-bf715d3b810) and come up with "usually about 45 minutes, but sometimes longer and sometimes shorter".  Using a timeout of 15 minutes seems reasonable to me--conservative but not excessively so.

## Testing Instructions

I don't think this can really be tested locally.  At the moment, it has been pushed to staging via a test branch and is running there.

Resolves #701
