### PR TITLE
Fix docker login command in `cipublish` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Changed
 - Update LODES data url to load 2018 data in analysis
+- Upgrade AWS CLI to v2 and update syntax in `cipublish` script 
+
 
 ## [0.14.0] - 2020-12-21
 

--- a/deployment/ansible/pfb.yml
+++ b/deployment/ansible/pfb.yml
@@ -8,7 +8,7 @@
 
   roles:
     - { role: "azavea.terraform" }
-    - { role: "pfb.aws-cli" }
+    - { role: "pfb.aws-cli2" }
     - { role: "pfb.env" }
     - { role: "pfb.docker" }
     - { role: "pfb.boto3" }

--- a/deployment/ansible/roles/pfb.aws-cli/defaults/main.yml
+++ b/deployment/ansible/roles/pfb.aws-cli/defaults/main.yml
@@ -1,3 +1,0 @@
----
-
-aws_cli_version: 1.18.219

--- a/deployment/ansible/roles/pfb.aws-cli/tasks/main.yml
+++ b/deployment/ansible/roles/pfb.aws-cli/tasks/main.yml
@@ -1,3 +1,0 @@
----
-- name: Install AWS Command Line Interface
-  pip: name=awscli version="{{ aws_cli_version }}"

--- a/deployment/ansible/roles/pfb.aws-cli2/defaults/main.yml
+++ b/deployment/ansible/roles/pfb.aws-cli2/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+aws_cli_version: 2.1.24

--- a/deployment/ansible/roles/pfb.aws-cli2/tasks/main.yml
+++ b/deployment/ansible/roles/pfb.aws-cli2/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Download awscliv2 installer.
+  unarchive:
+    src: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{{ aws_cli_version }}.zip"
+    dest: "{{ executable_temp_dir | default('/tmp') }}"
+    remote_src: yes
+    creates: /tmp/aws
+    mode: 0755
+
+- name: Run the installer.
+  command:
+  args:
+    cmd: "{{ executable_temp_dir | default('/tmp') }}/aws/install"
+    creates: /usr/local/bin/aws
+  become: true
+  register: aws_install
+
+- name: "Show installer output."
+  debug:
+    var: aws_install
+    verbosity: 2

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -31,7 +31,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         if [[ -n "${PFB_AWS_ECR_ENDPOINT}" ]]; then
             # Evaluate the return value of the get-login subcommand, which
             # is a docker login command with temporarily ECR credentials.
-            eval "$(aws ecr get-login)"
+            docker login -u AWS -p "$(aws ecr get-login-password)" "${PFB_AWS_ECR_ENDPOINT}"
 
             docker tag "pfb-nginx:${GIT_COMMIT}" \
                    "${PFB_AWS_ECR_ENDPOINT}/pfb-nginx:${GIT_COMMIT}"


### PR DESCRIPTION
## Overview

- Create AWS cli ansible task to install aws cli 2
- Update aws login command in `cipublish` script to use AWS cli v2


## Testing Instructions

 * `./scripts/update`
 * SSH into the vm, then
 * `export GIT_COMMIT="export GIT_COMMIT=$(git rev-parse --short HEAD)"`
 * `export ENVIRONMENT="staging|production"`
 * `export PFB_AWS_ECR_ENDPOINT="950872791630.dkr.ecr.us-east-1.amazonaws.com"`
* `./scripts/cibuild`
* `./scripts/cipublish`

## Checklist

- [ x ] Add entry to CHANGELOG.md

Resolves #823 
