### PR TITLE
Restore ansible version specifier in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,8 @@ Vagrant.configure("2") do |config|
     # local arguments
     # Ubuntu base box already has system python + pip installed, no need to reinstall here
     ansible.install = true
-    ansible.install_mode = "pip3"
+    ansible.install_mode = "pip"
+    ansible.version = "2.8.7"
   end
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
## Overview

When doing the Python upgrade I changed `ansible.install_mode = "pip"` to `pip3` (43cd67a2). But that's not actually a valid value of that variable (see https://www.vagrantup.com/docs/provisioning/ansible_local.html#install_mode).  Which I guess made Vagrant silently ignore it and start installing Ansible with `apt`. So once the Ansible version in the apt repository changed, that caused provisioning to fail because `ansible.version` didn't match the system-installed version. Not realizing it was installing Ansible the wrong way, I resolved that issue by removing the version specifier (eb8d99ba). But now that the version of Ansible in the repo has been upgraded to 2.9, there's a new crash due to breaking changes to the ansible file spec.

So this sets `ansible.install_mode` back to `"pip"` and restores the version specifier. Together, those succeed in installing Ansible 2.8.7, which works with our roles.

## Testing Instructions

- Either delete your VM (`vagrant destroy`) or check out a separate copy of the repo and do the setup from the README (i.e. copy the group vars file)
- Run `./scripts/setup`.  It should succeed.  In the preliminary provisioning, you should see that it has installed Ansible 2.8.7.  Later, it should get past the point in the `azavea.terraform` role that was crashing.

## Checklist

~- [ ] Add entry to CHANGELOG.md~ (just an internal bugfix)

Resolves #762
