### PR TITLE
Add subdivisions to 'countries' list, and country config

### DIFF
--- a/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.controller.js
+++ b/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.controller.js
@@ -14,7 +14,7 @@
                                           Country, State) {
         var ctl = this;
 
-        var DEFAULT_COUNTRY = {abbr: 'US', name: 'United States'};
+        var DEFAULT_COUNTRY = {alpha_2: 'US', name: 'United States'};
 
         function initialize() {
             ctl.country = DEFAULT_COUNTRY;
@@ -46,7 +46,7 @@
                     boundary_file: ctl.file,
                     state_abbrev: ctl.state && ctl.isDefaultCountry() ? ctl.state.abbr : '',
                     city_fips: ctl.city_fips && ctl.isDefaultCountry() ? ctl.city_fips : '',
-                    country: ctl.country.abbr || DEFAULT_COUNTRY,
+                    country: ctl.country.alpha_2 || DEFAULT_COUNTRY.alpha_2,
                     visibility: ctl.visibility,
                     label: ctl.label
                 }
@@ -78,7 +78,7 @@
         };
 
         ctl.isDefaultCountry = function() {
-            return ctl.country && ctl.country.abbr === 'US';
+            return ctl.country && ctl.country.alpha_2 === 'US';
         }
     }
     angular

--- a/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
+++ b/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
@@ -39,7 +39,7 @@
           <label for="role">Country</label>
           <select ng-model="neighborhoodCreate.country"
                   ng-options="country as country.name for country in neighborhoodCreate.countries
-                  track by country.abbr"
+                  track by country.alpha_2"
                   class="form-control" id="role" type="text" required>
           </select>
         </div>

--- a/src/django/pfb_analysis/countries.py
+++ b/src/django/pfb_analysis/countries.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+import pycountry
+
+
+def get_country_config(alpha_2):
+    return settings.COUNTRY_CONFIG.get(alpha_2, settings.COUNTRY_CONFIG['default'])
+
+
+def use_subdivisions(alpha_2):
+    return settings.COUNTRY_CONFIG.get(alpha_2, settings.COUNTRY_CONFIG['default'])['subdivisions']
+
+
+def subdivisions_for_country(alpha_2):
+    """ Subdivisions for the given country, if we want to track them
+
+    Returns a list of subdivisions, as {name, code, type}, for the given country, but
+    only if the country config in settings says to track subdivisions for the country. Otherwise
+    returns None.
+    """
+    if use_subdivisions(alpha_2):
+        return sorted(
+            # Note: pycountry's subdivision codes all start with the alpha_2 country code and
+            # a hyphen. Since we're attaching them to the country and don't expect to be
+            # mingling subdivisions from different countries, this strips off the prefix and
+            # keeps only the actual subdivision code.
+            [{'name': s.name, 'code': s.code[3:], 'type': s.type} for s in
+             pycountry.subdivisions.get(country_code=alpha_2)],
+            key=lambda s: s['name']
+        )
+    return None
+
+
+def build_country_list():
+    """ Build a list of countries, without US territories and with subdivisions if desired
+
+    Builds a list of {alpha_2, name, subdivisions} dictionaries, where 'subdivisions' is
+    a dictionary of {code, name, type} subdivisions, but is only present if the country
+    config in settings calls for tracking subdivisions for the country.
+
+    US territories are present in both the countries and subdivisions lists in pycountry,
+    so we need to get a list of them and filter them out of the countries list.
+    """
+    us_territories = [t['code'] for t in subdivisions_for_country('US')
+                      if t['type'] == 'Outlying area']
+    countries = []
+    for country in pycountry.countries:
+        if country.alpha_2 in us_territories:
+            continue
+        country_dict = {'alpha_2': country.alpha_2, 'name': country.name}
+        subdivisions = subdivisions_for_country(country.alpha_2)
+        if subdivisions is not None:
+            country_dict['subdivisions'] = subdivisions
+        countries.append(country_dict)
+    countries.sort(key=lambda c: c['name'])
+    return countries

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -334,3 +334,19 @@ PFB_ANALYSIS_PRESIGNED_URL_EXPIRES = 3600
 TILEGARDEN_ROOT = os.getenv('PFB_TILEGARDEN_ROOT')
 if not TILEGARDEN_ROOT:
     raise ImproperlyConfigured('env.PFB_TILEGARDEN_ROOT is required')
+
+# Configuration object for whether to collect state/province and how to display labels by country
+COUNTRY_CONFIG = {
+    'US': {
+        'subdivisions': True,
+        'label_template': "{name}, {subdivision_code}, {country_alpha_2}",
+    },
+    'CA': {
+        'subdivisions': True,
+        'label_template': "{name}, {subdivision_code}, {country_alpha_2}",
+    },
+    'default': {
+        'subdivisions': False,
+        'label_template': "{name}, {country_alpha_2}",
+    }
+}

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -15,6 +15,7 @@ django-storages==1.6.5
 django-watchman==0.15.0
 djangorestframework==3.7.7
 fiona==1.7.11
+pycountry==18.12.8
 pyuca==1.2
 requests==2.18.4
 us==1.0.0


### PR DESCRIPTION
## Overview

Main changes:
- Adds a config dictionary in settings to record what countries we want to track subdivisions for.
- Adds the `pycountry` package, which provides subdivisions
- Uses the `pycountry` and the config to add subdivisions to the list returned by the `countries` endpoint, only for the countries whitelisted in the config.

Incidental changes:
- Renames the country abbreviation field from `abbr` to `alpha_2`. That's what it's called in pycountry. Not that we have to be bound by that, but I like it better--more explicit.

This leaves the `state` endpoint alone. I think it should go away, but that seems to fall under issue #732.

Though it adds `pycountry`, this doesn't remove `django-countries` or `us`. It does reduce the usage of `us`, so I think we should be able to remove that by the time this is all done.  Whether `django-countries` can/should go away will depend on whether we want to keep using `CountryField`.

### Demo

![image](https://user-images.githubusercontent.com/6598836/55574859-727afc80-56db-11e9-9a3c-ee4e00545b50.png)

## Testing Instructions

- Go to http://localhost:9202/api/countries/.  It should have states for the US and provinces for Canada.
- The "Upload Neighborhood" form should work as before.

## Checklist

~- [ ] Add entry to CHANGELOG.md~
This could go in the CHANGELOG, but I don't think it's necessarily worth mentioning separately from the more visible things that will be built on it (e.g. #732, #733, and #734).

Resolves #731
