### PR TITLE
Update LODES data urls to read 2018 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Changed
+- Update LODES data url to load 2018 data in analysis
+
 ## [0.14.0] - 2020-12-21
 
 #### Changed

--- a/src/analysis/import/import_jobs.sh
+++ b/src/analysis/import/import_jobs.sh
@@ -46,7 +46,7 @@ function import_job_data() {
     NB_STATE_ABBREV="${1}"
     NB_DATA_TYPE="${2:-main}"    # Either 'main' or 'aux'
 
-    NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2017.csv"
+    NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2018.csv"
     S3_PATH="s3://${AWS_STORAGE_BUCKET_NAME}/data/${NB_JOB_FILENAME}.gz"
 
     if [ -f "/data/${NB_JOB_FILENAME}.gz" ]; then
@@ -62,9 +62,9 @@ function import_job_data() {
         wget -nv -O "${JOB_DOWNLOAD}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
         WGET_STATUS=$?
         set -e
-        # If the 2017 file isn't there (SD and AK), do the check/download/cache again for 2016
+        # If the 2018 file isn't there (SD and AK), do the check/download/cache again for 2016
         if [[ $WGET_STATUS -eq 8 ]]; then
-            echo "No 2017 job data available, falling back to 2016 data..."
+            echo "No 2018 job data available, falling back to 2016 data..."
             NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2016.csv"
             S3_PATH="s3://${AWS_STORAGE_BUCKET_NAME}/data/${NB_JOB_FILENAME}.gz"
             JOB_DOWNLOAD="${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz"


### PR DESCRIPTION
## Overview

Updates the LODES data url in the PFB analysis scripts to pull from 2018 data instead of 2017 data. LODES data should fall back to 2016 if 2018 data is not available.


### Demo

N/A

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * `./scripts/update`
 * Create a new analysis job for an existing neighborhood in the UI
 * Run the newly created analysis locally
 * Expect to receive a message in stdout indicating that 2018 jobs data has been loaded:
 
" Downloaded job data file /tmp/tmp.8FTDP8Bevp/import_jobs/co_od_main_JT00_2018.csv.gz from S3"


## Checklist

- [ x ] Add entry to CHANGELOG.md

Resolves #825 
