### PR TITLE
Sort places by name, remove sorting by state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 #### Changed
 - Updated containers based on Debian Jessie to Stretch
 - Support entering state/province for non-US neighborhoods
+- Default to sorting places list by name and remove order-by-state option
 
 ## [0.9.2] - 2019-03-11
 

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -111,10 +111,10 @@
         <section class="paginate">
             <button class="btn btn-default paginate-previous"
                 ng-click="placeList.getPrev()"
-                ng-disabled="!placeList.hasPrev">Previous</button>
+                ng-disabled="!placeList.getPrev">Previous</button>
             <button class="btn btn-default paginate-previous"
                 ng-click="placeList.getNext()"
-                ng-disabled="!placeList.hasNext">Next</button>
+                ng-disabled="!placeList.getNext">Next</button>
         </section>
         <!-- Pagintation -->
     </div>

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -61,19 +61,14 @@
             DEFAULT: 'default',
             COMPARE: 'compare'
         };
-        var nextParams = {};
-        var prevParams = {};
 
         initialize();
 
         function initialize() {
             ctl.isAdminUser = AuthService.isAdminUser();
 
-            ctl.hasNext = false;
-            ctl.getNext = getNext;
-
-            ctl.hasPrev = false;
-            ctl.getPrev = getPrev;
+            ctl.getNext = null;
+            ctl.getPrev = null;
             ctl.places = [];
             ctl.searchText = '';
             ctl.mapPlaces = {};
@@ -215,21 +210,8 @@
                 ctl.sections = _.keys(groupedPlaces).sort();
                 ctl.places = groupedPlaces;
 
-                if (data.next) {
-                    ctl.hasNext = true;
-                    nextParams = Pagination.getLinkParams(data.next);
-                } else {
-                    ctl.hasNext = false;
-                    nextParams = {};
-                }
-
-                if (data.previous) {
-                    ctl.hasPrev = true;
-                    prevParams = Pagination.getLinkParams(data.previous);
-                } else {
-                    ctl.hasPrev = false;
-                    prevParams = {};
-                }
+                ctl.getNext = pageButton('next', data);
+                ctl.getPrev = pageButton('previous', data);
 
                 if (fetchComparisonPlaces) {
                     getComparisonPlaces();
@@ -237,16 +219,18 @@
             });
         }
 
-        function getNext() {
-            var params = _.merge({}, defaultParams, nextParams);
-            $state.go('places.list', params, {notify: false});
-            getPlaces(false, params);
-        }
-
-        function getPrev() {
-            var params = _.merge({}, defaultParams, prevParams);
-            $state.go('places.list', params, {notify: false});
-            getPlaces(false, params);
+        // Returns a function to go the next or previous page, to be used by the pagination buttons,
+        // or 'null' if the data says there are no more pages in the given direction.
+        function pageButton(direction, data) {
+            if (!data[direction]) {
+                return null;
+            }
+            return function() {
+                var pageParams = Pagination.getLinkParams(data[direction])
+                var params = _.merge({}, defaultParams, pageParams);
+                $state.go('places.list', params, {notify: false});
+                getPlaces(false, params);
+            };
         }
 
         // Must set ctl.mapPlaces via this so that the object ref gets updated

--- a/src/angularjs/src/app/places/list/places-list.controller.js
+++ b/src/angularjs/src/app/places/list/places-list.controller.js
@@ -14,22 +14,12 @@
                                  Pagination, AuthService, Neighborhood, AnalysisJob) {
         var ctl = this;
 
-        var defaultGroupFn = function () {
-            return 'SKIPHEADER';
-        }
-
         var sortingOptions = [
             {
                 // string that gets passed to the /api/analysis_jobs/?ordering param
-                value: 'neighborhood__state_abbrev,neighborhood__label',
+                value: 'neighborhood__label',
                 // Human readable label to show in dropdown UI
-                label: 'Alphabetical by State',
-                // A bit hacky. The value for the groupFn key corresponds to the 'iteratee' param
-                //  of https://lodash.com/docs/4.17.4#groupBy
-                // The _.groupBy keys will be used as the section headers in the list UI.
-                // If you don't want section headers, groupFn blank, the
-                // defaultGroupFn above will be used.
-                groupFn: 'state_abbrev'
+                label: 'Place name'
             }, {
                 value: '-overall_score',
                 label: 'Highest Rated'
@@ -42,6 +32,10 @@
             }, {
                 value: '-population_total',
                 label: 'Population',
+                // The value for the groupFn key corresponds to the 'iteratee' param
+                //  of https://lodash.com/docs/4.17.4#groupBy
+                // The _.groupBy keys will be used as the section headers in the list UI.
+                // If you don't want section headers, omit groupFn.
                 groupFn: function (n) {
                     var pop = n.population_total;
                     if (pop >= 500000) {
@@ -53,7 +47,6 @@
                     } else {
                         return 'Unknown';
                     }
-
                 }
             }
         ];
@@ -213,7 +206,12 @@
                     return neighborhood;
                 });
                 setMapPlaces(places);
-                var groupedPlaces = _.groupBy(places, ctl.sortBy.groupFn || defaultGroupFn);
+
+                // Get the grouping function, or fall back to using a keyword that groups
+                // everything together and tells the template to omit sections labels.
+                var groupFn = ctl.sortBy.groupFn || function () { return 'SKIPHEADER'; };
+
+                var groupedPlaces = _.groupBy(places, groupFn);
                 ctl.sections = _.keys(groupedPlaces).sort();
                 ctl.places = groupedPlaces;
 


### PR DESCRIPTION
## Overview

Removes the option to sort places by state then name, which had been the default.  Now the default is alphabetical by place name across all states and countries.

(Issue #734 will add filtering to solve the problem of finding a place by country or state.)

### Demo

![image](https://user-images.githubusercontent.com/6598836/56058281-f7df5c00-5d2e-11e9-8fbc-2365313a99f4.png)

### Notes

This also includes a small code refactor to the next and previous buttons.  As noted in the commit message, they tripped me up for a minute and then bothered me enough to spend a few minutes reconfiguring them a bit to reduce moving parts and repetition.  I believe they're functionally unchanged.

## Testing Instructions

- Load the places list, behold the alphabetical sorting.
- Use the "Previous" and "Next" buttons (set `REST_FRAMEWORK['PAGE_SIZE']` to something small if you don't have enough places for the default page size) and confirm that they still work as expected.

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #730.
