### PR TITLE
Update django-q to fix migration error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 #### Changed
 - Upgrade AWS CLI to v2 in analysis container
 - Upgrade base VM from Ubuntu 16.04 to 20.04
+- Update django-q from 1.0.2 to 1.3.6
 
 ## [0.15.1] - 2021-06-04
 

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -12,7 +12,7 @@ django-amazon-ses==2.1.1
 django-countries==5.4
 django-extensions==2.2.1
 django-filter==2.2.0
-django-q==1.0.2
+django-q==1.3.6
 django-storages==1.7.1
 django-watchman==0.18.0
 djangorestframework==3.10.3


### PR DESCRIPTION
## Overview

We have not been able to run migrations in newly built VMs without getting an error. The error gives you a fix, but updating django-q to a recent version stops the error from occurring in the first place.

## Testing Instructions

 * Follow the README steps
 * You should see no error when running migrations

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #808 
