### PR TITLE
Increase timeout and decrease retries for Django Q tasks; also fix exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Changed
+- Increase timeout and reduce retries for analysis import tasks
+
 ## [0.15.0] - 2021-02-17
 
 #### Changed

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure("2") do |config|
     ansible.install = true
     ansible.install_mode = "pip"
     # Install pip3 for the system version of python3, and make sure 'pip3' works as well
-    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/3.5/get-pip.py | sudo python3 && sudo ln -s -f /usr/local/bin/pip /usr/local/bin/pip3"
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | sudo python3 && sudo ln -s -f /usr/local/bin/pip /usr/local/bin/pip3"
     ansible.version = "2.8.7"
   end
 

--- a/src/django/pfb_analysis/tasks.py
+++ b/src/django/pfb_analysis/tasks.py
@@ -76,7 +76,7 @@ def upload_local_analysis(local_upload_task_uuid):
         except Exception as ex:
             logging.error('Failed to upload analysis results for task {uuid}'.format(
                 uuid=local_upload_task_uuid))
-            raise LocalAnalysisFetchException(ex.message)
+            raise LocalAnalysisFetchException(ex)
 
     def download_and_extract_local_results(tmpdir, task):
         try:
@@ -99,9 +99,9 @@ def upload_local_analysis(local_upload_task_uuid):
                          uuid=local_upload_task_uuid))
         except Exception as ex:
             msg = 'Failed to fetch analysis results for task {uuid} from {url}: {msg}'.format(
-                uuid=local_upload_task_uuid, url=task.upload_results_url, msg=ex.message)
+                uuid=local_upload_task_uuid, url=task.upload_results_url, msg=str(ex))
             logging.error(msg)
-            raise LocalAnalysisFetchException(ex.message)
+            raise LocalAnalysisFetchException(ex)
 
     try:
         logging.info('Starting local analysis upload task {uuid}'.format(
@@ -141,7 +141,7 @@ def upload_local_analysis(local_upload_task_uuid):
         raise
     except Exception as ex:
         task.status = AnalysisLocalUploadTask.Status.ERROR
-        task.error = ex.message
+        task.error = str(ex)
         task.save()
         if task.job:
             task.job.update_status(AnalysisJob.Status.ERROR)

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -248,7 +248,19 @@ Q_CLUSTER = {
     'name': 'pfb-network-connectivity',
     'workers': 1,
     'recycle': 1,
-    'timeout': 600,
+    # Three hours. It certainly shouldn't take that long, but it can be slow for big files and
+    # failing is a bad option, so we want a big buffer.
+    'timeout': 10800,
+    # 'retry' is another timeout--the time between when a broker delivers a task and when it
+    # gives up on getting a result and delivers it again. It has to be longer than the 'timeout'
+    # value or you'll end up with a 2nd copy of a task added to the queue before the first one
+    # has definitely finished or been killed.
+    'retry': 10860,
+    # The default for 'max_attempts' is 0 which means "keep trying forever". It's not clear if
+    # retrying will ever work after a failure, but there's always the possibility of weird
+    # transient errors, so it's probably worth trying. Too many retries could cause stranded
+    # files to use up disk space, though, so one is enough.
+    'max_attempts': 2,
     'orm': 'default',
     'poll': 5,
     'cpu_affinity': 1


### PR DESCRIPTION
## Overview

Big imports are timing out and getting killed by Django Q. Also they leave their working files behind when that happens, so when they then get retried dozens of times, the disk ends up full.

To stop all that from happening, this increases the timeout (from 10 minutes to 3 hours) and sets the number of retries at only 1.  (Side note: I can see where "no retries" might not be a good default for a task processing system and any particular number would seem arbitrary, but ["keep retrying until the end of time"](https://django-q.readthedocs.io/en/latest/configure.html#max-attempts) still doesn't seem like the best choice of default behavior to me.)

I don't know what the upper limit is for how long an import could take. I ran one of the imports that failed in production--Oslo, Norway, using [this boundary](https://github.com/azavea/pfb-network-connectivity/files/6594256/oslo.zip) and the analysis results at `https://production-pfb-storage-us-east-1.s3.amazonaws.com/international_results_2021/europe/osloNO.zip`--and it took just under 20 minutes:
![image](https://user-images.githubusercontent.com/6598836/120725617-5da97780-c4a4-11eb-8e45-0d09cc9d7638.png)

Since killing a job that's still actually running would be a bummer, and waiting too long to mark an import unsuccessful if it hangs doesn't seem like that big of a problem, I went with 3 hours as a timeout, since that seems well outside the range of what we would expect even very large imports to take.

#### Exception `.message` error

While looking through the logs to figure out what was going wrong here, I also saw some crashes like this:
![image](https://user-images.githubusercontent.com/6598836/120725961-09eb5e00-c4a5-11eb-8a28-da1cf548bc4c.png)

The reason it's failing in the first place is that it can't open the zip file, but then in our code handling that exception, we were trying to use the `.message` attribute of the Exception, which went away in Python 3 (see https://www.python.org/dev/peps/pep-0352/).
So this fixes the places where we're doing that.

Resolves #841

## Testing Instructions

- Start the VM then run `scripts/server` inside it to start the app.
- Make a neighborhood for Oslo, using the file attached above.
- Import the Oslo analysis results using the newly-created neighborhood and the S3 path above. It should run successfully, with no errors or extra attempts, even though it will probably take more than 10 minutes to finish.  (Your `scripts/server` command should show logs, but you can also do `vagrant ssh -c "cd /vagrant && docker-compose logs -f django-q"` to see them.
- Run another import, with any neighborhood and an invalid "Results Zip File URL" (like `https://www.azavea.com/`, which will load but definitely isn't a zip file of analysis results). It should raise an exception and show the stack trace in the logs, but the second error should be a `LocalAnalysisFetchException`, not an `AttributeError`.


## Checklist

- [x] Add entry to CHANGELOG.md

