### PR TITLE
Filter Places list by country and state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Added
+- Places list filtering by country and state/province
+
 #### Changed
 - Updated containers based on Debian Jessie to Stretch
 - Support entering state/province for non-US neighborhoods

--- a/src/angularjs/src/app/places/list/place-list.html
+++ b/src/angularjs/src/app/places/list/place-list.html
@@ -17,7 +17,33 @@
                            ng-change="placeList.filterNeighborhoods()"
                            type="text"
                            class="form-control"/>
-
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="column-6">
+                <div class="form-group">
+                    <label for="country-filter">Filter by country</label>
+                    <select name="country-filter" class="form-control"
+                        ng-options="country.alpha_2 as country.name for country in placeList.countries"
+                        ng-model="placeList.countryFilter"
+                        ng-change="placeList.filterByCountry()">
+                        <option></option>
+                    </select>
+                </div>
+            </div>
+            <div class="column-6">
+                <div class="form-group">
+                    <label for="country-filter">Filter by state/province</label>
+                    <select name="country-filter" class="form-control"
+                        ng-options="state.code as state.name for state in placeList.states[placeList.countryFilter]"
+                        ng-model="placeList.stateFilter"
+                        ng-change="placeList.filterNeighborhoods()"
+                        ng-disabled="!placeList.countryFilter ||
+                                     !placeList.states[placeList.countryFilter] ||
+                                     placeList.states[placeList.countryFilter].length === 0">
+                        <option></option>
+                    </select>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Overview

Adds country and state/province filtering to the places list on the public site.  Both are droplists, populated by the `countries` endpoint.  The "state/province" list is disabled when there's no country filter selected or the selected country has no states to filter on.

Rather than present a massive list of countries, almost all of which would be irrelevant because there are no places there, I added a parameter to the `countries` view that makes it return only countries and subdivisions for which there is a visible result--i.e. ones for which there's at least one non-hidden Neighborhood with at least one completed job.

### Demo

![image](https://user-images.githubusercontent.com/6598836/56221211-d4225b80-6037-11e9-9e70-d339b144cb9e.png)

### Notes

- Putting a bunch of logic defining what it means for a `Neighborhood` to be visible inside the `CountriesView` seems kind of awkward, so I initially created a custom queryset method on `Neighborhood` to contain that logic.  But that was awkward, too, since the answer depends on whether you're an authenticated user or not (to decide whether to show PRIVATE neighborhoods).  So I cancelled that effort and just did it in the view.  Which means there's some repetition between `CountriesView.get` and `NeighborhoodViewSet.get_queryset`.  

## Testing Instructions

On the [places list](http://localhost:9301/#/places////):
- The country filter list should be populated with all (and only) the countries represented in your list
- The state/province filter should be disabled until you select a country with jobs that have state/province values. Then it should show the list of all the states/provinces for those jobs.
- Changing the country filter should clear the state/province filter
- Selecting the blank entry at the top of either list should un-filter
- The "Filter by place name" feature should work as before. The filters should be additive, so typing something in that input should remove entries that don't match, whether or not the list is filtered by country and state.
- When you're authenticated (i.e. signed in [here](http://localhost:9301/#/login/)), neighborhoods marked "Private" should show up, and their countries and states should be represented in the filter lists.  When you're not logged in, any country or state for which you only have Private neighborhoods should stop appearing in the relevant droplist.
- Everything else should work as before, including the Country and State/Province droplists on the "Create Neighborhood" page, which use the normal, unfiltered version of the `countries` endpoint.

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #734.
