### PR TITLE
Add State & FIPS cols to admin analysis jobs table (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade AWS CLI to v2 in analysis container
 - Upgrade base VM from Ubuntu 16.04 to 20.04
 - Update django-q from 1.0.2 to 1.3.6
+- Add State AbbreviaAnalysisJobtion, City FIPS to Admin Analysis Jobs table
 
 ## [0.15.1] - 2021-06-04
 

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.controller.js
@@ -52,6 +52,12 @@
             if (filters.batch) {
                 params.batch = filters.batch;
             }
+            if (filters.state_abbrev) {
+                params.neighborhood__state_abbrev = filters.state_abbrev
+            }
+            if (filters.city_fips) {
+                params.neighborhood__city_fips = filters.city_fips
+            }
             getAnalysisJobs(params);
         }
 

--- a/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
+++ b/src/angularjs/src/app/analysis-jobs/list/analysis-jobs-list.html
@@ -23,6 +23,8 @@
             <td><a ui-sref="admin.analysis-jobs.detail({uuid: analysisJob.uuid})">{{analysisJob.uuid | limitTo: 5}}</a></td>
             <td>{{analysisJob.status | displayStatus}}</td>
             <td>{{analysisJob.neighborhood.label}}</td>
+            <td>{{analysisJob.neighborhood.state_abbrev}}</td>
+            <td>{{analysisJob.neighborhood.city_fips}}</td>
             <td>{{analysisJob.batch}}</td>
             <td>{{analysisJob.local_upload_task.status | displayStatus}}</td>
             <td>{{analysisJob.createdAt | date:'yyyy-MM-dd HH:mm:ss'}}</td>

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.directive.js
@@ -22,9 +22,11 @@
 
         function onFilterChanged() {
             ctl.filters = {
+                batch: ctl.batchId,
+                city_fips: ctl.city_fips,
                 neighborhood: ctl.searchText,
-                status: AnalysisJobStatuses.filterMap[ctl.statusFilter],
-                batch: ctl.batchId
+                state_abbrev: ctl.state_abbrev.toUpperCase(),
+                status: AnalysisJobStatuses.filterMap[ctl.statusFilter]
             };
         }
     }

--- a/src/angularjs/src/app/components/filters/analysis-job-filter.html
+++ b/src/angularjs/src/app/components/filters/analysis-job-filter.html
@@ -2,7 +2,7 @@
     <th>ID</th>
     <th>
         <div class="dropdown">
-        <input name="neighborhood-filter"
+        <input 
                title="Filter by Status"
                placeholder="Status"
                ng-model="ctl.statusFilter"
@@ -17,7 +17,7 @@
     </th>
     <th>
         <div class="dropdown neighborhood">
-            <input name="neighborhood-filter"
+            <input 
                    title="Filter by Neighborhood"
                    placeholder="Neighborhood"
                    ng-model="ctl.searchText"
@@ -29,7 +29,31 @@
     </th>
     <th>
         <div class="dropdown">
-            <input name="neighborhood-filter"
+            <input 
+                   title="Filter by State abbreviation"
+                   placeholder="State"
+                   ng-model="ctl.state_abbrev"
+                   ng-model-options="{ debounce: 400 }"
+                   ng-change="ctl.onFilterChanged()"
+                   type="text"
+                   class="form-control"/>
+        </div>
+    </th>
+    <th>
+        <div class="dropdown">
+            <input 
+                   title="Filter by City FIPS"
+                   placeholder="City FIPS"
+                   ng-model="ctl.city_fips"
+                   ng-model-options="{ debounce: 400 }"
+                   ng-change="ctl.onFilterChanged()"
+                   type="text"
+                   class="form-control"/>
+        </div>
+    </th>
+    <th>
+        <div class="dropdown">
+            <input 
                    title="Filter by Batch ID"
                    placeholder="Batch ID"
                    ng-model="ctl.batchId"

--- a/src/django/pfb_analysis/filters.py
+++ b/src/django/pfb_analysis/filters.py
@@ -47,6 +47,7 @@ class AnalysisJobFilterSet(filters.FilterSet):
                   'neighborhood__label': ['exact', 'contains'],
                   'neighborhood__country': ['exact'],
                   'neighborhood__state_abbrev': ['exact'],
+                  'neighborhood__city_fips': ['exact'],
                   'batch': ['exact', 'in'],
                   'status': ['exact'],
                   'latest': ['exact']}

--- a/src/django/pfb_analysis/serializers.py
+++ b/src/django/pfb_analysis/serializers.py
@@ -134,7 +134,7 @@ class NeighborhoodSummarySerializer(PFBModelSerializer):
     class Meta:
         model = Neighborhood
         fields = ('uuid', 'name', 'label', 'label_suffix', 'country', 'state_abbrev',
-                  'organization', 'geom_pt',)
+                  'organization', 'geom_pt', 'city_fips',)
         read_only_fields = fields
 
 


### PR DESCRIPTION
## Overview

Adding the state name makes it easier to distinguish between cities with
the same name. Adding FIPS makes it easier to track cities over time and
stay aligned with other data sources. Both fields are filterable.


### Demo

![865](https://user-images.githubusercontent.com/36001800/159073801-95d5fc7a-06f1-49c0-9083-5e571ea48830.png)


## Testing Instructions

 * Start the server
 * Go to http://localhost:9301/admin#/admin/analysis-jobs/
 * Should be searchable by FIPS or state abbreviation

## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #865
