### PR TITLE
Adjust vagrant params and analysis job environment params to fix errors found while testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ PFB_SHARED_FOLDER_TYPE = ENV.fetch("PFB_SHARED_FOLDER_TYPE", "nfs")
 
 if PFB_SHARED_FOLDER_TYPE == "nfs"
   if Vagrant::Util::Platform.linux? then
-    PFB_MOUNT_OPTIONS = ['rw', 'vers=3', 'tcp', 'nolock', 'actimeo=1']
+    PFB_MOUNT_OPTIONS = ['rw', 'tcp', 'nolock', 'actimeo=1']
   else
     PFB_MOUNT_OPTIONS = ['vers=3', 'udp', 'actimeo=1']
   end
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.box = "bento/ubuntu-20.04"
   config.vm.hostname = "pfb-network-connectivity"
-  config.vm.network :private_network, ip: ENV.fetch("PFB_PRIVATE_IP", "192.168.111.111")
+  config.vm.network :private_network, ip: ENV.fetch("PFB_PRIVATE_IP", "192.168.56.12")
 
   config.vm.network :forwarded_port, guest: 9200, host: ENV.fetch("PFB_NGINX_PORT", 9200)
   config.vm.network :forwarded_port, guest: 9202, host: ENV.fetch("PFB_GUNICORN_PORT", 9202)

--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -739,7 +739,7 @@ class AnalysisJob(PFBModel):
         # Job-specific settings
         environment.update({
             'NB_TEMPDIR': os.path.join('/tmp', str(self.uuid)),
-            'NB_MAX_TRIP_DISTANCE': self.max_trip_distance,
+            'NB_MAX_TRIP_DISTANCE': str(self.max_trip_distance),
             'PGDATA': os.path.join('/pgdata', str(self.uuid)),
             'PFB_SHPFILE_URL': self.neighborhood.boundary_file.url,
             'PFB_STATE': self.neighborhood.state_abbrev,


### PR DESCRIPTION
## Overview

Two small fixes for issues I ran into while testing things:
- some of the parameters in the Vagrantfile stopped working when I upgraded to Virtualbox 6
- the analysis job submission wasn't working on staging because the boto client (or the AWS API? comes to the same thing) wants the values in the `environment` parameter to be strings, not numbers.

See the commit messages for a little bit more detail.

## Testing Instructions

I'm not sure how much testing this warrants, but it's worth checking that your VM comes up fine and that you can at least kick off an analysis job.  Testing it again on staging (I didn't test the changed code, but I did test that casting the param to a string made the job submission work in `shell_plus` on the staging instance) probably isn't worth the trouble.

## Checklist

- [ ] ~Add entry to CHANGELOG.md~ (too small)

