### PR TITLE
Migrates analysis scripts to Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support entering state/province for non-US neighborhoods
 - Default to sorting places list by name and remove order-by-state option
 - Adjust label formatting to show state/province and country
+- Upgraded analysis scripts to run under Python 3
 
 ## [0.9.2] - 2019-03-11
 

--- a/src/analysis/Dockerfile
+++ b/src/analysis/Dockerfile
@@ -41,13 +41,13 @@ RUN set -xe && \
         parallel \
         postgresql-plpython-$PG_MAJOR \
         postgresql-$PG_MAJOR-pgrouting \
-        python-gdal \
+        python3-gdal \
         gdal-bin \
         unzip \
         zip \
         postgis \
-        python-dev \
-        python-pip" && \
+        python3-dev \
+        python3-pip" && \
     apt-get update && apt-get install -y ${BUILD_DEPS} ${DEPS} --no-install-recommends && \
     \
     mkdir /tmp/build/ && cd /tmp/build && \
@@ -58,9 +58,9 @@ RUN set -xe && \
       git clone --branch $GIT_BRANCH_QUANTILE https://github.com/tvondra/quantile.git && \
         (cd quantile && make install) && \
     \
-    pip install --upgrade pip setuptools && \
+    pip3 install --upgrade pip setuptools && \
     hash -r && \
-    pip install -r /opt/pfb/django/requirements.txt && \
+    pip3 install -r /opt/pfb/django/requirements.txt && \
     \
     cd /tmp/ && rm -rf /tmp/build/ /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove ${BUILD_DEPS}

--- a/src/analysis/README.md
+++ b/src/analysis/README.md
@@ -2,10 +2,11 @@
 
 ## Docker
 
-To run the analysis in docker, first build the docker image:
+To run the analysis in docker, first build the docker image.
 
+From the `src` folder, run
 ```bash
-docker build -t pfb .
+docker build -t pfb -f analysis/Dockerfile .
 ```
 
 Then run the analysis as follows:

--- a/src/analysis/scripts/detect_utm_zone.py
+++ b/src/analysis/scripts/detect_utm_zone.py
@@ -1,9 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Accepts a polygon shapefile and finds the SRID for the UTM zone
 Based on https://github.com/jbranigan/geo-scripts-python/blob/master/latlng2utm/detect-utm-zone.py
 """
+from __future__ import print_function
+from __future__ import division
 
 import argparse
 import math
@@ -101,5 +103,6 @@ def main():
     args = parser.parse_args()
 
     get_srid(args.filename)
+
 
 main()

--- a/src/analysis/scripts/download_osm_extract.py
+++ b/src/analysis/scripts/download_osm_extract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 A script to cache Geofabrik OSM extracts on S3 to avoid downloading the same file repeatedly.
@@ -9,6 +9,9 @@ Given a local directory, a state, and an S3 bucket, it
 - If it's not there, downloads the file from Geofabrik and uploads it to the bucket, writing then
   clearing a lockfile to prevent other jobs from trying to do it at the same time.
 """
+from __future__ import print_function
+from builtins import str
+from builtins import range
 
 import argparse
 import datetime
