### PR TITLE
Upgrade ansible-docker, Docker, and Docker Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Changed
 - Upgraded Django and psycopg2 package versions and switched to psycopg2-binary
+- Upgraded ansible-docker module to 5.0.0, Docker to 18.*, and Docker Compose to 1.23.*
 - Fix lane handling in analysis
 - Fix population scores for destinations in analysis
 - Add favicon

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -8,10 +8,9 @@ pfb_aws_batch_analysis_job_queue_name: "name_of_batch_analysis_job_queue"
 pfb_aws_batch_analysis_job_definition_name: "staging-pfb-analysis-run-job"
 
 # azavea.docker
-# 1.12.* to match AWS ECS
-docker_version: 1.12.*
+docker_version: 18.*
 docker_options: "--storage-opt dm.basesize=20G"
-docker_compose_version: 1.9.0
+docker_compose_version: 1.23.*
 
 # azavea.terraform
 terraform_version: 0.9.3

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,6 +1,6 @@
 - src: azavea.aws-cli
   version: 0.1.0
 - src: azavea.docker
-  version: 3.0.0
+  version: 5.0.0
 - src: azavea.terraform
   version: 0.3.1


### PR DESCRIPTION
## Overview

Upgrades the [Ansible Docker](https://github.com/azavea/ansible-docker) module to `5.0.0`, which uses the [non-deprecated `download.docker.com` repository URL](https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/). Also upgrades Docker to `18.*`, the latest version available in the main repo and the version currently running on ECS; and Docker Compose to `1.23.*`, the latest version that will work with the current VM configuration.


### Notes

I upgraded Docker Compose to `1.23.*`, which is not the most recent version. Upgrading to `1.24.*` or `1.25.*` resulted in a segmentation fault for any subsequent step. I didn't dig very far into the root cause of this problem and instead created #799 to track it.


## Testing Instructions

 * Run `scripts/setup` and verify that VM is created successfully.
* Run `vagrant ssh` to SSH into VM.
* Run `scripts/update` to build Docker images.
* Run `scripts/test` and verify that all tests pass.


## Checklist

- [x] Add entry to CHANGELOG.md

Connects #798 
