### PR TITLE
Apply small fixes from non-US cities analysis testing

### DIFF
--- a/src/analysis/scripts/download_osm_extract.py
+++ b/src/analysis/scripts/download_osm_extract.py
@@ -179,7 +179,11 @@ def main():
         logger.setLevel('INFO')
 
     continent = country_to_continent.get_continent(country_alpha3).lower().replace(' ', '-')
-    country_name = pycountry.countries.get(alpha_3=country_alpha3).name.lower().replace(' ', '-')
+    country_name = (
+        pycountry.countries.get(alpha_3=country_alpha3).name.lower().replace(" ", "-")
+        if country_alpha3.lower() != "usa"
+        else "us"
+    )
     # Shortcut and do a direct geofabrik download if we don't have AWS configured
     # or a bucket provided
     if S3_CLIENT is None or bucket is None:

--- a/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
+++ b/src/angularjs/src/app/analysis-jobs/create/analysis-jobs-create.controller.js
@@ -27,7 +27,7 @@
                                           {autoDismiss: false});
 
             var job = new AnalysisJob({
-                max_trip_distance: ctl.maxTripDistance,
+                max_trip_distance: ctl.maxTripDistance === null ? undefined : ctl.maxTripDistance,
                 neighborhood: ctl.neighborhood.uuid,
                 osm_extract_url: ctl.osmUrl,
                 population_url: ctl.populationUrl,


### PR DESCRIPTION
## Overview

Two small fixes for things I ran into while testing the analysis changes.
1. The OSM extract download script wasn't quite right for US states.  I hadn't noticed because it was using a cached version of the extract from my S3 bucket.  Once I cleared that out, it started producing an error.  The issue is that, whereas the country name in the URL for every other country (as far as I can tell) is the full name (in lower case, with hyphens for spaces), the country name for the US is just "us".  This adds a condition in `download_osm_extract.py` to adjust for that.
2. A couple times I accidentally changed the new "Max Trip Distance" then cleared the field again to let it use the default, but then ended up with a crash because it got a null value rather than the default.  I added a check to the front-end to send it as `undefined` (which is what it does if the field is never set) rather than `null` (which is what it ends up as if you set then clear it).

### Notes

I'm putting this up as a PR for visibility, but these were in place for all the testing I just did, and I don't think we need another round of testing for them, so I'm just going to merge this.

