### PR TITLE
Define Tilegarden executor role in Terraform config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Changed
+- Use Terraform to create and configure the Tilegarden executor role
+
 ## [0.9.1] - 2019-02-20
 
 #### Added

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -114,11 +114,14 @@ the Lambda function. Copy over the example file to create a new one:
 $ cp ./src/tilegarden/.env.example ./src/tilegarden/.env
 ```
 
-The three required variables are `AWS_PROFILE`, `PROJECT_NAME`, and
-`LAMBDA_REGION`. Other optional variables can be uncommented and edited to
-reflect your configuration. If you need Tilegarden to access a database, for
-example, you'll likely want to set `LAMBDA_SUBNETS` and `LAMBDA_SECURITY_GROUPS` to point
-to the relevant resources in your VPC.
+Edit the new file to fill in or adjust variables.  The required variables are:
+- `AWS_PROFILE`: the name of the AWS credentials profile you created above, e.g. "pfb"
+- `PROJECT_NAME`: a name to identify this deployment, which should include the environment name
+- `LAMBDA_REGION`
+- `LAMBDA_ROLE`: the role the Lambda function should run under. Use the one created by Terraform, e.g. "pfbStagingTilegardenExecutor"
+
+Other optional variables can be uncommented and edited to reflect your configuration. If you
+need Tilegarden to access a database, for example, you'll likely want to set `LAMBDA_SUBNETS` and `LAMBDA_SECURITY_GROUPS` to point to the relevant resources in your VPC.
 
 If you have any additional environment variables (like database connection
 strings) that you need access to in your function, add them to `./src/tilegarden/.env`
@@ -136,27 +139,13 @@ vagrant@pfb-network-connectivity:/vagrant$ docker-compose \
                                              tilegarden deploy-new
 ```
 
-### 4. Manually add permissions
-
-The Tilegarden Lambda function needs certain permissions to work. Some are set automatically by
-Claudia, but the ones related to caching and warming aren't (see [issue #710](https://github.com/azavea/pfb-network-connectivity/issues/710)).
-
-After both Terraform and the Tilegarden deploy have run (the former to create the cache bucket,
-the latter to create the executor role), find the IAM role corresponding to your Tilegarden deployment
-(it will be the `PROJECT_NAME` you sent in the `.env` file plus `-executor`) and add two permissions:
-- An S3 policy to allow writing to the cache bucket (currently it just blindly writes, so read
-permissions aren't required, though as long as the policy is restricted to the bucket there's not
-much harm in it granting extra permissions.)
-- A Lambda policy to grant `InvokeFunction`, so that the Lambda function can trigger itself to
-generate concurrent warming invocations.
-
-### 5. Manually add a scheduled warming event
+### 4. Manually add a scheduled warming event
 
 In the [CloudWatch Rules console](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#rules:),
 add a scheduled event to generate warming invocations to prevent users from being subjected to cold starts.
 See [issue #714](https://github.com/azavea/pfb-network-connectivity/issues/714).
 
-### 6. Update remote state for Claudia and Terraform
+### 5. Update remote state for Claudia and Terraform
 
 Once the deployment has completed, upload your `.env` file and Claudia metadata
 file to the remote state bucket so that CI can update Tilegarden automatically:

--- a/src/tilegarden/.env.example
+++ b/src/tilegarden/.env.example
@@ -9,15 +9,16 @@ PROJECT_NAME=
 ## REQUIRED ##
 LAMBDA_REGION=
 
+# name of role associated with this lambda function (created by Terraform)
+LAMBDA_ROLE=role-name
+# Amount of time in seconds your lambdas will run before timing out.
+# Default is 3, so some override is necessary.
+LAMBDA_TIMEOUT=
+
 ## OPTIONAL ##
-# name of role associated with this lambda function
-#LAMBDA_ROLE=role-name
-# Amount of time in seconds your lambdas will wait before timing out
-# Increase this value if your tile requests are timing out
-LAMBDA_TIMEOUT=60
 # Memory in MB allocated to your lambda functions
-# Increase this value if you plan on rendering vector tiles
-#LAMBDA_MEMORY=128
+# More memory also brings more CPU and bandwidth. Default if not specified is 128.
+#LAMBDA_MEMORY=512
 # The following VPC (Virtual Private Cloud) settings should be used if you
 # need your lambdas to be able to connect to other AWS resources,
 # e.g. an RDS instance, and should match the subnets/security groups used


### PR DESCRIPTION
## Overview

The Tilegarden Lambda function needs some permissions, specifically
- write logs
- attach to a VPC
- write to the S3 cache
- invoke itself for warming

If you don't provide a role to Claudia.js, it makes one that has the first two, but since the other two are for custom Tilegarden functionality, they need to be added.  The most straightforward way to do that is to define the whole role in Terraform and just hand it to Claudia.js in the .env file.

So this adds the Terraform code to do that, moves the `LAMBDA_ROLE` variable out of the "Optional" section of the .env.example file, and removes the section from the deployment instructions saying you have to do it manually.

### Demo

I ran terraform `plan` and `apply` manually for staging, so here's a screenshot of the created role:
![image](https://user-images.githubusercontent.com/6598836/53505592-23a9c980-3a82-11e9-8578-4fb797ab20fa.png)

### Notes

- I put a few extra permissions on the "write to cache" role because I'm imagining future worlds in which the function does some amount of cache evaluation/invalidation.  I don't think there's any harm in having them there, though.  It's pretty restricted (only a few permissions and only on the cache bucket).
- It seems like Claudia only sets the executor role on `create` (i.e. our `deploy-new` command), not on update.  So setting the role in the .env file and deploying didn't cause it to change.  So I changed it manually.  I didn't try it here, but from other experience I believe it would do the right thing (assign the specified role) for `deploy-new`.

## Testing Instructions

I already deployed this manually to staging.  It's probably not worth creating a whole new stack to test it from scratch, though you could delete the role and confirm that it recreates it properly.

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #710 
