### PR TITLE
Delete Neighborhood and AnalysisJob files from S3 on instance deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Added
 - A delete button for neighborhoods, with a confirmation modal
+- Clean up S3 assets when deleting neighborhoods and analysis jobs
 
 ## [0.11.0] - 2019-10-31
 


### PR DESCRIPTION
## Overview

Now that we can delete neighborhoods--which means we can also delete analysis jobs, since they get deleted along with their neighborhood--we run the risk of creating a mess of orphaned files on S3.  The Neighborhood model keeps its boundary file on S3, and the results of the AnalysisJob processing are stored on S3 as well.

This adds post-delete handlers for those two models to delete the files from S3 after the instances have been deleted. For Neighborhood, which uses a `FileField`, it's just a matter of calling `.delete()` on it.  AnalysisJob doesn't have a field to track its own assets, but it does know the S3 path where they live, so we can use that to delete them with boto3.

### Demo

![image](https://user-images.githubusercontent.com/6598836/70263117-a2473c00-1763-11ea-8756-84131b6691c5.png)

## Testing Instructions

Note: to make it easy to see files appearing and disappearing on S3, I decided to clear out the `results/` path on my development S3 bucket.  None of the files were connected to jobs I still had in my database, since I've destroyed and rebuilt my containers recently, so it was all cruft.
I did so by running this in `shell_plus`:
```
import boto3
bucket = boto3.resource('s3').Bucket(settings.AWS_STORAGE_BUCKET_NAME)
deletion_results = bucket.objects.filter(Prefix='results/').delete()
```
It took quite a while, because it turned out it was deleting 328,401 files.  I had a lot of old analysis results that included tilesets.  But now I can do `aws s3 ls s3://MY_STORAGE_BUCKET_NAME/results/ --recursive` and easily see the files I just created (or not see the ones I deleted).

- Make a neighborhood if you don't already have one.
- If you don't have a completed analysis, import one. You can use any import file URL. Here's one: `https://s3.amazonaws.com/khoekema-pfb-storage-us-east-1/uploads/marquette_results.zip`
- You should see the boundary file somewhere in `s3://YOUR_STORAGE_BUCKET_NAME/neighborhood_boundaries/` and the imported analysis results in `s3://YOUR_STORAGE_BUCKET_NAME/results/` (in a subdirectory for the analysis job's UUID).
- From the [Neighborhoods list view](http://localhost:9301/#/admin/neighborhoods/), delete the neighborhood.
- In addition to the neighborhood and job being gone from the front-end, you should see a couple messages in the log, and the files on S3 should now be gone.

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #187
