### PR TITLE
Clean up neighborhood management error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Clean up S3 assets when deleting neighborhoods and analysis jobs
 - Editing of neighborhood details
 
+#### Changed
+- Fixed garbled error messages and improved error formatting
+
 ## [0.11.0] - 2019-10-31
 
 #### Changed

--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
@@ -10,7 +10,8 @@
     'use strict';
 
     /** @ngInject */
-    function AnalysisJobCreateController($state, $filter, toastr, AnalysisJob, Neighborhood) {
+    function AnalysisJobCreateController($state, $filter, toastr, AnalysisJob, Neighborhood,
+                                         parseErrorFilter) {
         var ctl = this;
 
         function initialize() {
@@ -35,7 +36,9 @@
                 $state.go('admin.analysis-jobs.list');
             }).catch(function(error) {
                 toastr.clear(submitToast);
-                toastr.error('Error submitting analysis job: ' + error);
+                var errorDetails = parseErrorFilter(error);
+                toastr.error('Error submitting analysis job' +
+                             (errorDetails ? ': <br/>' + errorDetails : ''));
             });
         };
     }

--- a/src/angularjs/src/app/index.module.js
+++ b/src/angularjs/src/app/index.module.js
@@ -3,8 +3,9 @@
 
     angular
         .module('pfb', [
-            'angular-loading-bar',  'pfb.login', 'pfb.analysisJobs', 'pfb.help', 'pfb.home',
-            'pfb.places', 'pfb.passwordReset', 'pfb.users', 'pfb.organizations', 'pfb.neighborhoods',
+            'angular-loading-bar', 'pfb.login', 'pfb.analysisJobs', 'pfb.help', 'pfb.home',
+            'pfb.utils', 'pfb.places', 'pfb.passwordReset', 'pfb.users', 'pfb.organizations',
+            'pfb.neighborhoods',
             'ngAnimate', 'ngCookies', 'ngSanitize', 'ngMessages', 'ngAria',
             'ngResource', 'ui.router', 'toastr', 'ui.bootstrap', 'pfb.components']);
 

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.controller.js
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.controller.js
@@ -11,7 +11,7 @@
 
     /** @ngInject */
     function NeighborhoodDetailController($log, $state, $stateParams, toastr, Upload, Neighborhood,
-                                          Country) {
+                                          Country, parseErrorFilter) {
         var ctl = this;
 
         var DEFAULT_COUNTRY = {alpha_2: 'US', name: 'United States'};
@@ -90,23 +90,10 @@
             }).catch(function(error) {
                 $log.error(error);
                 toastr.clear(uploadToast);
-                var msg = 'Unable to ' + verb + ' neighborhood:';
-                if (error.data && error.data.non_field_errors) {
-                    // extract non-field errors
-                    for (var i in error.data.non_field_errors) {
-                        msg += ' ' + error.data.non_field_errors[i];
-                    }
-                } else if (error.data) {
-                    // extract field errors
-                    for (var err in error.data) {
-                        msg += ' ' + err + ': ' + error.data[err];
-                    }
-                    $log.error(msg);
-                } else {
-                    msg += ' ' + error;
-                }
+                var errorDetails = parseErrorFilter(error);
+                var msg = 'Unable to ' + verb + ' neighborhood' +
+                          (errorDetails ? ': <br/>' + errorDetails : '');
                 toastr.error(msg);
-                $log.error(msg);
             });
         };
 

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.controller.js
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.controller.js
@@ -73,7 +73,7 @@
                 // Only send state if it's supported (i.e. if the country has subdivisions)
                 state_abbrev: ctl.state && ctl.country.subdivisions ? ctl.state.code : '',
                 // Only send city FIPS if it's supported (i.e. only for US)
-                city_fips: ctl.isDefaultCountry() && (ctl.neighborhood.city_fips || ''),
+                city_fips: ctl.isDefaultCountry() ? (ctl.neighborhood.city_fips || '') : '',
                 country: ctl.country.alpha_2,
                 visibility: ctl.neighborhood.visibility,
                 label: ctl.neighborhood.label

--- a/src/angularjs/src/app/utils/module.js
+++ b/src/angularjs/src/app/utils/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('pfb.utils', []);
+})();

