### PR TITLE
Fix email sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade base VM from Ubuntu 16.04 to 20.04
 - Update django-q from 1.0.2 to 1.3.6
 
+#### Fixed
+- Fixe email sending
+
 ## [0.15.1] - 2021-06-04
 
 #### Changed

--- a/deployment/aws-batch/Dockerfile
+++ b/deployment/aws-batch/Dockerfile
@@ -1,10 +1,9 @@
 
-FROM python:3-slim
+FROM python:3.9-slim
 
 MAINTAINER Azavea
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ipython \
     python3-pip \
     build-essential \
     && rm -rf /var/lib/apt/lists/*

--- a/src/django/pfb_network_connectivity/settings.py
+++ b/src/django/pfb_network_connectivity/settings.py
@@ -273,10 +273,8 @@ REPOSITORY_HELP_EMAIL = os.getenv('REPOSITORY_HELP_EMAIL', 'help@bna.peopleforbi
 # Root user email (the email address of the main admin user for the root org in the database)
 ROOT_USER_EMAIL = 'systems+pfb@azavea.com'
 
-if DJANGO_ENV in ['staging', 'production']:
-    EMAIL_BACKEND = 'django_amazon_ses.backends.boto.EmailBackend'
-elif DJANGO_ENV in ['development', 'test']:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+if DJANGO_ENV in ['staging', 'production', 'development', 'test']:
+    EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
 else:
     raise ImproperlyConfigured('Unknown DJANGO_ENV')
 

--- a/src/verifier/Dockerfile
+++ b/src/verifier/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3-slim
 MAINTAINER Azavea
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ipython \
     python3-pip \
     build-essential \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Overview

This PR updates the `EMAIL_BACKEND` in `settings.py` so that it matches the suggested settings in  [`django-amazon-ses v2.1.1`](https://github.com/azavea/django-amazon-ses/tree/2.1.1#django-configuration), since the trackback in the original issue seems to suggest that it ran into module import issue of this dependency, and that this module change in this dep happened in the upgrade of 0.3.2 -> 2.1.1.

This PR also removes `ipython` installation from `deployment/aws-batch/Dockerfile` and `src/verifier/Dockerfile`, and it pins the base image python version in `deployment/aws-batch/Dockerfile`.

## Testing Instructions

 * Push a `test/` branch up to trigger a staging deploy
 * Once the ECS tasks are cycled, go to https://staging.pfb.azavea.com/#/login/ , click on "Reset password", put in the email address that is stored under `PFB Staging Root User` from lastpass
 * Check if there is a password reset email send to that email address

## Checklist

- [X] Add entry to CHANGELOG.md

Resolves https://github.com/azavea/pfb-network-connectivity/issues/818
