### PR TITLE
Revise calculation of population scores for destinations

### DIFF
--- a/src/analysis/connectivity/access_colleges.sql
+++ b/src/analysis/connectivity/access_colleges.sql
@@ -67,19 +67,25 @@ SET     colleges_score =    CASE
 -- set population shed for each college in the neighborhood
 UPDATE  neighborhood_colleges
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_colleges.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_colleges.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_colleges.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_colleges.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_community_centers.sql
+++ b/src/analysis/connectivity/access_community_centers.sql
@@ -67,19 +67,25 @@ SET     community_centers_score =   CASE
 -- set population shed for each community center in the neighborhood
 UPDATE  neighborhood_community_centers
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_community_centers.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_community_centers.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_community_centers.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_community_centers.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_dentists.sql
+++ b/src/analysis/connectivity/access_dentists.sql
@@ -67,19 +67,25 @@ SET     dentists_score =    CASE
 -- set population shed for each dentists destination in the neighborhood
 UPDATE  neighborhood_dentists
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_dentists.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_dentists.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_dentists.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_dentists.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_doctors.sql
+++ b/src/analysis/connectivity/access_doctors.sql
@@ -67,19 +67,25 @@ SET     doctors_score = CASE
 -- set population shed for each doctors destination in the neighborhood
 UPDATE  neighborhood_doctors
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_doctors.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_doctors.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_doctors.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_doctors.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_hospitals.sql
+++ b/src/analysis/connectivity/access_hospitals.sql
@@ -67,19 +67,25 @@ SET     hospitals_score =   CASE
 -- set population shed for each hospitals destination in the neighborhood
 UPDATE  neighborhood_hospitals
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_hospitals.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_hospitals.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_hospitals.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_hospitals.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_pharmacies.sql
+++ b/src/analysis/connectivity/access_pharmacies.sql
@@ -67,19 +67,25 @@ SET     pharmacies_score =  CASE
 -- set population shed for each pharmacies destination in the neighborhood
 UPDATE  neighborhood_pharmacies
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_pharmacies.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_pharmacies.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_pharmacies.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_pharmacies.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_retail.sql
+++ b/src/analysis/connectivity/access_retail.sql
@@ -67,19 +67,25 @@ SET     retail_score =  CASE
 -- set population shed for each retail destination in the neighborhood
 UPDATE  neighborhood_retail
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_retail.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_retail.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_retail.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_retail.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_schools.sql
+++ b/src/analysis/connectivity/access_schools.sql
@@ -67,19 +67,25 @@ SET     schools_score = CASE
 -- set population shed for each school in the neighborhood
 UPDATE  neighborhood_schools
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_schools.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_schools.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_schools.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_schools.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_social_services.sql
+++ b/src/analysis/connectivity/access_social_services.sql
@@ -67,19 +67,25 @@ SET     social_services_score = CASE
 -- set population shed for each social service destination in the neighborhood
 UPDATE  neighborhood_social_services
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_social_services.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_social_services.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_social_services.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_social_services.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_supermarkets.sql
+++ b/src/analysis/connectivity/access_supermarkets.sql
@@ -67,19 +67,25 @@ SET     supermarkets_score =    CASE
 -- set population shed for each supermarket in the neighborhood
 UPDATE  neighborhood_supermarkets
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_supermarkets.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_supermarkets.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_supermarkets.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_supermarkets.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_transit.sql
+++ b/src/analysis/connectivity/access_transit.sql
@@ -67,19 +67,25 @@ SET     transit_score =   CASE
 -- set population shed for each park in the neighborhood
 UPDATE  neighborhood_transit
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_transit.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_transit.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_transit.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_transit.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1

--- a/src/analysis/connectivity/access_universities.sql
+++ b/src/analysis/connectivity/access_universities.sql
@@ -67,19 +67,25 @@ SET     universities_score =    CASE
 -- set population shed for each university in the neighborhood
 UPDATE  neighborhood_universities
 SET     pop_high_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_universities.blockid10)
+            SELECT  SUM(shed.pop)
+            FROM    ( 
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop 
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_universities.blockid10)
+                    GROUP BY cb.blockid10) as shed
         ),
         pop_low_stress = (
-            SELECT  SUM(cb.pop10)
-            FROM    neighborhood_census_blocks cb,
-                    neighborhood_connected_census_blocks cbs
-            WHERE   cbs.source_blockid10 = cb.blockid10
-            AND     cbs.target_blockid10 = ANY(neighborhood_universities.blockid10)
-            AND     cbs.low_stress
+            SELECT  SUM(shed.pop)
+            FROM    (
+                    SELECT  cb.blockid10, MAX(cb.pop10) as pop
+                    FROM    neighborhood_census_blocks cb,
+                            neighborhood_connected_census_blocks cbs
+                    WHERE   cbs.source_blockid10 = cb.blockid10
+                    AND     cbs.target_blockid10 = ANY(neighborhood_universities.blockid10)
+                    AND     cbs.low_stress
+                    GROUP BY cb.blockid10) as shed
         )
 WHERE   EXISTS (
             SELECT  1


### PR DESCRIPTION
## Overview

When the user clicks on a destination in the BNA map "pop low stress," "pop high stress," and "pop score" values appear in the pop-up. For destinations retrieved from OSM as points (single nodes) residing within a single census block area, these values are accurate. For destinations retrieved from OSM as polygons that overlap multiple census blocks, these values are inaccurate. For single block destinations these values are accurate because they sum the population in all blocks within the bikeshed. For multi-block destinations these values are incorrect because they repeat the summation of the bikeshed population for every destination block without distinguishing between blocks that have already been counted. In the fixes implemented here, only the population of each **unique** block in the bikeshed for all of the destination blocks is summed.

### Demo

Running the BNA for the Algiers region of New Orleans and selecting the destination in the Universities output, University of the Holy Cross, gives a pop_low_stress score of 5609, pop_high_stress score of 248036, and a pop_score of 0.0226. The pop_high_stress score is clearly too high because the population of the Algiers region is only 51755 and the population of all of New Orleans is only 345392. Using the corrected access_universities.sql script included here, pop_low_stress=4463, pop_high_stress=34097, and pop_score=0.13. As another point of comparison, University of the Holy Cross is also tagged as a school as a single node destination in close proximity to the university tag and the pop_high_stress value for that destination is 31164. 

Original:
![image](https://user-images.githubusercontent.com/13860074/72852478-d91dd680-3c6b-11ea-84a7-5ee0c2f225c7.png)

Revised:
![image](https://user-images.githubusercontent.com/13860074/72852674-8abd0780-3c6c-11ea-98e4-473f5b68d95b.png)

### Notes

The same changes has been applied to all destinations retrieved as points or polygons from OSM: 
* colleges
* community centers
* dentists
* doctors
* hospitals
* parks
* pharmacies
* retail
* schools
* social services
* supermarkets
* transit 
* universities

## Testing Instructions

 * Run BNA with and without these changes for a sample city.
 * Compare destination pop scores for all destination types listed above, particularly for multi-polygon destinations. 
 * The output for single census block destinations should not differ. The output for destinations covering multiple census blocks will be different in most cases, and accurate.
