### PR TITLE
Revert "Update django-q to fix migration error"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 #### Changed
 - Upgrade AWS CLI to v2 in analysis container
 - Upgrade base VM from Ubuntu 16.04 to 20.04
-- Update django-q from 1.0.2 to 1.3.6
-- Add State AbbreviaAnalysisJobtion, City FIPS to Admin Analysis Jobs table
+- Add State Abbreviation, City FIPS to Admin Analysis Jobs table
 
 #### Fixed
-- Fixe email sending
+- Fix email sending
 
 ## [0.15.1] - 2021-06-04
 

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -12,7 +12,7 @@ django-amazon-ses==2.1.1
 django-countries==5.4
 django-extensions==2.2.1
 django-filter==2.2.0
-django-q==1.3.6
+django-q==1.0.2
 django-storages==1.7.1
 django-watchman==0.18.0
 djangorestframework==3.10.3


### PR DESCRIPTION
This reverts commit b187474e87733ea506e26929fed569f2fc97b0e2.

## Overview

The original upgrade was to resolve #808, but what I didn't realize at the time was that upgrading django-q currently breaks the local analysis functionality.

