### PR TITLE
Drop unmaintained angular-file-saver

### DIFF
--- a/src/angularjs/bower.json
+++ b/src/angularjs/bower.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "angular": "1.5.11",
     "angular-animate": "1.5.11",
-    "angular-file-saver": "1.1.3",
     "angular-loading-bar": "0.9.0",
     "angular-aria": "1.5.11",
     "angular-cookies": "1.5.11",


### PR DESCRIPTION
This also broke the build.
I grepped for SaveAs and couldn't find it used anywhere.