### PR TITLE
Update AWS CLI to v2 to fix unsupported Python error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Changed
+- Upgrade AWS CLI to v2 in analysis container
+
 ## [0.15.1] - 2021-06-04
 
 #### Changed

--- a/src/analysis/Dockerfile
+++ b/src/analysis/Dockerfile
@@ -43,7 +43,7 @@ RUN set -xe && \
         unzip \
         zip \
         postgis \
-        python \
+        python3 \
         python3-dev \
         python3-pip \
         osm2pgrouting \
@@ -62,10 +62,10 @@ RUN set -xe && \
     apt-get purge -y --auto-remove ${BUILD_DEPS}
 
 RUN set -xe && \
-    wget -q "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -r ./awscli-bundle*
+    wget -q "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && \
+    unzip awscli-exe-linux-x86_64.zip && \
+    ./aws/install && \
+    rm -r ./aws*
 
 RUN set -xe && \
     wget -q -O /usr/local/bin/osmconvert "https://s3.amazonaws.com/pfb-binaries-us-east-1/osmconvert64" && \


### PR DESCRIPTION
## Overview

We've been installing AWS CLI v1 on the analysis container using the "download the bundle and run the install script" method, but that no longer supports older versions of Python. Rebecca emailed with a crash she got when building the analysis container:
![image](https://user-images.githubusercontent.com/6598836/129625258-cf990ba0-09e8-410d-8de1-8c26c1d051ce.png)

Rather than have to upgrade the version of Python we're running in the container, we can just switch to AWS CLI v2, which has no external Python dependency.  The analysis only uses the AWS CLI for simple S3 uploading and downloading, so moving to v2 doesn't require any changes to the commands we're running.

### Notes

- I also changed `python` to `python3` in the list of apt-get packages to install. It was already getting pulled in by `python3-dev`, but I don't think there's any reason to keep the Python 2 package around, and if there's a place that we're accidentally still using Python 2, I'd rather find out about it than let it keep quietly working.
- We upgraded to AWS CLI v2 in the VM then reverted back to v1 because we couldn't use v2 on the CI server.  This is independent of that, and doesn't suffer the same compatibility problems since it's inside the analysis container.

## Testing Instructions

- Either build everything from scratch (i.e. destroy your VM and run `scripts/setup`) or build just the analysis container from scratch by starting the VM, sshing to it, and running `docker-compose build --pull --no-cache analysis`
- Run a test analysis job to confirm that the steps that download from and upload to S3 work properly

## Checklist

- [x] Add entry to CHANGELOG.md
