### PR TITLE
Upgrade Django to 2.2

### DIFF
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -1,7 +1,7 @@
 # Note: the Django and psycopg2 versions are repeated in requirements.txt for the benefit
 # of the analysis container. The base container and requirements file versions should be kept
 # in sync.
-FROM quay.io/azavea/django:1.11-python3.6-slim
+FROM quay.io/azavea/django:2.2-python3.6-slim
 
 MAINTAINER Azavea
 

--- a/src/django/pfb_analysis/management/commands/add_city_fips.py
+++ b/src/django/pfb_analysis/management/commands/add_city_fips.py
@@ -63,13 +63,13 @@ def add_city_fips(input_path, output_path, fips_csv):
                                                                   state=prop['state'], fips=fips))
                             if found_fips:
                                 if found_fips != fips:
-                                    logger.warn("""FIPS mismatch. Expected: {fips}
+                                    logger.warning("""FIPS mismatch. Expected: {fips}
                                         Got: {found} for {place}, {state}""".format(
                                         fips=fips, found=found_fips, place=place,
                                         state=prop['state']))
                             found_fips = fips
                 if not found_fips:
-                    logger.warn('Could not find FIPS for {city}, {state}'.format(city=city,
+                    logger.warning('Could not find FIPS for {city}, {state}'.format(city=city,
                                 state=prop['state']))
                 else:
                     found += 1

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -674,12 +674,12 @@ class AnalysisJob(PFBModel):
     def run(self):
         """ Run the analysis job, configuring ENV appropriately """
         if self.status != self.Status.CREATED:
-            logger.warn('Attempt to re-run job: {}. Skipping.'.format(self.uuid))
+            logger.warning('Attempt to re-run job: {}. Skipping.'.format(self.uuid))
             return
 
         # TODO: #614 remove this check on adding support for running international jobs
         if not self.neighborhood.state:
-            logger.warn('Running jobs outside the US is not supported yet. Skipping {}.'.format(
+            logger.warning('Running jobs outside the US is not supported yet. Skipping {}.'.format(
                 self.uuid))
             self.update_status(self.Status.ERROR)
             return
@@ -706,7 +706,7 @@ class AnalysisJob(PFBModel):
         # bail out with a helpful message
         if settings.DJANGO_ENV == 'development':
             self.update_status(self.Status.QUEUED)
-            logger.warn("Can't actually run development analysis jobs on AWS. Try this:"
+            logger.warning("Can't actually run development analysis jobs on AWS. Try this:"
                         "\nPFB_JOB_ID='{PFB_JOB_ID}' PFB_CITY_FIPS='{PFB_CITY_FIPS}' PFB_S3_RESULTS_PATH='{PFB_S3_RESULTS_PATH}' "
                         "./scripts/run-local-analysis "
                         "'{PFB_SHPFILE_URL}' {PFB_STATE} {PFB_STATE_FIPS}".format(**environment))

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import connection, DataError
 from django.utils.text import slugify
 from django_filters.rest_framework import DjangoFilterBackend
-from django_q.tasks import async
+from django_q.tasks import async_task
 from rest_framework import mixins, parsers, status
 from rest_framework.decorators import action, parser_classes
 from rest_framework.exceptions import NotFound
@@ -130,7 +130,7 @@ class AnalysisBatchViewSet(ViewSet):
             ClientMethod='get_object',
             Params={'Bucket': settings.AWS_STORAGE_BUCKET_NAME, 'Key': key}
         )
-        async('pfb_analysis.tasks.create_batch_from_remote_shapefile',
+        async_task('pfb_analysis.tasks.create_batch_from_remote_shapefile',
             url,
             group='create_analysis_batch',
             ack_failure=True)
@@ -179,7 +179,7 @@ class AnalysisLocalUploadTaskViewSet(mixins.CreateModelMixin,
                                          created_by=user, modified_by=user)
         obj = serializer.save(job=job, created_by=user, modified_by=user)
 
-        async('pfb_analysis.tasks.upload_local_analysis',
+        async_task('pfb_analysis.tasks.upload_local_analysis',
             obj.uuid,
             group='import_analysis_job',
             ack_failure=True)

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -13,7 +13,7 @@ from django.utils.text import slugify
 from django_filters.rest_framework import DjangoFilterBackend
 from django_q.tasks import async
 from rest_framework import mixins, parsers, status
-from rest_framework.decorators import detail_route, parser_classes
+from rest_framework.decorators import action, parser_classes
 from rest_framework.exceptions import NotFound
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import AllowAny, IsAuthenticatedOrReadOnly
@@ -69,7 +69,7 @@ class AnalysisJobViewSet(ModelViewSet):
         instance = serializer.save()
         instance.run()
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def cancel(self, request, pk=None):
         job = self.get_object()
         job.cancel(reason='AnalysisJob terminated via API by {} at {}'
@@ -77,7 +77,7 @@ class AnalysisJobViewSet(ModelViewSet):
         serializer = AnalysisJobSerializer(job)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['GET'])
+    @action(detail=True, methods=['GET'])
     def results(self, request, pk=None):
         job = self.get_object()
 

--- a/src/django/pfb_network_connectivity/pagination.py
+++ b/src/django/pfb_network_connectivity/pagination.py
@@ -1,4 +1,4 @@
-from rest_framework.pagination import LimitOffsetPagination, _get_count
+from rest_framework.pagination import LimitOffsetPagination
 
 
 class OptionalLimitOffsetPagination(LimitOffsetPagination):
@@ -11,7 +11,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
         self.limit = self.get_limit(request)
         # set the limit to one more than the queryset count
         if self.limit == 'all':
-            self.limit = _get_count(queryset) + 1
+            self.limit = self.get_count(queryset) + 1
         return super(OptionalLimitOffsetPagination, self).paginate_queryset(queryset, request, view)
 
     def get_limit(self, request):

--- a/src/django/pfb_network_connectivity/permissions.py
+++ b/src/django/pfb_network_connectivity/permissions.py
@@ -90,7 +90,7 @@ class IsAdminOrSelfOnly(permissions.BasePermission):
     def has_permission(self, request, view):
         """Allow access to admins or if safe method"""
 
-        if not request.user or not request.user.is_authenticated():
+        if not request.user or not request.user.is_authenticated:
             return False
 
         if is_admin(request.user) or is_org_admin(request.user):
@@ -104,7 +104,7 @@ class IsAdminOrSelfOnly(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         """Only allow access to own user, do not allow deleting self"""
 
-        if not request.user or not request.user.is_authenticated():
+        if not request.user or not request.user.is_authenticated:
             return False
 
         # User cannot delete themselves
@@ -141,7 +141,7 @@ class RestrictedCreate(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        if not request.user or not request.user.is_authenticated():
+        if not request.user or not request.user.is_authenticated:
             return False
 
         if 'AnalysisJobViewSet' == view.__class__.__name__:

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -77,7 +77,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -238,6 +238,7 @@ WATCHMAN_CHECKS = (
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 AWS_STORAGE_BUCKET_NAME = os.getenv('PFB_S3_STORAGE_BUCKET',
                                     '{0}-pfb-storage-{1}'.format(DEV_USER, AWS_REGION))
+AWS_DEFAULT_ACL = None  # Override the insecure default behavior to silence the warning about it.
 AWS_QUERYSTRING_AUTH = False
 
 # Django Q

--- a/src/django/pfb_network_connectivity/urls.py
+++ b/src/django/pfb_network_connectivity/urls.py
@@ -39,8 +39,8 @@ router.register(r'neighborhoods', analysis_views.NeighborhoodViewSet, base_name=
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^api/', include(router.urls, namespace='api')),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^api/', include((router.urls, 'api'))),
+    url(r'^api-auth/', include('rest_framework.urls')),
 
     # Countries view
     url(r'^api/countries/', analysis_views.CountriesView.as_view()),

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,25 +1,25 @@
 # Django and psycopg2 are included in the django base container but repeated here
 # so that the analysis container will know to install them. These should be kept
 # in sync with the versions in the base container.
-Django==1.11.23
+Django==2.2.5
 psycopg2==2.8.3
 
-boto3==1.6.7
-django-amazon-ses==0.3.2
-django-countries==5.3.2
-django-extensions==2.0.5
-django-filter==1.1.0
-django-q==0.9.4
-django-storages==1.6.5
-django-watchman==0.15.0
-djangorestframework==3.7.7
-fiona==1.7.11
+boto3==1.9.224
+django-amazon-ses==2.1.1
+django-countries==5.4
+django-extensions==2.2.1
+django-filter==2.2.0
+django-q==1.0.2
+django-storages==1.7.1
+django-watchman==0.18.0
+djangorestframework==3.10.3
+fiona==1.8.6
 future==0.17.1
-pycountry==18.12.8
+pycountry==19.8.18
 pyuca==1.2
-requests==2.18.4
+requests==2.22.0
 us==1.0.0
 
 # This been removed from application code but was used in old migrations, so it can't be removed
 # unless those migrations are refactored to not import it.
-django-localflavor==2.0
+django-localflavor==2.2

--- a/src/django/users/views.py
+++ b/src/django/users/views.py
@@ -11,7 +11,7 @@ from django.core.signing import TimestampSigner, BadSignature
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.authtoken.models import Token
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
@@ -122,7 +122,7 @@ class PFBUserViewSet(viewsets.ModelViewSet):
             )
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
-    @detail_route(methods=['get', 'post'])
+    @action(detail=True, methods=['get', 'post'])
     def token(self, request, pk=None):
         """Creates/Retrieves tokens
 
@@ -155,7 +155,7 @@ class PFBUserViewSet(viewsets.ModelViewSet):
             token = Token.objects.create(user=user)
             return Response(token_data(token), status=status.HTTP_201_CREATED)
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def set_password(self, request, pk=None):
         """Detail ``POST`` endpoint for changing a user's password
 


### PR DESCRIPTION
## Overview

Upgrades Django from 1.11 to 2.2, and upgrades the rest of the Python dependencies as well.

See individual commits for specific deprecations/changes.  There were a few that were reported by running `python -Wa manage.py test` pre-upgrade, as suggested, and some that weren't.  And there were a few items arising from the package upgrades.

### Demo

Here's some output from the [test CI build](http://urbanappsci.internal.azavea.com/job/azavea/job/pfb-network-connectivity/job/test%252Fdjango-2.2/1/console);
> Building django
Step 1/9 : FROM quay.io/azavea/django:2.2-python3.6-slim
 ---> 7424cdf34978
Step 2/9 : MAINTAINER Azavea
 ---> Using cache
 ---> ef191e1361a5
Step 3/9 : RUN pip3 install --upgrade pip
 ---> Using cache
 ---> 5b12beb19bc2
Step 4/9 : COPY requirements.txt /tmp/
 ---> Using cache
 ---> 3e018ea35d8d
Step 5/9 : RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 ---> Using cache
 ---> b54ffdcbd179
Step 6/9 : COPY . /usr/src
 ---> 225633154368
Removing intermediate container a47c9b956028
Step 7/9 : WORKDIR /usr/src
 ---> 95a15c507eb9
Removing intermediate container ed87d420a120
Step 8/9 : EXPOSE 9202
 ---> Running in ae6c0d60c822
 ---> 22267280cf84
Removing intermediate container ae6c0d60c822
Step 9/9 : CMD -w 1 -b 0.0.0.0:9202 --reload --log-level info --error-logfile - --forwarded-allow-ips * -k gevent pfb_network_connectivity.wsgi
 ---> Running in 0320ada83b27
 ---> fbd4c8d033b5
Removing intermediate container 0320ada83b27
Successfully built fbd4c8d033b5
Successfully tagged pfb-app:53dc065

### Notes

- As noted above, I pushed a test branch so that CI would build it and deploy it to staging, which it did, successfully.
- There are 4 migrations that come with the upgrade:
   - In `admin`, [0003_logentry_add_action_flag_choices](https://github.com/django/django/blob/master/django/contrib/admin/migrations/0003_logentry_add_action_flag_choices.py)
   - In `auth`:
      - [0009_alter_user_last_name_max_length](https://github.com/django/django/blob/master/django/contrib/auth/migrations/0009_alter_user_last_name_max_length.py)
      - [0010_alter_group_name_max_length](https://github.com/django/django/blob/master/django/contrib/auth/migrations/0010_alter_group_name_max_length.py)
      - [0011_update_proxy_permissions](https://github.com/django/django/blob/master/django/contrib/auth/migrations/0011_update_proxy_permissions.py)
   - None of them seem liable to cause issues, especially since we don't have any `LogEntry` instances and we only have a small handful of users.

## Testing Instructions

- If your instance is from before the Python 3 upgrade, destroy the VM (`vagrant destroy`)
- Run `./scripts/setup` to provision the VM (might not be necessary, but doesn't hurt) and build new containers.
- Run tests: `vagrant ssh -c "cd /vagrant && ./scripts/test"`. They should pass and not produce any new warnings (the warning that you can't actually run analysis jobs in local development will be there, but that's fine).
- Run the server: `vagrant ssh -c "cd /vagrant && ./scripts/server"`  It shouldn't produce any errors or warnings when starting up.
- Interact with the site:
   - Add a neighborhood
   - Run a batch (it will just print the analysis commands to the log, but it will create the neighborhoods)
   - Import an analysis and confirm it shows up properly
   - Run an analysis and confirm it shows up properly
   - Compare your two analysis cities
   - Do some user and org management

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #753