### PR TITLE
Add Terraform var for Tilegarden function name

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -131,7 +131,7 @@ $ cp ./src/tilegarden/.env.example ./src/tilegarden/.env
 
 Edit the new file to fill in or adjust variables.  The required variables are:
 - `AWS_PROFILE`: the name of the AWS credentials profile you created above, e.g. "pfb"
-- `PROJECT_NAME`: a name to identify this deployment, which should include the environment name
+- `LAMBDA_FUNCTION_NAME`: a name to identify this deployment, which should include the environment name
 - `LAMBDA_REGION`
 - `LAMBDA_ROLE`: the role the Lambda function should run under. Use the one created by Terraform, e.g. "pfbStagingTilegardenExecutor"
 

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -212,7 +212,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 data "aws_iam_policy_document" "lambda_invoke" {
   statement {
     effect = "Allow"
-    resources = ["*"]
+    resources = ["arn:aws:lambda:*:*:function:${var.tilegarden_function_name}"]
     actions = [
       "lambda:InvokeFunction",
     ]
@@ -263,7 +263,7 @@ data "aws_iam_policy_document" "s3_write_tile_cache" {
 }
 
 resource "aws_iam_role" "tilegarden_executor" {
-  name               = "pfb${var.environment}TilegardenExecutor"
+  name               = "${var.tilegarden_function_name}Executor"
   assume_role_policy = "${data.aws_iam_policy_document.lambda_assume_role.json}"
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -162,3 +162,6 @@ variable "tilegarden_api_gateway_domain_name" {}
 variable "cloudfront_price_class" {
   default = "PriceClass_100"
 }
+
+# Should be environment-specific and match the value in the Tilegarden .env file
+variable "tilegarden_function_name" {}

--- a/src/tilegarden/.env.example
+++ b/src/tilegarden/.env.example
@@ -2,15 +2,13 @@
 # If you want to set them specifically, change them to assignments
 AWS_PROFILE
 
-# Name of the lambda function
-PROJECT_NAME=
+# Name of the lambda function. Should match the `tilegarden_function_name` Terraform variable.
+LAMBDA_FUNCTION_NAME=
 
 # Function config information
 ## REQUIRED ##
 LAMBDA_REGION=
 
-# name of role associated with this lambda function (created by Terraform)
-LAMBDA_ROLE=role-name
 # Amount of time in seconds your lambdas will run before timing out.
 # Default is 3, so some override is necessary.
 LAMBDA_TIMEOUT=

--- a/src/tilegarden/scripts/deploy-new
+++ b/src/tilegarden/scripts/deploy-new
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 yarn claudia create --config claudia/claudia.json --no-optional-dependencies \
-    --api-module dist/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} \
-    ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} \
+    --api-module dist/api \
+    --name ${LAMBDA_FUNCTION_NAME} \
+    --region ${LAMBDA_REGION} \
+    --role "${LAMBDA_FUNCTION_NAME}Executor" \
     ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} \
     ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} \
     ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} \


### PR DESCRIPTION
## Overview

Adds a tfvar for the name of the Tilegarden Lambda function and uses it to restrict the Lambda execution permission on the TilegardenExecutor role.

See [discussion on PR #719](https://github.com/azavea/pfb-network-connectivity/pull/719#discussion_r260855692)

Also
- Uses the tfvar to set the name of the executor role.
- Renames the variable on the Tilegarden side to `LAMBDA_FUNCTION_NAME`, since that's what it's used for.
- Removes the `LAMBDA_ROLE` variable from the Tilegarden .env example and uses the `LAMBDA_FUNCTION_NAME` value with 'Executor' appended to match what Terraform does when creating it.

What this does *not* do is resolve #714 by incorporating the Lambda-warming scheduled task into Terraform.  It turns out giving CloudWatch the permission to invoke a Lambda function is done by [defining a policy on the Lambda function](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/resource-based-policies-cwe.html#lambda-permissions) and can't be done via IAM role or any sort of resource wildcard.

So trying to define the scheduled warming event before the actual Lambda function exists isn't possible, which means putting it in the Terraform config would add a bunch more complexity to the circular dependency between the Terraform and Claudia deployment steps.

Using a variable to set the function name is useful, though, and since I did that first on the way to configuring the CloudWatch rule and discovering this problem, we might as well keep it.

### Notes

[Here's a branch](https://github.com/azavea/pfb-network-connectivity/tree/feature/kjh/lambda-warming-in-terraform) with [the CloudWatch rule/event config](https://github.com/azavea/pfb-network-connectivity/blob/feature/kjh/lambda-warming-in-terraform/deployment/terraform/events.tf).

## Testing Instructions

If run for Staging, starting with current `develop` deployed:
- With the `tilegarden_function_name` variable set to the existing function name (pfbTilegardenStaging) `infra plan` (after the usual setup per the deployment instructions) should show only the usual service task updates (caused by the batch job revision changing) plus a change to the `InvokeLambda` permission, changing it to a more restrictive `resources` clause.
- With the variable set to something else, `infra plan` should show that plus a bunch of changes to the Executor role to remove the one with the old name and create one with the new name.

## Checklist

~- [ ] Add entry to CHANGELOG.md~


