### PR TITLE
Remove filters for created_by, modified_by and fips_code for Analysis Batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Changed
 - Add filter to Neighborhood List
+- Remove filters for created_by, modified_by and fips_code for matching an AnalysisJob to existing Neighborhood records
 
 #### Added
 - S3 caching of Census data files

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Requirements:
 #### Notes for non-Windows users
 
 1. An NFS daemon must be running on the host machine. This should be enabled by default on MacOS. Linux computers may require the installation of an additional package such as nfs-kernel-server on Ubuntu.
+2. For some commands (e.g., `./scripts/test`), you may need to add the ENV variable `PFB_SHARED_FOLDER_TYPE=virtualbox` for the shared folders to work as expected with Django. 
 
 ### Setting up AWS credentials
 


### PR DESCRIPTION
## Overview

Ensure that neighborhoods created as part of an AnalysisBatch job are matched with existing neighborhoods, even if they were created by a different user within the organization or if they don't have a fips_code that matches with the existing neighborhood's fips_code. Neighborhoods are now only matched on the fields defined in [unique_together](https://github.com/azavea/pfb-network-connectivity/blob/af9fc26510dfea0ebe806ba5ebc26b952dd55527/src/django/pfb_analysis/models.py#L332). Test cases added to validate AnalysisBatch neighborhood matching logic.

### Demo

N/A


### Notes

I'm running into some issues running `./scripts/test` locally, but I am _hopeful_ that the test cases will work as written. I'm continuing to troubleshoot this on my end - I have attached the output logs of this command here for review in case someone is able to assist in rectifying the issue here.


## Testing Instructions

Path 1 (admin frontend)
 * Reload the servers with 
* `vagrant ssh` then `./scripts/update` and `./scripts/server`
 * Create a batch upload AnalysisJob from the admin frontend while logged in as the systems-pfb@azavea.com user
 * Create another user and log in as the newly created user
 * Create another batch upload AnalysisJob as the newly created user using the same shapefile - there should not be any new neighborhoods created as part of this second AnalysisJob

Path 2 (Django test suite)
* `vagrant ssh` then `./scripts/update`
* Run ./scripts/test

## Checklist

- [ x ] Add entry to CHANGELOG.md

Resolves #795 

[django_test.log](https://github.com/azavea/pfb-network-connectivity/files/5513573/django_test.log)
