### PR TITLE
Allow replacing geometry when editing neighborhoods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 #### Added
 - A delete button for neighborhoods, with a confirmation modal
 - Clean up S3 assets when deleting neighborhoods and analysis jobs
-- Editing of neighborhood details
+- Editing of neighborhood details and boundary
 - A boundary map preview to the neighborhood editing page
 
 #### Changed

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.controller.js
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.controller.js
@@ -62,7 +62,7 @@
         }
 
         ctl.saveNeighborhood = function() {
-            var uploadToast = toastr.info('Creating neighborhood. Please wait...',
+            var uploadToast = toastr.info('Saving neighborhood. Please wait...',
                                           {autoDismiss: false});
 
             var url = '/api/neighborhoods/' + (ctl.editing ? ctl.neighborhood.uuid + '/' : '');

--- a/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.html
+++ b/src/angularjs/src/app/neighborhoods/detail/neighborhoods-detail.html
@@ -8,7 +8,7 @@
       <form name="neighborhoodForm" novalidate
             ng-submit="neighborhoodDetail.saveNeighborhood()" class="panel">
         <div class="panel-body">
-        <div class="form-group" ng-if="!neighborhoodDetail.editing">
+        <div class="form-group">
           <label for="file">File</label>
           <input ngf-select ng-model="neighborhoodDetail.file"
                  ngf-pattern="'.zip'" ngf-accept="'.zip'"


### PR DESCRIPTION
## Overview

I spun issue #779 off of #766 because it didn't "just work" and I wasn't sure what it would take to get it working.  This gets it working.  The file field is optional in editing mode, but if it's set, the new boundary file will be used to replace the existing neighborhood boundary.

Resolves #779.

### Notes

- This builds on the branch for PR #781 (map preview), so I pointed the PR at that.  It's not actually dependent, but it's really nice to have the preview map to be able to easily see that saving worked.
- It was pretty straightforward to hook into the existing model functionality for saving the boundary, but I would have preferred to do it closer to the edge--i.e. in the view or serializer rather than way down in the model.  But there are a bunch of steps in between, and to pass an `override` parameter or the like all the way through would require customizing each of them.  The `FileField` object already works as part of the standard setup, so using a property of that means we don't have to change anything but the condition where it's actually relevant.  So that seemed like a win, despite the fact that it's not super direct and it relies on a `_committed` property on the `FileField`.
- This is meant for fixing errors before any analysis jobs have been run or for making small tweaks to a boundary.  Totally transforming a neighborhood with an existing analysis job would work partly--much of the analysis outputs are written to S3 and keyed by ID, so they wouldn't be affected by a change in the geometry--but it would also break partly, e.g. the map will start in the new location but the tiles and features will all be for the old location.  It would be tricky to validate against this, and it doesn't seem like a likely enough scenario to try.

## Testing Instructions

- Create a neighborhood.  It should work the same as before.
- Click to edit your new neighborhood. It'll have the map preview for the geometry you just gave it.
- Click the "Choose File" button and pick a different geometry file.  Click "Save Changes".
- Click the edit button again for the same neighborhood.  You should now see the new geometry on the preview map.
- Change something else but don't upload a new file.  Saving should work, and when you click back to the instance it should show your changes and its most recent geometry.

## Checklist

- [x] Add entry to CHANGELOG.md
