### PR TITLE
Expand bicycle permissions accepted

### DIFF
--- a/src/analysis/features/functional_class.sql
+++ b/src/analysis/features/functional_class.sql
@@ -50,7 +50,7 @@ SET     functional_class = 'path'
 FROM    neighborhood_osm_full_line osm
 WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway = 'footway'
-AND     osm.bicycle = 'designated'
+AND     osm.bicycle IN ('yes','permissive', 'designated')
 AND     (osm.access IS NULL OR osm.access NOT IN ('no','private'))
 AND     COALESCE(width_ft,0) >= 8;
 
@@ -59,7 +59,7 @@ SET     functional_class = 'path'
 FROM    neighborhood_osm_full_line osm
 WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway='service'
-AND     osm.bicycle='designated';
+AND     osm.bicycle IN ('yes','permissive', 'designated');
 
 UPDATE  neighborhood_ways
 SET     functional_class = 'living_street'


### PR DESCRIPTION
## Overview

Currently, service roads and footways are labeled as bike paths in the BNA if they have the tag "bicycle=designated." If they do not have that tag they are not considered bikeable ways, i.e. neither high nor low stress. This PR adds "yes" and "permissive" to the acceptable values for the "bicycle" tag, enabling a wider range of ways to be considered bike paths and aligning with the acceptable values for the "living street" functional class. This change ensures designated bikeways that are also service roads or footways are not excluded from the analysis. As before, if service roads and footways do not have any "bicycle" tag at all they are excluded from the network.

### Demo

![image](https://user-images.githubusercontent.com/13860074/71039221-e0881800-20e0-11ea-8505-52ebf97280dc.png)
BNA results for Madison, Wisconsin show a lakefront path ending abruptly. 

![image](https://user-images.githubusercontent.com/13860074/71039272-fac1f600-20e0-11ea-8a86-7fe9b6051336.png)
When the "bicycle=yes" tag is allowed, the path becomes a continuous connection to the rest of the Madison street network. Before, the connection was left out of network because it is a service road and did not have the "bicycle=designated" tag.

The same segment styled as a bike path also illustrates the change:

![image](https://user-images.githubusercontent.com/13860074/71039391-47a5cc80-20e1-11ea-8104-afe1a8123795.png)
Before

![image](https://user-images.githubusercontent.com/13860074/71039370-3bba0a80-20e1-11ea-8f8e-4c56d3c2fbaf.png)
After

## Notes

I tried to incorporate a similar change last year in #690 but only for service roads. However we ran out of time to incorporate the change.

## Testing Instructions

 * Identify service road or footway with "bicycle=yes" or "bicycle=permissive" tag.
 * Run analysis without expanded permissions. Footway or service road should not appear in the network map.
 * Run analysis with expanded permissions.
 * Compare results. Footway or service road should become visible as a low-stress way in the network  map and as a bike path in the infrastructure map.
