### PR TITLE
Improve changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,4 +22,8 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include test case, and expected output
 
 
-Connects #XXX
+## Checklist
+
+- [ ] Add entry to CHANGELOG.md
+
+Resolves #XXX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.9.0] - 2019-02-14
 
+#### Added
 - Enable local analysis uploads
-- Analysis: state/city speed limit defaults
+- Add support for non-US neighborhoods
+- Dynamic tile server
+
+#### Changed
+- Analysis: add support for state/city speed limit defaults
 - Analysis: improve handling of pedestrian paths and one-way street segments
-- Activate dynamic tile server
 - Update census block tile styling
 
 ## [0.8.1] - 2019-01-22
@@ -28,21 +32,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.7.0] - 2018-06-14
 
-### Added
-
+#### Added
 - Async Batch job creation via Admin UI using Django Q running as an ECS task
 - S3 caching for state OSM downloads from Geofabrik to reduce chance of throttling
 - Google Analytics for basic site hit tracking
 
-### Changed
-
+#### Changed
 - Upgrade Django to 1.11.13 LTS
 - Upgrade application third-party Django dependencies
 - Improve robustness of Neighborhood boundary simplification algorithm by checking simplified
   geom area against original geom area
 
-### Fixed
-
+#### Fixed
 - Improper handling of AWS_REGION variable in development environments
 - Invalid string formatting of single-digit UTM zones
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!--Note: to keep the headings readable, the version number links are defined at the bottom.-->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -5,9 +7,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Upcoming release]
 
-## 0.9.0 - 2019-02-14
+## [0.9.0] - 2019-02-14
 
 - Enable local analysis uploads
 - Analysis: state/city speed limit defaults
@@ -15,11 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Activate dynamic tile server
 - Update census block tile styling
 
-## 0.8.1 - 2019-01-22
+## [0.8.1] - 2019-01-22
 
 - Only import geometries for each neighborhood's latest analysis job
 
-## 0.8.0 - 2019-01-16
+## [0.8.0] - 2019-01-16
 
 - Preliminary back-end changes to enable dynamic tile server
 - Preliminary back-end changes to enable local analysis uploads
@@ -43,3 +45,47 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Improper handling of AWS_REGION variable in development environments
 - Invalid string formatting of single-digit UTM zones
+
+## [0.6.1] - 2017-08-08
+## [0.6.0] - 2017-07-28
+## [0.5.1] - 2017-07-24
+## [0.5.0] - 2017-07-18
+## [0.4.3] - 2017-06-16
+## [0.4.2] - 2017-06-02
+## [0.4.1] - 2017-05-25
+## [0.4.0] - 2017-05-23
+## [0.3.0] - 2017-05-12
+## [0.2.2] - 2017-05-10
+## [0.2.1] - 2017-05-10
+## [0.2.0] - 2017-05-08
+## [0.1.5] - 2017-04-28
+## [0.1.4] - 2017-04-28
+## [0.1.3] - 2017-04-27
+## [0.1.2] - 2017-04-26
+## [0.1.1] - 2017-04-21
+## [0.1.0] - 2017-04-21
+
+
+[Upcoming release]: https://github.com/azavea/pfb-network-connectivity/compare/0.9.0...HEAD
+[0.9.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.8.1...0.9.0
+[0.8.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.8.0...0.8.1
+[0.8.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.7.0...0.8.0
+[0.7.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.6.1...0.7.0
+[0.6.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.6.0...0.6.1
+[0.6.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.5.1...0.6.0
+[0.5.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.5.0...0.5.1
+[0.5.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.4.3...0.5.0
+[0.4.3]: https://github.com/azavea/pfb-network-connectivity/compare/0.4.2...0.4.3
+[0.4.2]: https://github.com/azavea/pfb-network-connectivity/compare/0.4.1...0.4.2
+[0.4.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.4.0...0.4.1
+[0.4.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.3.0...0.4.0
+[0.3.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.2.2...0.3.0
+[0.2.2]: https://github.com/azavea/pfb-network-connectivity/compare/0.2.1...0.2.2
+[0.2.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.2.0...0.2.1
+[0.2.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.1.5...0.2.0
+[0.1.5]: https://github.com/azavea/pfb-network-connectivity/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/azavea/pfb-network-connectivity/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/azavea/pfb-network-connectivity/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/azavea/pfb-network-connectivity/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.1.0...0.1.1
+[0.1.0]: https://github.com/azavea/pfb-network-connectivity/releases/tag/0.1.0


### PR DESCRIPTION
## Overview

Fills out and spruces up the CHANGELOG:
- Adds comparison links
- Adds headings for all the past release tags (with dates and comparison links but not any details about what they included)
- Tweaks the 0.9.0 entry to use subsections like the 0.7.0 one (and like the Keep A Changelog pattern)
- Adds a (one-item) checklist to the PR template to remind us to update the changelog

I also changed `Connects` to `Resolves` in the PR template to avoid "I merged the PR, why didn't the related issue get closed?" situations.

### Demo

![image](https://user-images.githubusercontent.com/6598836/52865115-ce78ca00-3109-11e9-9ae9-80a5e3eeb476.png)

## Testing Instructions

- Take a look: https://github.com/azavea/pfb-network-connectivity/blob/feature/kjh/improve-changelog/CHANGELOG.md
- Follow a link or two and confirm they point at the right thing

Resolves #657 
