### PR TITLE
Update base VM to fix ansible installation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Changed
 - Upgrade AWS CLI to v2 in analysis container
+- Upgrade base VM from Ubuntu 16.04 to 20.04
 
 ## [0.15.1] - 2021-06-04
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ ROOT_VM_DIR = "/vagrant"
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-20.04"
   config.vm.hostname = "pfb-network-connectivity"
   config.vm.network :private_network, ip: ENV.fetch("PFB_PRIVATE_IP", "192.168.111.111")
 
@@ -58,7 +58,7 @@ Vagrant.configure("2") do |config|
     ansible.install = true
     ansible.install_mode = "pip"
     # Install pip3 for the system version of python3, and make sure 'pip3' works as well
-    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | sudo python3 && sudo ln -s -f /usr/local/bin/pip /usr/local/bin/pip3"
+    ansible.pip_install_cmd = "sudo apt-get install -y python3-pip && sudo ln -s -f /usr/bin/pip3 /usr/bin/pip"
     ansible.version = "2.8.7"
   end
 

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -9,9 +9,9 @@ pfb_aws_batch_analysis_job_queue_name: "name_of_batch_analysis_job_queue"
 pfb_aws_batch_analysis_job_definition_name: "staging-pfb-analysis-run-job"
 
 # azavea.docker
-docker_version: 18.*
+docker_version: 5:19.*
 docker_options: "--storage-opt dm.basesize=20G"
 docker_compose_version: 1.23.*
 
 # azavea.terraform
-terraform_version: 0.9.3
+terraform_version: 0.9.11

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,4 +1,4 @@
 - src: azavea.docker
-  version: 5.0.0
+  version: 6.0.0
 - src: azavea.terraform
-  version: 0.3.1
+  version: 0.4.0


### PR DESCRIPTION
## Overview

VM provisioning has started failing, with a message about Python 3.5 having reached end-of-life. There might be other ways to get around it, but upgrading the base VM would be a good thing anyway, so that's the first thing I tried.

It seems like it worked--I'm able to provision the app and run the analysis. I also updated the Ansible roles for good measure. We only use the VM as a standard environment in which to build and run the containers, so it's not that surprising that it wouldn't be too susceptible to issues from upgrading.

### Notes

There's a chance this will affect deployment, since we do deployments from within the VM.  But the crash is currently blocking Rebecca from running the analysis locally, and I'm not sure it's worth pursuing the deployment question at the moment, when there are no imminent plans to deploy.

## Testing Instructions

- **Update**: Copy the changes from `deployment/ansible/group_vars/all.example` into your `deployment/ansible/group_vars/all` file.
- Provision the project per the README
- If it gets as far as starting the app, that means you're definitely past the point where it was crashing. For a more complete test, you could go through adding a neighborhood and starting an analysis job for it.

## Checklist

- [x] Add entry to CHANGELOG.md
