### PR TITLE
Handle NULL values in city_fips column in batch shapefiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update LODES data url to load 2018 data in analysis
 - Upgrade AWS CLI to v2 and update syntax in `cipublish` script 
 - Update BNA logo with updated 2021 design
+- Add check for null city_fips values in batch upload
 
 ## [0.14.0] - 2020-12-21
 

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -387,11 +387,15 @@ class AnalysisBatchManager(models.Manager):
                 city = feature['properties']['city']
                 state = feature['properties']['state']
                 city_fips = feature['properties'].get('city_fips', '')
+                # Handle NULL values in the city_fips property, which aren't allowed in the model
+                if city_fips is None:
+                    city_fips = ''
                 osm_extract_url = feature['properties'].get('osm_url', None)
                 label = city
                 name = Neighborhood.name_for_label(label)
 
-                # Get or create neighborhood for feature using fields in Neighborhood `unique_together` clause
+                # Get or create neighborhood for feature using only the fields in the
+                # Neighborhood `unique_together` constraint
                 neighborhood_dict = {
                     'name': name,
                     'label': label,
@@ -412,7 +416,7 @@ class AnalysisBatchManager(models.Manager):
 
                 neighborhood.set_boundary_file(geom)
 
-                # Update neighborhood record with provided fields not included in `unique_together` clause
+                # Update neighborhood record with provided fields not included in `unique_together`
                 neighborhood.city_fips = city_fips
                 neighborhood.modified_by = user
                 neighborhood.save()


### PR DESCRIPTION
## Overview

In the method that processes batch shapefile uploads, which was updated in PR #814 to look for neighborhoods based on their unique attributes then update their other attributes based on the shapefile, having some neighborhoods with `city_fips` values and some without caused a crash, because the ones without returned `None` as their `city_fips` value, which violates the null constraint of the field.

This adds a check to convert `None` values into empty strings.

Resolves #831

## Testing Instructions

Here's a batch shapefile with one town that has a FIPS code: [WI_and_IA_amesfips.zip](https://github.com/azavea/pfb-network-connectivity/files/5990484/WI_and_IA_amesfips.zip)
The FIPS is 1916900, so if you add a line with that code to your `city_fips_speed.csv` file (download it from `s3://pfb-public-documents/city_fips_speed.csv` if you don't already have one) and run the analysis for Ames, IA, (per the command logged by the batch process), you should see it pick up a city speed limit.
Also, in the admin neighborhood list, the other neighborhoods shouldn't have FIPS codes but Ames, IA, should.

## Checklist

- [x] Add entry to CHANGELOG.md

