### PR TITLE
Minor change to README to clarify run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ aws s3api put-bucket-policy --bucket "${DEV_USER}-pfb-storage-us-east-1" --polic
 
 At this point, if you only intend to run the 'Bike Network Analysis', skip directly to [Running the Analysis](#running-the-analysis)
 
-To start the application containers:
+To start the application containers (from within the Vagrant VM):
 ```
 ./scripts/server
 ```


### PR DESCRIPTION
Update README to indicate that the `./scripts/server` command should be run within the Vagrant VM

## Overview

Update README.md to clarify that the `./scripts/server' command must be run within the Vagrant VM.


### Demo

See [README.md](https://github.com/azavea/pfb-network-connectivity/blob/feature/ked/update-readme-run-instructions/README.md)


## Testing Instructions

N/A


## Checklist

- [ ] Add entry to CHANGELOG.md
