### PR TITLE
Switch to psycopg2-binary to resolve build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Changed
+- Upgraded Django and psycopg2 package versions and switched to psycopg2-binary
+
 ## [0.12.0] - 2019-12-30
 
 #### Added

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,8 +1,8 @@
 # Django and psycopg2 are included in the django base container but repeated here
 # so that the analysis container will know to install them. These should be kept
 # in sync with the versions in the base container.
-Django==2.2.8
-psycopg2==2.8.3
+Django==2.2.9
+psycopg2-binary==2.8.4
 
 boto3==1.9.224
 django-amazon-ses==2.1.1


### PR DESCRIPTION
## Overview

The CI build of develop [started failing after release 0.12.0](http://urbanappsci.internal.azavea.com/job/azavea/job/pfb-network-connectivity/job/develop/355/).

It's saying "pg_config executable not found." and "pg_config is required to build psycopg2 from source."

I'm not sure why this is coming up now, since the requirements file hasn't been changed since the last successful `develop` builds.  But here we are.

The error message also says "If you prefer to avoid building psycopg2 from source, please install the PyPI 'psycopg2-binary' package instead."  So I switched to that.

I also bumped the patch versions of Django and psycopg2 by 1 (to 2.2.9 and 2.8.4, respectively), since there's no reason not to and [the Django fix](https://docs.djangoproject.com/en/2.2/releases/2.2.9/), at least, seems worth having.

### Notes

- Since the deployment went fine, I don't think there's any need to make a new release for this. But it seemed worth the trouble to not leave `develop` in a state where CI isn't working and it won't build successfully from scratch.

## Testing Instructions

- Running `docker-compose build --pull --no-cache django` in the VM will fail on current `develop` but work on this branch.

## Checklist

- [x] Add entry to CHANGELOG.md