--- a/src/angularjs/src/app/utils/parse-errors.js
+++ b/src/angularjs/src/app/utils/parse-errors.js
@@ -1,0 +1,34 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function parseError() {
+        // Filter to extract API error messages into a readable format
+        function parse(error) {
+            if (error.data && angular.isObject(error.data)) {
+                if (angular.isArray(error.data)) {
+                    // Model validation error converted to serializer error comes back as a list
+                    return error.data.join('<br/>');
+                }
+                if (error.data.non_field_errors) {
+                    // Errors raised in `validate` come back as `non_field_errors`, an array
+                    return error.data.non_field_errors.join('<br/>');
+                } else {
+                    // If neither of those apply, there should be field errors, as {field: msg}
+                    return _.map(error.data, function(msg, field) {
+                        return field + ': ' + msg; }).join('<br/>')
+                }
+            } else if (error.data) {
+                // If there's `data` but it doesn't match an expected format, strip HTML formatting
+                // and pass it along, or just pass it along if it's not formatted as HTML
+                return angular.element(error.data).text() || error.data;
+            } else {
+                // If there's no `data`, return statusText (which might be empty or null)
+                return error.statusText;
+            }
+        }
+        return parse;
+    }
+    angular.module('pfb.utils')
+        .filter('parseError', parseError);
+})();

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -192,8 +192,7 @@ class Neighborhood(PFBModel):
 
     def save(self, *args, **kwargs):
         """ Override to do validation checks before saving """
-        if not self.name:
-            self.name = self.name_for_label(self.label)
+        self.name = self.name_for_label(self.label)
         self.full_clean()
         self._set_geom_from_boundary_file()
         super(Neighborhood, self).save(*args, **kwargs)
@@ -234,8 +233,6 @@ class Neighborhood(PFBModel):
             self.geom_simple = simplify_geom(geom)
             self.geom_pt = geom.centroid
             self.save()
-        except:
-            raise
         finally:
             if boundary_file:
                 boundary_file.close()


### PR DESCRIPTION
## Overview

The error message being shown there was a problem creating a neighborhood was a mess--the exception gets raised in the model's `save` method and wasn't getting translated into an exception that Django Rest Framework can translate into an informative response, so it was coming back as a generic 500 error, with its content in HTML.  Then the front-end was treating that HTML string as a `{fieldname: error message}` object and trying to print each property.  Since a string can be cast to an array and an array can be treated as an object with integer properties, what we got was a each letter of the response preceded by its index.  Wacky.  And not useful.

So this adjusts the error parsing to account for that case.  It still extracts field errors and lists them in the error message, but only if the error data is actually an object.
I also added a `save` method to the Neighborhood serializer so that errors generated in the model will get caught and transformed into DRF `serializer.ValidationError` exceptions, so that the accompanying message can be passed along.

Since the parsing is moderately complicated and there were two controllers doing roughly the same thing (for neighborhoods and analysis jobs), I put it in a helper, which I set up as a custom filter, since that seemed like the most straightforward way to make it available to be injected into components.

Resolves #741

### Demo

Duplicate neighborhood:
![image](https://user-images.githubusercontent.com/6598836/70741926-72abad00-1cea-11ea-8178-a083b7b92575.png)

Invalid FIPS code:
![image](https://user-images.githubusercontent.com/6598836/70741948-7d664200-1cea-11ea-9d6c-801475169b53.png)

Creating a job for a deleted neighborhood:
![image](https://user-images.githubusercontent.com/6598836/70741967-87884080-1cea-11ea-99aa-8ee1bc00f61c.png)

### Notes

- I don't know if there are actual back-end error scenarios for analysis job creation.  The one way I managed to trigger an error from the back-end was by selecting a neighborhood on the job creation page then deleting it in another tab before hitting submit.  But it makes sense to have handling in place in case there are scenarios I'm not thinking of.  And it certainly doesn't do any harm.
- After merging #778 and rebasing this branch, I realized that the parens in the `city_fips` field caused a problem for non-US neighborhoods. So this tweaks that to work properly (send the value if the neighborhood is in the US and there is one, otherwise send empty string).

## Testing Instructions

- It should show errors that are readable and include some details when you...
   - Make a neighborhood that's the same (label, country, state) as an existing one
   - Edit a neighborhood to be the same as an existing one
   - Enter a city FIPS code that meets the formatting rules but isn't valid
   - Shut down your django container or set your browser to "offline" in development tools and try to save a neighborhood
   - Select a neighborhood on the "Run Analysis" page, delete the neighborhood in a different tab, then submit the job
- Any other error cases that you can think of should at least create a Toast error message in the bottom right that tells you there was an error. Not all will have details, but all should make sense and not contain anything that looks broken or garbled.

## Checklist

- [x] Add entry to CHANGELOG.md

