### PR TITLE
Analysis upgrade fixups

### DIFF
--- a/src/django/pfb_analysis/models.py
+++ b/src/django/pfb_analysis/models.py
@@ -144,8 +144,10 @@ def create_environment(**kwargs):
 
     Writes argument pairs to an array {name, value} objects, which is what AWS wants for
     environment overrides.
+    Casts values to string, since that's what AWS wants, and there's some benefit (e.g. catching
+    a stray integer) and really no cost to making sure.
     """
-    return [{'name': k, 'value': v} for k, v in kwargs.items()]
+    return [{'name': k, 'value': str(v)} for k, v in kwargs.items()]
 
 
 class Neighborhood(PFBModel):


### PR DESCRIPTION
## Overview

A couple fixes for the recent changes to the analysis--one related to the new options, one to the Django upgrade:
1. The new `RUN_IMPORT_JOBS` environment variable for the analysis is a number (0 or 1), which works fine for running the analysis locally but, it turns out, is not OK when sending actual jobs to Batch.  I think this has bitten us once before, and since the values always need to be strings, rather than adjust this one value, I just added a `str()` call to the function that packages the environment variables up for the boto request.
2. The stress network tiles for newly run analysis jobs had some black lines on them.  I had seen them earlier in development, but I thought they were due to stale OSM files, and I thought after I had cleared my OSM cache they went away.  But my test runs must not have worked how I thought, because they definitely showed up on staging.  E.g.
![image](https://user-images.githubusercontent.com/6598836/184780683-7b809507-dacd-4143-ac96-eeed0e8e49a7.png)
This turned out to be because the [LayerMapping utility](https://docs.djangoproject.com/en/4.1/ref/contrib/gis/layermapping/), which we use to re-import the shapefiles produced by the analysis so that they can be displayed by the tiler, evidently shifted its treatment of nulls with the Django upgrade.  When there are null values in the shapefile properties for integer fields, it used to import them as zeroes, but now it imports them as nulls.  So that seems like a bug fix, and you can hardly blame them for making the change, but it turns out we were relying on those zeroes.  Adjusting the tiler configuration to be able to handle both cases would be somewhat complicated, and especially right now when we haven't touched it in a while, but updating the data to replace nulls with zeroes right after the import is simple, so I did that.  Here's an "after" version (the score and map are also slightly different because it turned out there were stale OSM extracts in the staging bucket, too, which I cleared out): 
![image](https://user-images.githubusercontent.com/6598836/184781726-d37e845a-a442-4565-99a7-ba5e9762f972.png)

## Testing Instructions

There's a staging batch worker running right now, so it should work to submit a job and watch it run.
Or you could take the existence of three successful jobs within the past 24 hours and the fact that the map looks OK on https://staging.pfb.azavea.com/#/places/f99374b7-abe3-44ef-bc6a-4feb22545e4d/ as sufficient evidence that these ultimately very small code changes are working as intended.

## Checklist

- [ ] ~Add entry to CHANGELOG.md~ (just fixups)
