### PR TITLE
Update LODES data retrieval to latest available (2017/2016)

### DIFF
--- a/src/analysis/import/import_jobs.sh
+++ b/src/analysis/import/import_jobs.sh
@@ -45,7 +45,7 @@ function import_job_data() {
 
     NB_STATE_ABBREV="${1}"
     NB_DATA_TYPE="${2:-main}"    # Either 'main' or 'aux'
-    NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2014.csv"
+    NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2017.csv"
 
     if [ -f "/data/${NB_JOB_FILENAME}.gz" ]; then
         JOB_DOWNLOAD="/data/${NB_JOB_FILENAME}.gz"
@@ -59,9 +59,9 @@ function import_job_data() {
         WGET_STATUS=$?
         set -e
         if [[ $WGET_STATUS -eq 8 ]]; then
-            echo "No 2014 job data available, falling back to 2013 data..."
+            echo "No 2017 job data available, falling back to 2016 data..."
             JOB_DOWNLOAD="${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz"
-            NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2013.csv"
+            NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2016.csv"
             wget -nv -O "${JOB_DOWNLOAD}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
         fi
     fi


### PR DESCRIPTION
## Overview

The BNA retrieves 2014 LODES data from the Census (2013 data if 2014 is not available for a state). 2017 or 2016 data are now available for all states, so this PR updates the data retrieval to use the latest data available for each state.

## Notes

The LODES automated data retrieval has failed frequently lately in testing, apparently due to problems on the Census Bureau's end. When the data is manually downloaded and provided to the BNA it runs fine.

## Testing Instructions

 * Run BNA for any U.S. state.
 * For all U.S. states except Alaska and South Dakota, analysis will proceed as usual and produce Employment score at finish.
 * For Alaska and South Dakota, analysis will fail to find 2017 data and will instead default to downloading 2016 data, then proceed as usual.
