### PR TITLE
Add map preview to neighborhood editing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A delete button for neighborhoods, with a confirmation modal
 - Clean up S3 assets when deleting neighborhoods and analysis jobs
 - Editing of neighborhood details
+- A boundary map preview to the neighborhood editing page
 
 #### Changed
 - Fixed garbled error messages and improved error formatting

--- a/src/angularjs/src/app/components/map/map.directive.js
+++ b/src/angularjs/src/app/components/map/map.directive.js
@@ -35,12 +35,12 @@
                 }
 
                 if (changes.pfbMapBaselayer && changes.pfbMapBaselayer.currentValue) {
-                    if (ctl.baselayer) {
-                        ctl.map.removeLayer(ctl.baselayer);
-                        ctl.baselayer = null;
+                    if (ctl.baseLayer) {
+                        ctl.map.removeLayer(ctl.baseLayer);
+                        ctl.baseLayer = null;
                     }
-                    ctl.baselayer = changes.pfbMapBaselayer.currentValue;
-                    ctl.map.addLayer(ctl.baselayer);
+                    ctl.baseLayer = changes.pfbMapBaselayer.currentValue;
+                    ctl.map.addLayer(ctl.baseLayer);
                 }
             }
         };

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -57,7 +57,7 @@
         };
 
         function loadBounds(uuid) {
-            Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
+            Neighborhood.bounds({uuid: uuid, simplified: true}).$promise.then(function (data) {
                 ctl.boundsLayer = L.geoJSON(data, {});
                 ctl.map.addLayer(ctl.boundsLayer);
             });

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.directive.js
@@ -18,7 +18,7 @@
 
             // will set center and zoom level by zooming to fit geojson polygon bounds when loaded
             ctl.boundsConus = MapConfig.conusBounds;
-            ctl.baselayer = L.tileLayer(
+            ctl.baseLayer = L.tileLayer(
                 MapConfig.baseLayers.Positron.url, {
                     attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom

--- a/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
+++ b/src/angularjs/src/app/components/thumbnail-map/thumbnail-map.html
@@ -4,7 +4,7 @@
     pfb-map
     pfb-map-zoom="12"
     pfb-map-bounds="ctl.boundsConus"
-    pfb-map-baselayer="ctl.baselayer"
+    pfb-map-baselayer="ctl.baseLayer"
     pfb-map-options="ctl.mapOptions"
     pfb-map-ready="ctl.onMapReady(map)">
 </div>

--- a/src/angularjs/src/app/home/neighborhood-map.directive.js
+++ b/src/angularjs/src/app/home/neighborhood-map.directive.js
@@ -9,7 +9,7 @@
         ctl.$onInit = function () {
             ctl.mapOptions = { scrollWheelZoom: false };
             ctl.boundsConus = MapConfig.conusBounds;
-            ctl.baselayer = L.tileLayer(
+            ctl.baseLayer = L.tileLayer(
                 MapConfig.baseLayers.Positron.url, {
                     attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom

--- a/src/angularjs/src/app/home/neighborhood-map.html
+++ b/src/angularjs/src/app/home/neighborhood-map.html
@@ -16,7 +16,7 @@
     <div class="map map-below" id="map-{{::$id}}"
         pfb-map
         pfb-map-bounds="ctl.boundsConus"
-        pfb-map-baselayer="ctl.baselayer"
+        pfb-map-baselayer="ctl.baseLayer"
         pfb-map-options="ctl.mapOptions"
         pfb-map-ready="ctl.onMapReady(map)">
     </div>

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.directive.js
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.directive.js
@@ -1,0 +1,72 @@
+
+(function() {
+
+    /* @ngInject */
+    function NeighborhoodDetailMapController(MapConfig, Neighborhood) {
+        var ctl = this;
+        ctl.map = null;
+        ctl.boundsLayer = null;
+
+        ctl.$onInit = function () {
+            ctl.mapOptions = {
+                // All the defaults are fine for this purpose
+            };
+
+            // The map directive has to have some bounds to initialize. It will zoom to the
+            // fit the neighborhood polygon bounds when it's loaded.
+            ctl.initialBounds = MapConfig.conusBounds;
+
+            ctl.baseLayer = L.tileLayer(
+                MapConfig.baseLayers.Positron.url, {
+                    attribution: MapConfig.baseLayers.Positron.attribution,
+                    maxZoom: MapConfig.conusMaxZoom
+                });
+        };
+
+        // Listener to load and zoom to the boundary once the instance is set from the parent scope
+        ctl.$onChanges = function(changes) {
+            if (changes.pfbNeighborhoodId && changes.pfbNeighborhoodId.currentValue && ctl.map) {
+                loadBounds(changes.pfbNeighborhoodId.currentValue);
+            }
+        };
+
+        ctl.onMapReady = function (map) {
+            ctl.map = map;
+            // If the id is already in place (unlikely but maybe possible), load the boundary now
+            if (ctl.pfbNeighborhoodId) {
+                loadBounds(ctl.pfbNeighborhoodId);
+            }
+        };
+
+        function loadBounds(uuid) {
+            Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
+                var boundsLayer = L.geoJSON(data, {});
+                ctl.map.addLayer(boundsLayer);
+                ctl.map.fitBounds(boundsLayer.getBounds(), {
+                    maxZoom: MapConfig.conusMaxZoom,
+                    animate: false
+                });
+            });
+        }
+    }
+
+    function NeighborhoodDetailMapDirective() {
+        var module = {
+            restrict: 'E',
+            scope: {
+                pfbNeighborhoodId: '<'
+            },
+            controller: 'NeighborhoodDetailMapController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            templateUrl: 'app/neighborhoods/detail/neighborhood-detail-map.html'
+        };
+        return module;
+    }
+
+
+    angular.module('pfb.neighborhoods.detail')
+        .controller('NeighborhoodDetailMapController', NeighborhoodDetailMapController)
+        .directive('pfbNeighborhoodDetailMap', NeighborhoodDetailMapDirective);
+
+})();

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.directive.js
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.directive.js
@@ -39,7 +39,7 @@
         };
 
         function loadBounds(uuid) {
-            Neighborhood.bounds({uuid: uuid, detailed: true}).$promise.then(function (data) {
+            Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
                 var boundsLayer = L.geoJSON(data, {});
                 ctl.map.addLayer(boundsLayer);
                 ctl.map.fitBounds(boundsLayer.getBounds(), {

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.directive.js
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.directive.js
@@ -39,7 +39,7 @@
         };
 
         function loadBounds(uuid) {
-            Neighborhood.bounds({uuid: uuid}).$promise.then(function (data) {
+            Neighborhood.bounds({uuid: uuid, detailed: true}).$promise.then(function (data) {
                 var boundsLayer = L.geoJSON(data, {});
                 ctl.map.addLayer(boundsLayer);
                 ctl.map.fitBounds(boundsLayer.getBounds(), {

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.html
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhood-detail-map.html
@@ -1,0 +1,10 @@
+<!-- keep the .map class. It's important for sizing. -->
+<div class="map" id="map-{{::$id}}"
+    pfbPreviewMapPlace="ctl.pfbNeighborhoodId"
+    pfb-map
+    pfb-map-zoom="12"
+    pfb-map-bounds="ctl.initialBounds"
+    pfb-map-baselayer="ctl.baseLayer"
+    pfb-map-options="ctl.mapOptions"
+    pfb-map-ready="ctl.onMapReady(map)">
+</div>

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.html
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.html
@@ -70,6 +70,12 @@
         </div>
         </div>
       </form>
+      <div ng-if="neighborhoodDetail.editing">
+        <h4>Geometry preview</h4>
+        <div class="neighborhood-detail-map">
+          <pfb-neighborhood-detail-map pfb-neighborhood-id="neighborhoodDetail.neighborhood.uuid"></pfb-neighborhood-detail-map>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/angularjs/src/app/places/detail/place-map.directive.js
+++ b/src/angularjs/src/app/places/detail/place-map.directive.js
@@ -13,7 +13,7 @@
 
             // set center and zoom level by zooming to fit geojson polygon bounds, once loaded
             ctl.boundsConus = MapConfig.conusBounds;
-            ctl.baselayer = L.tileLayer(
+            ctl.baseLayer = L.tileLayer(
                 MapConfig.baseLayers.Positron.url, {
                     attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
@@ -80,7 +80,7 @@
 
             if (!ctl.layerControl) {
                 ctl.layerControl = L.control.groupedLayers({
-                    'Positron': ctl.baselayer,
+                    'Positron': ctl.baseLayer,
                     'Satellite': satelliteLayer
                 }, {
                     'Overlays': {},

--- a/src/angularjs/src/app/places/detail/place-map.html
+++ b/src/angularjs/src/app/places/detail/place-map.html
@@ -5,7 +5,7 @@
      pfb-place-map-uuid="ctl.pfbPlaceMapUuid"
      pfb-map-zoom="12"
      pfb-map-bounds="ctl.boundsConus"
-     pfb-map-baselayer="ctl.baselayer"
+     pfb-map-baselayer="ctl.baseLayer"
      pfb-map-options="ctl.mapOptions"
      pfb-map-ready="ctl.onMapReady(map)">
  </div>

--- a/src/angularjs/src/app/places/list/places-list-map-directive.js
+++ b/src/angularjs/src/app/places/list/places-list-map-directive.js
@@ -13,7 +13,7 @@
 
         ctl.$onInit = function () {
             ctl.boundsConus = MapConfig.conusBounds;
-            ctl.baselayer = L.tileLayer(
+            ctl.baseLayer = L.tileLayer(
                 MapConfig.baseLayers.Positron.url, {
                     attribution: MapConfig.baseLayers.Positron.attribution,
                     maxZoom: MapConfig.conusMaxZoom
@@ -35,7 +35,7 @@
 
             if (!ctl.layerControl) {
                 ctl.layerControl = L.control.layers({
-                        'Positron': ctl.baselayer,
+                        'Positron': ctl.baseLayer,
                         'Satellite': satelliteLayer
                     },
                     []).addTo(ctl.map);

--- a/src/angularjs/src/app/places/list/places-list-map.html
+++ b/src/angularjs/src/app/places/list/places-list-map.html
@@ -2,7 +2,7 @@
  <div class="map map-below" id="map-{{::$id}}"
      pfb-map
      pfb-map-bounds="ctl.boundsConus"
-     pfb-map-baselayer="ctl.baselayer"
+     pfb-map-baselayer="ctl.baseLayer"
      pfb-map-options="ctl.mapOptions"
      pfb-map-ready="ctl.onMapReady(map)">
  </div>

--- a/src/angularjs/src/styles/pages/_mapping.scss
+++ b/src/angularjs/src/styles/pages/_mapping.scss
@@ -217,3 +217,9 @@ section.paginate {
     float: right;
   }
 }
+
+.neighborhood-detail-map {
+  width: 100%;
+  height: 400px;
+  position: relative;
+}

--- a/src/django/pfb_analysis/views.py
+++ b/src/django/pfb_analysis/views.py
@@ -249,9 +249,9 @@ class NeighborhoodBoundsGeoJsonViewDetail(APIView):
     permission_classes = (AllowAny,)
 
     def get(self, request, format=None, *args, **kwargs):
-        # Look for a 'detailed' query param and return the full geometry if it's truthy
-        detailed = request.GET.get('detailed', False)
-        table = 'geom' if detailed else 'geom_simple'
+        # Look for a 'simplified' query param and return the simplified geometry if it's truthy
+        simplified = request.GET.get('simplified', False)
+        table = 'geom_simple' if simplified else 'geom'
 
         query = """
         SELECT row_to_json(fc)


### PR DESCRIPTION
## Overview

Adds a map to the bottom of the "Edit Neighborhood Details" view.  It's for informational purposes only, not editable, but since currently there's no way to see a neighborhood's geometry without having analysis results for it and loading the boundary layer on the public site, it seems useful.

It's a copy-modify of the thumbnail map directive, since they're pretty similar, but not necessarily similar enough that it makes sense to adapt a single directive to work in both places.
It uses the existing `neighborhoods_bounds_geojson` endpoint, but modifies it slightly to take a `detailed` parameter.  The simplified geometry that makes works well for the thumbnail looks jagged on a larger map.  And since we're only loading one geometry at a time rather than a whole list of them, the larger size of the response shouldn't be a problem.

UPDATE: since we're also using the endpoint a 3rd time, for the boundary layer on the public site's detail view, and the full geometry would look better there as well, I changed it so that the endpoint defaults to returning the full geometry and the thumbnail view passes a `simplified` param.

Resolves #767

### Demo

![image](https://user-images.githubusercontent.com/6598836/70816802-46516880-1d9e-11ea-8617-77050a3b8bb3.png)

### Notes

As noted in the commit message, renaming `ctl.baselayer` to `ctl.baseLayer` in all the map components wasn't necessary, but I found the all-lower name confusing, since it's used around other properties that capitalize "Layer".  So rather than add another copy in this new component, I decided to change all the others.

## Testing Instructions

- Go to the [Neighborhoods list](http://localhost:9301/#/admin/neighborhoods/) and click the edit button for a neighborhood.  You should see its boundary, zoomed and centered, in a map at the bottom of the page.  You should be able to zoom and drag the map.
- Everything else, including the "Create Neighborhood" view, should be the same as before.

## Checklist

- [x] Add entry to CHANGELOG.md
