### PR TITLE
Format neighborhood labels to include state/province and country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated containers based on Debian Jessie to Stretch
 - Support entering state/province for non-US neighborhoods
 - Default to sorting places list by name and remove order-by-state option
+- Adjust label formatting to show state/province and country
 
 ## [0.9.2] - 2019-03-11
 

--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
@@ -14,7 +14,7 @@
         var ctl = this;
 
         function initialize() {
-            ctl.neighborhoods = Neighborhood.all().$promise.then(function(data) {
+            ctl.neighborhoods = Neighborhood.all({ordering: 'label'}).$promise.then(function(data) {
                 ctl.neighborhoods = data.results;
             });
         }

--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.html
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.html
@@ -10,8 +10,8 @@
             <div class="form-group">
               <label for="role">Neighborhood</label>
               <select ng-model="analysisJobCreate.neighborhood"
-                      ng-options="neighborhood as neighborhood.label for neighborhood
-                      in analysisJobCreate.neighborhoods track by neighborhood.uuid"
+                      ng-options="neighborhood as neighborhood.label + ', ' + neighborhood.label_suffix
+                      for neighborhood in analysisJobCreate.neighborhoods track by neighborhood.uuid"
                       class="form-control" id="neighborhood" type="text" required>
               </select>
             </div>

--- a/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.controller.js
@@ -14,7 +14,7 @@
         var ctl = this;
 
         function initialize() {
-            ctl.neighborhoods = Neighborhood.all().$promise.then(function(data) {
+            ctl.neighborhoods = Neighborhood.all({ordering: 'label'}).$promise.then(function(data) {
                 ctl.neighborhoods = data.results;
             });
         }

--- a/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.html
+++ b/src/angularjs/src/app/analysis-jobs/import/analysis-jobs-import.html
@@ -10,8 +10,8 @@
             <div class="form-group">
                 <label for="neighborhood">Neighborhood</label>
                 <select ng-model="analysisJobImport.neighborhood"
-                        ng-options="neighborhood as neighborhood.label for neighborhood
-                        in analysisJobImport.neighborhoods track by neighborhood.uuid"
+                        ng-options="neighborhood as neighborhood.label + ', ' + neighborhood.label_suffix
+                        for neighborhood in analysisJobImport.neighborhoods track by neighborhood.uuid"
                         class="form-control" id="neighborhood" type="text" required>
                 </select>
             </div>

--- a/src/angularjs/src/app/home/home.html
+++ b/src/angularjs/src/app/home/home.html
@@ -30,7 +30,7 @@
                     </div>
                     <div class="card-details">
                         <h3>{{city.label}}</h3>
-                        <h4>{{city.state_abbrev || city.country.name}}</h4>
+                        <h4>{{city.label_suffix}}</h4>
                         <div class="network-score large">{{city.overall_score | number:0}}</div>
                         <div class="location-timestamp"><span>Last updated:</span>
                             {{city.modifiedAt | date:'MMMM dd, yyyy'}}</div>

--- a/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
+++ b/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
@@ -28,7 +28,7 @@
         </div>
         <div class="form-group animationIf" ng-if="neighborhoodCreate.isDefaultCountry() ||
           (neighborhoodCreate.country && neighborhoodCreate.country.subdivisions)">
-          <label for="role">State</label>
+          <label for="role">State/Province</label>
           <select ng-model="neighborhoodCreate.state"
                   ng-options="state as state.name for state
                     in neighborhoodCreate.country.subdivisions track by state.code"

--- a/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
+++ b/src/angularjs/src/app/neighborhoods/create/neighborhoods-create.html
@@ -26,13 +26,19 @@
                   class="form-control" id="role" type="text" required>
           </select>
         </div>
-        <div class="form-group animationIf" ng-if="neighborhoodCreate.isDefaultCountry() ||
-          (neighborhoodCreate.country && neighborhoodCreate.country.subdivisions)">
-          <label for="role">State/Province</label>
+        <div class="form-group animationIf"
+             ng-if="neighborhoodCreate.isDefaultCountry() ||
+                    (neighborhoodCreate.country &&
+                     neighborhoodCreate.country.subdivisions &&
+                     neighborhoodCreate.country.subdivisions.length > 0)">
+          <label for="role">State/Province
+            <span ng-if="!neighborhoodCreate.country.subdivisions_required">(optional)</span></label>
           <select ng-model="neighborhoodCreate.state"
                   ng-options="state as state.name for state
                     in neighborhoodCreate.country.subdivisions track by state.code"
-                  class="form-control" id="role" type="text" required>
+                  ng-required="neighborhoodCreate.country.subdivisions_required"
+                  class="form-control" id="role" type="text">
+                  <option></option>
           </select>
         </div>
         <div class="form-group animationIf" ng-if="neighborhoodCreate.isDefaultCountry()">

--- a/src/angularjs/src/app/neighborhoods/list/neighborhoods-list.html
+++ b/src/angularjs/src/app/neighborhoods/list/neighborhoods-list.html
@@ -13,7 +13,7 @@
           <tr>
             <th>ID</th>
             <th>Name</th>
-            <th>State</th>
+            <th>State/Province</th>
             <th>City FIPS</th>
             <th>Country</th>
             <th>Visibility</th>

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -27,7 +27,7 @@
                             <i class="icon-cross"></i>
                         </a>
                         <h3>{{place.neighborhood.label}}</h3>
-                        <h4>{{place.neighborhood.state_abbrev || place.neighborhood.country.name}}</h4>
+                        <h4>{{place.neighborhood.label_suffix}}</h4>
                         <div class="network-score large">{{place.lastJob.overall_score | number:0}}</div>
                         <div class="location-timestamp"><span>Last updated:</span>
                             {{place.lastJob.modifiedAt | date:'MMMM dd, yyyy'}}</div>

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -9,7 +9,7 @@
         <div class="row">
             <div class="column-8">
                 <h2 class="sidebar-title">{{placeDetail.place.label }}</h2>
-                <h4 class="sidebar-title">{{placeDetail.place.state_abbrev || placeDetail.place.country.name}}</h4>
+                <h4 class="sidebar-title">{{placeDetail.place.label_suffix}}</h4>
                 <div class="location-timestamp"><span>Last updated:</span>
                     {{placeDetail.place.modifiedAt | date:'MMMM dd, yyyy'}}</div>
             </div>

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -47,8 +47,9 @@
                             uib-dropdown-menu>
                             <li ng-repeat="neighborhood in placeList.comparePlaces | filter:{uuid: '!!'}">
                                 <div>
-                                    <div class="compare-title">{{neighborhood.label}},
-                                        {{neighborhood.state_abbrev || neighborhood.country.name}}</div>
+                                    <div class="compare-title">
+                                        {{neighborhood.label}}, {{neighborhood.label_suffix}}
+                                    </div>
                                     <div class="network-score small">{{neighborhood.overall_score | number:0}}</div>
                                     <a ng-click="placeList.removeComparePlace(neighborhood.uuid)"
                                         class="compare-remove">Remove</a>
@@ -84,7 +85,7 @@
                         <pfb-thumbnail-map pfb-thumbnail-map-place="neighborhood.uuid">
                         </pfb-thumbnail-map>
                     </div>
-                    <div class="result-title">{{neighborhood.label}}, {{neighborhood.state_abbrev || neighborhood.country.name}}
+                    <div class="result-title">{{neighborhood.label}}, {{neighborhood.label_suffix}}
                         <div class="location-timestamp"><span>Last updated:</span> {{neighborhood.modifiedAt | date:'MMMM dd, yyyy'}}</div>
                     </div>
                 </div>

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -28,6 +28,7 @@ import us
 from pfb_network_connectivity.models import PFBModel
 from pfb_network_connectivity.utils import download_file
 from users.models import Organization, PFBUser
+from .countries import get_country_config
 from .functions import ObjectAtPath
 
 
@@ -268,6 +269,14 @@ class Neighborhood(PFBModel):
 
         """
         return us.states.lookup(self.state_abbrev)
+
+    @property
+    def label_suffix(self):
+        """ State/province and country, formatted per the country config. """
+        return get_country_config(self.country)['label_suffix_template'].format(
+            subdivision_code=self.state_abbrev,
+            country_alpha_2=self.country.code,
+        )
 
     @classmethod
     def name_for_label(cls, label):

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -28,7 +28,6 @@ import us
 from pfb_network_connectivity.models import PFBModel
 from pfb_network_connectivity.utils import download_file
 from users.models import Organization, PFBUser
-from .countries import get_country_config
 from .functions import ObjectAtPath
 
 
@@ -272,11 +271,15 @@ class Neighborhood(PFBModel):
 
     @property
     def label_suffix(self):
-        """ State/province and country, formatted per the country config. """
-        return get_country_config(self.country)['label_suffix_template'].format(
-            subdivision_code=self.state_abbrev,
-            country_alpha_2=self.country.code,
-        )
+        """ State/province (if applicable) and country suffix for display label.
+
+        State/province isn't collected for some countries, and is optional for others, so
+        sometimes this is just the country.
+        """
+        elements = [self.country.code]
+        if self.state_abbrev:
+            elements.insert(0, self.state_abbrev)
+        return ', '.join(elements)
 
     @classmethod
     def name_for_label(cls, label):

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -79,7 +79,7 @@ class NeighborhoodSerializer(PFBModelSerializer):
         if state_abbrev:
             if not use_subdivisions(country):
                 raise serializers.ValidationError(
-                    'State should not be set for {} neighborhoods'.format(country))
+                    'State/Province should not be set for {} neighborhoods'.format(country))
             if state_abbrev not in [s['code'] for s in subdivisions_for_country(country)]:
                 raise serializers.ValidationError(
                     "State/Province '{}' not valid for country '{}'".format(state_abbrev, country))

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -105,8 +105,8 @@ class NeighborhoodSerializer(PFBModelSerializer):
         model = Neighborhood
         # explicitly list fields (instead of using `exclude`) to control ordering
         fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
-                  'name', 'label', 'organization', 'country', 'state_abbrev', 'city_fips',
-                  'boundary_file', 'visibility', 'last_job',)
+                  'name', 'label', 'label_suffix', 'organization', 'country', 'state_abbrev',
+                  'city_fips', 'boundary_file', 'visibility', 'last_job',)
         read_only_fields = ('uuid', 'createdAt', 'modifiedAt', 'createdBy', 'modifiedBy',
                             'organization', 'last_job', 'name',)
 
@@ -121,7 +121,8 @@ class NeighborhoodSummarySerializer(PFBModelSerializer):
 
     class Meta:
         model = Neighborhood
-        fields = ('uuid', 'name', 'label', 'country', 'state_abbrev', 'organization', 'geom_pt',)
+        fields = ('uuid', 'name', 'label', 'label_suffix', 'country', 'state_abbrev',
+                  'organization', 'geom_pt',)
         read_only_fields = fields
 
 

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -199,7 +199,8 @@ class NeighborhoodViewSet(ModelViewSet):
     filter_backends = (DjangoFilterBackend, OrderingFilter, OrgAutoFilterBackend)
     serializer_class = NeighborhoodSerializer
     pagination_class = OptionalLimitOffsetPagination
-    ordering_fields = ('created_at',)
+    ordering_fields = ('created_at', 'label')
+    ordering = ('-created_at',)
 
     def perform_create(self, serializer):
         if serializer.is_valid():

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -334,18 +334,15 @@ TILEGARDEN_ROOT = os.getenv('PFB_TILEGARDEN_ROOT')
 if not TILEGARDEN_ROOT:
     raise ImproperlyConfigured('env.PFB_TILEGARDEN_ROOT is required')
 
-# Configuration object for whether to collect state/province and how to display labels by country
+# Configuration object for whether to collect state/province by country
 COUNTRY_CONFIG = {
     'US': {
         'subdivisions': True,
-        'label_suffix_template': u"{subdivision_code}, {country_alpha_2}",
     },
     'CA': {
         'subdivisions': True,
-        'label_suffix_template': u"{subdivision_code}, {country_alpha_2}",
     },
     'default': {
         'subdivisions': False,
-        'label_suffix_template': u"{country_alpha_2}",
     }
 }

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -338,14 +338,14 @@ if not TILEGARDEN_ROOT:
 COUNTRY_CONFIG = {
     'US': {
         'subdivisions': True,
-        'label_template': "{name}, {subdivision_code}, {country_alpha_2}",
+        'label_suffix_template': u"{subdivision_code}, {country_alpha_2}",
     },
     'CA': {
         'subdivisions': True,
-        'label_template': "{name}, {subdivision_code}, {country_alpha_2}",
+        'label_suffix_template': u"{subdivision_code}, {country_alpha_2}",
     },
     'default': {
         'subdivisions': False,
-        'label_template': "{name}, {country_alpha_2}",
+        'label_suffix_template': u"{country_alpha_2}",
     }
 }

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -335,14 +335,45 @@ if not TILEGARDEN_ROOT:
     raise ImproperlyConfigured('env.PFB_TILEGARDEN_ROOT is required')
 
 # Configuration object for whether to collect state/province by country
+# 'subdivision_types' is used to filter the subdivisions returned by 'pycountry' in cases where
+# there are ones we don't want.
 COUNTRY_CONFIG = {
-    'US': {
-        'subdivisions': True,
+    'default': {
+        'use_subdivisions': False,
+    },
+    'AU': {
+        'use_subdivisions': True,
+        'subdivisions_required': True,
     },
     'CA': {
-        'subdivisions': True,
+        'use_subdivisions': True,
+        'subdivisions_required': True,
     },
-    'default': {
-        'subdivisions': False,
-    }
+    'DK': {
+        'use_subdivisions': False,
+        # Regions don't have abbreviations in 'pycountry'. Will need to define by hand.
+    },
+    'FR': {
+        'use_subdivisions': True,
+        'subdivisions_required': False,
+        'subdivision_types': ['Metropolitan region'],
+    },
+    'GB': {
+        'use_subdivisions': True,
+        'subdivisions_required': False,
+        'subdivision_types': ['Country', 'Province'],  # just England, Wales, Scotland, N Ireland
+    },
+    'NL': {
+        'use_subdivisions': True,
+        'subdivisions_required': False,
+        'subdivision_types': ['Province'],  # exclude 'Country' and 'Special Municipality'
+    },
+    'NO': {
+        'use_subdivisions': False,
+        # Regions are not defined in 'pycountry'. Will need to define by hand if we want them.
+    },
+    'US': {
+        'use_subdivisions': True,
+        'subdivisions_required': True,
+    },
 }


### PR DESCRIPTION
## Overview

Changes the way neighborhood labels are formatted, moving it partly out of the front-end templates and into the API.  They'll now show up as "Label, ST, CO", where ST is the state/province abbreviation if there is one and CO is the 2-letter country code.
I removed the label template from the `COUNTRY_CONFIG` dictionary because the desired label format is simple enough that it's not necessary.  It always uses abbreviations, and always includes a state if there is one.

This means that special cases like running an analysis for a whole region should be handled by leaving the State/Province field blank when creating the neighborhood.  I.e. the neighborhood for the whole province of Limburg, Netherlands, should be entered as (label='Limburg', state_abbrev='', country='NL').  This is straightforward, and avoids troubles that would come with trying to differentiate a whole-region neighborhood from a regular one if the region is entered as state/province--which would require either name comparison or a new model property for identification.  To enable this use case, I added a config parameter to determine whether subdivision is required or not.  I made it required in the US, Canada, and Australia.

I also:
- changed the few remaining labels that said "State" to "State/Province"
- used the new labels in the Neighborhood droplist in the "Run Analysis" and "Import Analysis" forms, and sorted the lists alphabetically for good measure

### Demo

![image](https://user-images.githubusercontent.com/6598836/56157437-8224fb80-5f8d-11e9-876b-833c7663c425.png)

### Notes

- The examples sent by PFB include subdivisions for Norway and Denmark, but those aren't available from `pycountry` in the format shown, so they'll need to be added by hand.  I'll make a separate issue for that.

## Testing Instructions

- Add some neighborhoods.
   - It should give you no State/Province field for countries not set in the config to use subdivisions
   - For the US, Canada, and Australia, State/Province should be required
   - For other configured countries (Netherlands, France, the UK), it should offer but not require a list of subdivisions.
- The labels for new neighborhoods (on the Places list if you've run or imported a job for them, on the droplists regardless) should include country and, if applicable, state/province abbreviations.
- There shouldn't be any places where the site just says "State" rather than "State/Province"


## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #733 
Resolves #735
