### PR TITLE
Destination types with no locations are N/A (#867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade base VM from Ubuntu 16.04 to 20.04
 - Add State Abbreviation, City FIPS to Admin Analysis Jobs table
 - Add Max Trip Distance (meters) to Admin Analysis Jobs forms
+- Make Places service show N/A for destination types w/o locations
 
 #### Fixed
 - Fix email sending

--- a/src/angularjs/src/app/components/places.service.js
+++ b/src/angularjs/src/app/components/places.service.js
@@ -9,13 +9,26 @@
     'use strict';
 
     /* @ngInject */
-    function Places($q, $log, Neighborhood, AnalysisJob) {
+    function Places($q, $http, $log, Neighborhood, AnalysisJob) {
 
         var module = {
             getPlace: getPlace
         };
 
         return module;
+
+        function scoreKeyToDestinationsUrlName(key)  {
+            return key
+                // one-to-one mappings
+                .replace("core_services_grocery","supermarkets")
+                .replace("opportunity_k12_education","schools")
+                .replace("opportunity_technical_vocational_college","colleges")
+                .replace("opportunity_higher_education","universities")
+                // prefixes to strip
+                .replace("core_services_", "")
+                .replace("recreation_","")
+                .replace("opportunity_","");
+        }
 
         function getPlace(uuid) {
             var dfd = $q.defer();
@@ -48,14 +61,32 @@
                     place.results = results;
                     place.scores = results.overall_scores;
 
+                    var destinations_promises = [];
                     _.each(results.overall_scores, function (scores, key) {
-                        scores.score_normalized = (key === 'population_total' ?
-                                                   scores.score_original : scores.score_normalized)
+                        scores.score_normalized = key === "population_total"
+                            ? scores.score_original
+                            : Math.round(scores.score_normalized);          
+                        if (scores.score_normalized === 0) {
+                            var found_destinations_url = results.destinations_urls.find(function(destinations_url) {
+                                return scoreKeyToDestinationsUrlName(key) === destinations_url.name;
+                            });
+                            if (found_destinations_url) {
+                                var destinations_promise = $http.get(found_destinations_url.url).then(function(response) {
+                                    if (response.data.features.length === 0) {
+                                        scores.score_normalized = 'N/A' ;
+                                    }
+                                    return scores;
+                                });
+                                destinations_promises.push(destinations_promise)
+                            }
+                        }
                     });
                     place.scores.default_speed_limit = {
                         score_normalized: results.residential_speed_limit
                     };
-                    dfd.resolve(place);
+                    $q.all(destinations_promises).then(function() {
+                        dfd.resolve(place);
+                    });
                 });
             });
             return dfd.promise;

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -42,7 +42,7 @@
                             {{ ::m.label }}
                             <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
                             <span ng-if="place.scores[m.name]"
-                                class="network-score small">{{ ::place.scores[m.name].score_normalized | number:0 }}</span>
+                                class="network-score small">{{ ::place.scores[m.name].score_normalized }}</span>
                             <span ng-if="!place.scores[m.name]"
                                 class="network-score small">N/A</span>
                         </li>

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -67,7 +67,7 @@
                 ng-class="m.subscoreClass">
                 {{ ::m.label }}
                 <div class="tooltip" data-title="{{ ::m.description }}"><i class="icon-info-circled"></i></div>
-                <span class="network-score small" ng-if="m.name!=='default_speed_limit'">{{ ::placeDetail.scores[m.name].score_normalized | number:0 }}</span>
+                <span class="network-score small" ng-if="m.name!=='default_speed_limit'">{{ ::placeDetail.scores[m.name].score_normalized }}</span>
                 <span class="network-score small" ng-if="m.name==='default_speed_limit'">{{ ::placeDetail.scores[m.name].score_normalized | number:0 }} mph</span>
             </li>
         </ul>


### PR DESCRIPTION
## Overview

In the places detail and compare pages, there has been no way to
differentiate between destination types without instances in the given
place and destination types with instances that are inaccessible by low
stress routes. The former are now marked N/A; the latter are marked 0.


### Demo

![detailscreen](https://user-images.githubusercontent.com/36001800/162472323-1a3fedbc-9dc5-4ef9-9b7f-4b1e96cdd2a3.png)
![comparescreen](https://user-images.githubusercontent.com/36001800/162472327-9f72b599-dccc-403b-8fea-acbb1118d3f3.png)


## Testing Instructions

 * `./scripts/setup`
 * `vagrant ssh`
 * `./scripts/server`
 * if you don't have any places yet when you go to [all places](http://localhost:9301/admin#/places////)
   * go to http://localhost:9301/admin#/admin/analysis-jobs/create/batch/ 
   * give it a shapefile (feel free to slack me for one)
* go to http://localhost:9301/admin#/places//// and select a place
* for any metric that shows N/A, the associated geojson in your s3 bucket should have 0 features
* for any metric that shows 0, the associated geojson in your s3 bucket should have 1+ features
* the above two bullets should also be true if you go to http://localhost:9301/admin#/places//// then compare two places


## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #867
