### PR TITLE
Lanes

### DIFF
--- a/src/analysis/features/lanes.sql
+++ b/src/analysis/features/lanes.sql
@@ -15,7 +15,7 @@ SET     ft_lanes =
                                     ),
                                     1       -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'ft'
+                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    array_length(
                                     regexp_split_to_array(
                                         osm."turn:lanes",
@@ -25,9 +25,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:forward" IS NOT NULL
                         THEN    substring(osm."lanes:forward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way_car = 'ft'
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
+                    WHEN osm."lanes" IS NOT NULL AND (osm."oneway" IS NULL OR osm."oneway" = 'no')
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         tf_lanes =
@@ -39,7 +39,7 @@ SET     ft_lanes =
                                             ),
                                             1       -- only one dimension
                                         )
-                            WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'tf'
+                            WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" = '-1'
                                 THEN    array_length(
                                             regexp_split_to_array(
                                                 osm."turn:lanes",
@@ -49,9 +49,9 @@ SET     ft_lanes =
                                         )
                             WHEN osm."lanes:backward" IS NOT NULL
                                 THEN    substring(osm."lanes:backward" FROM '\d+')::INT
-                            WHEN osm."lanes" IS NOT NULL AND one_way_car = 'tf'
+                            WHEN osm."lanes" IS NOT NULL AND osm."oneway" = '-1'
                                 THEN    substring(osm."lanes" FROM '\d+')::INT
-                            WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
+                            WHEN osm."lanes" IS NOT NULL AND (osm."oneway" IS NULL OR osm."oneway" = 'no')
                                 THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                             END,
         ft_cross_lanes =
@@ -66,7 +66,7 @@ SET     ft_lanes =
                                     ),
                                     1               -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'ft'
+                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    array_length(
                                     array_remove(
                                         regexp_split_to_array(
@@ -79,9 +79,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:forward" IS NOT NULL
                         THEN    substring(osm."lanes:forward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way_car = 'ft'
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" IN ('1', 'yes')
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
+                    WHEN osm."lanes" IS NOT NULL AND (osm."oneway" IS NULL OR osm."oneway" = 'no')
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         tf_cross_lanes =
@@ -96,7 +96,7 @@ SET     ft_lanes =
                                     ),
                                     1               -- only one dimension
                                 )
-                    WHEN osm."turn:lanes" IS NOT NULL AND one_way_car = 'tf'
+                    WHEN osm."turn:lanes" IS NOT NULL AND osm."oneway" = '-1'
                         THEN    array_length(
                                     array_remove(
                                         regexp_split_to_array(
@@ -109,9 +109,9 @@ SET     ft_lanes =
                                 )
                     WHEN osm."lanes:backward" IS NOT NULL
                         THEN    substring(osm."lanes:backward" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way_car = 'tf'
+                    WHEN osm."lanes" IS NOT NULL AND osm."oneway" = '-1'
                         THEN    substring(osm."lanes" FROM '\d+')::INT
-                    WHEN osm."lanes" IS NOT NULL AND one_way_car = NULL
+                    WHEN osm."lanes" IS NOT NULL AND (osm."oneway" IS NULL OR osm."oneway" = 'no')
                         THEN    ceil(substring(osm."lanes" FROM '\d+')::FLOAT / 2)
                     END,
         twltl_cross_lanes =

--- a/src/analysis/stress/stress_segments_higher_order.sql
+++ b/src/analysis/stress/stress_segments_higher_order.sql
@@ -79,7 +79,7 @@ SET     ft_seg_stress =
                                     WHEN COALESCE(speed_limit,:default_speed) < 30 THEN 1
                                     ELSE 3
                                     END
-                        WHEN COALESCE(ft_bike_infra_width,:default_facility_width) + :default_parking_width >= 13   -- treat as bike lane with no parking
+                        WHEN COALESCE(ft_bike_infra_width,:default_facility_width) + :default_parking_width >= 12.9   -- treat as bike lane with no parking
                             THEN    CASE
                                     WHEN COALESCE(speed_limit,:default_speed) > 30 THEN 3
                                     WHEN COALESCE(speed_limit,:default_speed) = 30
@@ -171,7 +171,7 @@ SET     ft_seg_stress =
                                     WHEN COALESCE(speed_limit,:default_speed) < 30 THEN 1
                                     ELSE 3
                                     END
-                        WHEN COALESCE(tf_bike_infra_width,:default_facility_width) + :default_parking_width >= 13   -- treat as bike lane with no parking
+                        WHEN COALESCE(tf_bike_infra_width,:default_facility_width) + :default_parking_width >= 12.9   -- treat as bike lane with no parking
                             THEN    CASE
                                     WHEN COALESCE(speed_limit,:default_speed) > 30 THEN 3
                                     WHEN COALESCE(speed_limit,:default_speed) = 30


### PR DESCRIPTION
## Overview

This PR accomplishes two objectives:
1. Correcting the lanes.sql script to accommodate all likely values for the "oneway" OSM tag including 1, yes, no, -1, and NULL. This script was edited last year in #682 but that solution was only a partial fix ultimately. This solution should be a complete fix.
2. Reducing the width requirement in feet for certain infrastructure and parking combinations in order to accommodate metric entries. 1.5 meters converts to 4.9 feet, which can result in a facility + parking width of 12.9 feet (less than the required 13 feet). 1.5 meters should be an acceptable lane width so this change provides leeway for that conversion. 

### Demo

1. The changes to the lanes.sql script in 2019 corrected errors in the evaluation of oneway streets as described in #586. However, it created new errors in the interpretation of lane counts. The error is visible in Bradford Street Extension in Provincetown, MA. In the current BNA results, Bradford Street Extension has no lane counts listed in the TF_Lanes and FT_Lanes columns despite that a lane count was entered in the "lanes" tag in OSM at the time of the analysis. Using the revised lanes.sql script, the lane count appears in the TF_Lanes and FT_Lanes columns, and the street rating changes to low stress.

2. Moors Road in Provincetown, MA has a bike lane that is entered as 1.5 m wide in OSM. In the current BNA results this road rates as high stress. With the changes implemented here, Moors Road is low stress.

Original:
![image](https://user-images.githubusercontent.com/13860074/72849829-dd92c100-3c64-11ea-908e-35f99e734e81.png)

Revised:
![image](https://user-images.githubusercontent.com/13860074/72850090-83463000-3c65-11ea-8332-cf083aefdc8a.png)

## Testing Instructions

 * Run BNA for Provincetown, MA using current and revised versions of lanes.sql script. 
 * Compare output for Bradford St Ext. and Moors Road using both versions.
 * Any other BNA results including streets with a value in the "lanes" tag could be used to evaluate objective 1. Examples of bike lanes entered in meters are rare so objective 2 is harder to evaluate across cities.