### PR TITLE
Fix pip installation and remove azavea.pip ansible role

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ PFB Bicycle Network Connectivity
 ## Getting Started
 
 Requirements:
-- Vagrant 1.8.3+
-- VirtualBox 4.3+
+- Vagrant 2.2.6+
+- VirtualBox 5.2+
 - [AWS CLI](https://aws.amazon.com/cli/)
 
 #### Notes for Windows users

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,9 +55,10 @@ Vagrant.configure("2") do |config|
                              "dev_user=#{ENV.fetch("USER", "vagrant")}"]
 
     # local arguments
-    # Ubuntu base box already has system python + pip installed, no need to reinstall here
     ansible.install = true
     ansible.install_mode = "pip"
+    # Install pip3 for the system version of python3, and make sure 'pip3' works as well
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/3.5/get-pip.py | sudo python3 && sudo ln -s -f /usr/local/bin/pip /usr/local/bin/pip3"
     ansible.version = "2.8.7"
   end
 

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -1,4 +1,5 @@
 ---
+ansible_python_interpreter: "/usr/bin/python3"
 
 # PFB env settings
 aws_profile: pfb

--- a/deployment/ansible/pfb.yml
+++ b/deployment/ansible/pfb.yml
@@ -7,8 +7,8 @@
       apt: update_cache=yes
 
   roles:
-    - { role: "azavea.aws-cli" }
     - { role: "azavea.terraform" }
+    - { role: "pfb.aws-cli" }
     - { role: "pfb.env" }
     - { role: "pfb.docker" }
     - { role: "pfb.boto3" }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,3 @@
-- src: azavea.aws-cli
-  version: 0.1.0
 - src: azavea.docker
   version: 5.0.0
 - src: azavea.terraform

--- a/deployment/ansible/roles/pfb.aws-cli/defaults/main.yml
+++ b/deployment/ansible/roles/pfb.aws-cli/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+aws_cli_version: 1.18.219

--- a/deployment/ansible/roles/pfb.aws-cli/tasks/main.yml
+++ b/deployment/ansible/roles/pfb.aws-cli/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Install AWS Command Line Interface
+  pip: name=awscli version="{{ aws_cli_version }}"


### PR DESCRIPTION
## Overview

The URL of the 'get-pip.py' script now has a version number, which broke provisioning. In two places, actually, since we need pip at the very beginning to install Ansible inside the VM, then we also had the Azavea `pip` role being used by the Azavea `aws-cli` role.

Having a second place where we install `pip`, especially one that's very simple but not very actively maintained, isn't worth it. So this clones the `aws-cli` role into a local role and drops the dependency on the `pip` role. Since `pip` is installed in the Vagrantfile provisioning, it will always be there.

Also, Ansible still wants to use Python 2 by default, but that's no good. Not that the VM is a user-facing environment, but we already upgraded most of this project and it doesn't make sense to keep using Python 2 if we don't have to. This makes sure Ansible and the AWS CLI both get installed in Python 3.

### Notes

- I had planned to roll upgrading the AWS CLI for issue #823 into this, since I was already changing the role that installs it, but I backtracked on that since there's no PyPI package for AWS CLI v2, so switching to that will require a more substantial change, not to mention the need to look for places where breaking changes could affect us.
- UPDATE: I originally said this would reprovision an existing VM without issues, but actually with the `ansible_python_interpreter` group var in place it crashes because it can't find `pip3` to check whether `awscli` is installed. I don't know of a way to get the pip installation in the Vagrantfile to re-run. It's possible to work around this and preserve an existing VM by manually installing `pip3`, i.e. `vagrant ssh -c "sudo apt-get install -y python3-pip"`

## Testing Instructions

- UPDATE: copy the new line (`ansible_python_interpreter: "/usr/bin/python3"`) from `deployment/ansible/group_vars/all.example` to `deployment/ansible/group_vars/all`
- ~Running `provision` again on an existing VM should work with these changes, but they mostly won't actually take effect.  The `ansible_local` section in the `Vagrantfile` will detect that Ansible is already installed, so it won't try to install it again, and the `aws-cli` role will upgrade the version, but using the existing `pip`, which is Python 2.  But that's fine.~ UPDATE: see note above.

- If you do `vagrant destroy` and build the VM again, it should now be free of pesky crashes.
- If you ssh into the new VM, you should find that `pip` and `aws` both use `/usr/bin/python3`, which is Python 3.5.
- Once the VM is up, running `./scripts/update` and `./scripts/server` inside it should work as before.

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #827
