### PR TITLE
Upgrade Django and psycopg2 to match base container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Added
 - S3 caching of Census data files
+- Upgrade Django (2.2.10 -> 2.2.16) and psycopg2 (2.8.4 -> 2.8.5)
 
 ## [0.13.0] - 2020-02-14
 

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,8 +1,11 @@
-# Django and psycopg2 are included in the django base container but repeated here
-# so that the analysis container will know to install them. These should be kept
-# in sync with the versions in the base container.
-Django==2.2.10
-psycopg2-binary==2.8.4
+# Django and psycopg2 are included in the django base container, but the analysis
+# container also needs them, and uses this same requirements file.
+# Which means the versions here will be the ones that get installed, in both places.
+# Ideally these should be kept in sync with the versions in the base container
+# (https://github.com/azavea/docker-django/blob/master/2.2/requirements.txt) to avoid
+# downgrading when building the django container.
+Django==2.2.16
+psycopg2-binary==2.8.5
 
 boto3==1.9.224
 django-amazon-ses==2.1.1


### PR DESCRIPTION
## Overview

The base container has gotten some patch version upgrades and dependabot is saying we should upgrade Django. Staying in sync with the base container isn't strictly necessary, but seems like a good plan. So this does that, and adjusts the comment in the requirements file to better describe the situation.

This is lieu of PR #803.

## Testing Instructions

- Run `./scripts/update` to rebuild the containers then `./scripts/server` and make sure the app still works.
- That's probably about as far as we need to go for moving this relatively simple Django app up a few patch versions.

## Checklist

- [x] Add entry to CHANGELOG.md

