### PR TITLE
Add documentation section and infra commands for migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use Terraform to create and configure the Tilegarden executor role
 - Show country name in neighborhood labe for non-US places
 - Treat US territories as states, not countries
+- Add management-only deployment command for applying migrations before deployment
 
 #### Removed
 - Removed 'tilemaker' container and all code and config related to static tiling

--- a/scripts/infra
+++ b/scripts/infra
@@ -17,6 +17,26 @@ Execute Terraform subcommands with remote state management.
 "
 }
 
+function update_batch_definitions() {
+    echo "Updating AWS Batch job definitions"
+    pushd "../aws-batch"
+    # TODO: Only trigger this if the pfb-analysis container has changed, otherwise skip
+    #       and reuse old version
+    # TODO: This is a bit awkward. If we `plan` but never `apply`, we'll have created
+    #       an orphaned job definition that never gets used.
+    docker-compose build
+
+    ENVIRONMENT="${ENVIRONMENT:-staging}"
+    BATCH_ANALYSIS_JOB_NAME_REVISION=$(docker-compose run --rm \
+        update-job-defs \
+        "${ENVIRONMENT}-pfb-analysis-run-job.json" \
+        "${PFB_AWS_ECR_ENDPOINT}/pfb-analysis:${GIT_COMMIT}")
+
+    echo "Analysis Task Name:Revision -- ${BATCH_ANALYSIS_JOB_NAME_REVISION}"
+    popd
+}
+
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
@@ -35,22 +55,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         case "${1}" in
             plan)
-                echo "Updating AWS Batch job definitions"
-                pushd "../aws-batch"
-                # TODO: Only trigger this if the pfb-analysis container has changed, otherwise skip
-                #       and reuse old version
-                # TODO: This is a bit awkward. If we `plan` but never `apply`, we'll have created
-                #       an orphaned job definition that never gets used.
-                docker-compose build
-
-                ENVIRONMENT="${ENVIRONMENT:-staging}"
-                BATCH_ANALYSIS_JOB_NAME_REVISION=$(docker-compose run --rm \
-                    update-job-defs \
-                    "${ENVIRONMENT}-pfb-analysis-run-job.json" \
-                    "${PFB_AWS_ECR_ENDPOINT}/pfb-analysis:${GIT_COMMIT}")
-
-                echo "Analysis Task Name:Revision -- ${BATCH_ANALYSIS_JOB_NAME_REVISION}"
-                popd
+                update_batch_definitions
 
                 docker-compose run --rm \
                     --entrypoint rm \
@@ -81,6 +86,29 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                     -f docker-compose.yml \
                     -f docker-compose.test.yml \
                     run --rm --entrypoint yarn tilegarden deploy
+                ;;
+            plan-mgmt)
+                update_batch_definitions
+
+                docker-compose run --rm \
+                    --entrypoint rm \
+                    terraform -rf .terraform/ terraform.tfstate*
+
+                docker-compose run --rm \
+                    terraform init \
+                    -backend-config="bucket=${PFB_SETTINGS_BUCKET}" \
+                    -backend-config="key=terraform/state"
+
+                docker-compose run --rm \
+                    terraform plan \
+                          -var-file="${PFB_SETTINGS_BUCKET}.tfvars" \
+                          -var="git_commit=\"${GIT_COMMIT}\"" \
+                          -var="batch_analysis_job_definition_name_revision=${BATCH_ANALYSIS_JOB_NAME_REVISION}" \
+                          -target=aws_ecs_task_definition.pfb_app_management \
+                          -out="${PFB_SETTINGS_BUCKET}-mgmt.tfplan"
+                ;;
+            apply-mgmt)
+                docker-compose run --rm terraform apply "${PFB_SETTINGS_BUCKET}-mgmt.tfplan"
                 ;;
             *)
                 echo "ERROR: I don't have support for that Terraform subcommand!"


### PR DESCRIPTION
## Overview

Adds a section to the deployment documentation about how to safely apply migrations.  Since in some cases migrations need to be applied before the API service is updated, also adds a pair of commands to `infra` to deploy only the management task, so that migrations can be run before the matching API service is updated and starts handling requests that might rely on the schema being updated.

### Demo

```
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Your plan was also saved to the path below. Call the "apply" subcommand
with this plan file and Terraform will exactly execute this execution
plan.

Path: staging-pfb-config-us-east-1-mgmt.tfplan

-/+ aws_ecs_task_definition.pfb_app_management
    arn:                   "arn:aws:ecs:us-east-1:950872791630:task-definition/StagingManagement:401" => "<computed>"
    container_definitions: "62deef93ae6e6aa7824fff26374548bddabe0dae" => "d3eda56040ec17d18a4a7b6c778e48c1044a7770" (forces new resource)
    family:                "StagingManagement" => "StagingManagement"
    network_mode:          "" => "<computed>"
    revision:              "401" => "<computed>"

Plan: 1 to add, 0 to change, 1 to destroy.
vagrant@pfb-network-connectivity:/vagrant$ ./scripts/infra apply-mgmt

Attempting to deploy application version [a759192]...
-----------------------------------------------------
download: s3://staging-pfb-config-us-east-1/terraform/terraform.tfvars to ./staging-pfb-config-us-east-1.tfvars
aws_ecs_task_definition.pfb_app_management: Destroying... (ID: StagingManagement)
aws_ecs_task_definition.pfb_app_management: Destruction complete
aws_ecs_task_definition.pfb_app_management: Creating...
  arn:                   "" => "<computed>"
  container_definitions: "" => "d3eda56040ec17d18a4a7b6c778e48c1044a7770"
  family:                "" => "StagingManagement"
  network_mode:          "" => "<computed>"
  revision:              "" => "<computed>"
aws_ecs_task_definition.pfb_app_management: Creation complete (ID: StagingManagement)
Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

### Notes

The Management task requires the `batch_analysis_job_definition_name_revision` variable, which means `plan-mgmt` still has to run the `update-job-defs` container to make new job revisions.  I pulled that section out into a function so it could be run by both `plan` commands.  Per the TODO in that code, it doesn't have a way of knowing whether the analysis container has actually been changed, so it just makes a new revision every time.  This doesn't do any harm, but it does mean that doing a full `plan/apply` after doing `plan-mgmt/apply-mgmt` will update the batch definitions again, which will mean that the Management task definition will get updated again.

## Testing Instructions

- Follow the deployment instructions to set environment variables (use `ENVIRONMENT=staging`) and build containers
- Run `./scripts/infra plan-mgmt`.  It should create a plan to update only one resource, `aws_ecs_task_definition.pfb_app_management`
- Run `/.scripts/infra apply-mgmt`.  It should apply the plan and update the task definition.

Actually runing a management task, since there's not enough extra memory on the staging EC2 instance to add a task, would require either adding an EC2 instance to the cluster or temporarily killing the HTTPS service's task.

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #664.