@@ -67,7 +70,7 @@ def wait_for_lockfile(bucket, state_abbrev):
     """
     logger.debug('Checking for OSM extract lockfile for {}'.format(state_abbrev))
     key = compose_lockfile_key(state_abbrev)
-    for attempt in xrange(LOCKFILE_POLLING_ATTEMPTS):
+    for attempt in range(LOCKFILE_POLLING_ATTEMPTS):
         if read_from_s3(bucket, key) is None:
             return None
         logger.info('Lockfile exists for {}, waiting'.format(state_abbrev))
@@ -90,7 +93,8 @@ def get_lockfile(bucket, state_abbrev):
     lockfile_content = '{} {}'.format(os.getpid(), datetime.datetime.now())
     try:
         write_to_s3(bucket, key, lockfile_content)
-        sleep(30)  # The likely race condition window is probably <2 seconds, but caution doesn't hurt
+        # The likely race condition window is probably <2 seconds, but caution doesn't hurt
+        sleep(30)
         if read_from_s3(bucket, key) == lockfile_content:
             return key
         else:
@@ -166,7 +170,7 @@ def main():
         logger.debug('Shortcut direct Geofabrik download: S3_CLIENT={}, bucket={}'
                      .format(str(S3_CLIENT), bucket))
         osm_extract_filepath = download_from_geofabrik(local_dir, state_abbrev)
-        print osm_extract_filepath
+        print(osm_extract_filepath)
         return
 
     # First try to download the file, since that's all we ultimately want to accomplish
@@ -197,7 +201,7 @@ def main():
                 # If we have the lock, we want to make sure we release it even on error
                 delete_from_s3(bucket, lockfile_key)
 
-    print osm_extract_filepath
+    print(osm_extract_filepath)
 
 
 main()


### PR DESCRIPTION
## Overview

Updates the Python scripts in `/src/analysis` to Python 3.

### Notes

Although backward compatibility with Python2 was not a requirement, and the code required only minimal changes to achieve Python3 compatibility, I discovered that the import statements necessary to achieve backwards compatibility can serve a useful signaling function to both automated and human readers that the code has been audited for Py3 compatibility. For example, performing automated conversion on `detect_utm_zone.py` initially resulted in the following diff:
```
--- scripts/detect_utm_zone.py	(original)
+++ scripts/detect_utm_zone.py	(refactored)
@@ -5,6 +5,8 @@
 Based on https://github.com/jbranigan/geo-scripts-python/blob/master/latlng2utm/detect-utm-zone.py
 """
 from __future__ import print_function
+from __future__ import division
+from past.utils import old_div
 
 import argparse
 import math
@@ -32,7 +34,7 @@
     """ Finds the UTM zone of a WGS84 coordinate """
     # There are 60 longitudinal projection zones numbered 1 to 60 starting at 180W
     # So that's -180 = 1, -174 = 2, -168 = 3
-    zone = ((coord - -180) / 6.0)
+    zone = (old_div((coord - -180), 6.0))
     return int(math.ceil(zone))
 
 
@@ -79,10 +81,10 @@
     check_latlng(bbox)
     check_width(bbox)
 
-    avg_longitude = ((bbox[1] - bbox[0]) / 2) + bbox[0]
+    avg_longitude = (old_div((bbox[1] - bbox[0]), 2)) + bbox[0]
     utm_zone = get_zone(avg_longitude)
 
-    avg_latitude = ((bbox[3] - bbox[2]) / 2) + bbox[2]
+    avg_latitude = (old_div((bbox[3] - bbox[2]), 2)) + bbox[2]
 
     # convert UTM zone to SRID
     # SRID for a given UTM ZONE: 32[6 if N|7 if S]<zone>
```

This is because division changed between Python 2 and Python 3, so the conversion script is doing its best to prevent a change in script behavior. However, the Python 2 code is actually somewhat problematic here -- in the unlikely situation that pure integers managed to sneak into the inputs, we would consider integer division to be a bug rather than a feature because it would make the average incorrect in most cases. So it's preferable to adopt the Python 3 behavior, which can be done by manually adding `from __future__ import division` to the file. This makes the conversion tool ignore that particular fix. This could also be done by switching off the fix from the command line, but this way is more transparent and durable because it signals to all future readers that the change in division behavior has been accounted for in this file.

Maybe this kind of signaling won't be necessary once Python 3 is widespread enough that everyone just assumes that code is in Python 3, but for the immediate future it seems like a helpful way to broadcast "this code has been migrated".

This doesn't migrate all the way to Python 3.7. Given the difficulties that caused on Cicero, it seems like waiting a year is more likely to be the most efficient use of available project budget since it should hopefully become easier to do the upgrade then.

## Testing Instructions

 * Edit `download_osm_extract.py` to add `logger.info(sys.version)` near the top of `main()`
 * Follow the README instructions to rebuild the `pfb` container
 * If you don't have it already, grab the `gtown_westside.zip` shapefile from the project S3 bucket
 * Run something like `docker run -e PFB_SHPFILE=/data/gtown_westside/gtown_westside.shp -e PFB_STATE=pa -e PFB_STATE_FIPS=42 -e NB_INPUT_SRID=4326 -e NB_BOUNDARY_BUFFER=1 -v $(pwd)/data/:/data/ pfb`
 * Confirm that your log message says the script is running under Python 3 when `download_osm_extract.py` starts up.
 * Confirm that the script completes successfully and that the analysis completes successfully.

## Checklist

- [X] Add entry to CHANGELOG.md

Resolves #752 
