### PR TITLE
Fix import script

### DIFF
--- a/src/analysis/import/import_neighborhood.sh
+++ b/src/analysis/import/import_neighborhood.sh
@@ -137,7 +137,7 @@ then
             else
                 echo "Using blocks file from PFB_POP_URL: ${PFB_POP_URL}"
             fi
-            wget -nv -O "${BLOCK_DOWNLOAD}" "${PFB_POP_URL}"      
+            wget -nv -O "${BLOCK_DOWNLOAD}" "${PFB_POP_URL}"
 
             if [ "${AWS_STORAGE_BUCKET_NAME}" ]; then
                 echo "Uploading census blocks file to S3 cache"
@@ -145,14 +145,6 @@ then
             fi
         fi
         unzip "${BLOCK_DOWNLOAD}" -d "${NB_TEMPDIR}"
-
-        if [ "${PFB_COUNTRY}" != "USA" ]; then
-            # Rename unzipped files if not from census so they can be found easily
-            cd $NB_TEMPDIR
-            rm "${NB_BLOCK_FILENAME}.zip"
-            for x in *; do mv "$x" "${NB_BLOCK_FILENAME}.${x##*.}"; done
-            cd - 
-        fi
 
         # Import block shapefile
         update_status "IMPORTING" "Loading census blocks"
@@ -166,7 +158,7 @@ then
                 AS boundary WHERE NOT ST_DWithin(blocks.geom, boundary.geom, \
                 ${NB_BOUNDARY_BUFFER});"
         echo "DONE: Finished removing blocks outside buffer"
-        
+
         if [ "${PFB_COUNTRY}" == "USA" ]; then
             # Discard blocks that are all water / no land area
             update_status "IMPORTING" "Removing water blocks"


### PR DESCRIPTION
The image is built from `azavea/pfb-network-connectivity@0037a5c`, and the command I ran was the following:

```bash
docker run --rm \
    -e PFB_SHPFILE="/data/metz-lorraine.shp" \
    -e PFB_OSM_FILE="/data/metz-lorraine.osm" \
    -e PFB_COUNTRY=nonus \
    -e PFB_STATE=zz \
    -e PFB_STATE_FIPS=0 \
    -e NB_OUTPUT_DIR=/data \
    -e RUN_IMPORT_JOBS=0 \
    -e PFB_DEBUG=1 \
    -v "PeopleForBikes/brokenspoke-analyzer/data":/data \
    azavea/pfb-network-connectivity:0.17
```

The goal is to run an analysis for the city of Metz in France, located in the Lorraine region.

In `analysis/import/import_neighborhood.sh` the block attempting to do some cleanup is erroneous and can be removed.

If left, it crashes with the following error:

```bash
+ echo 'Updating job status: IMPORTING' 'Downloading census blocks'
+ '[' -n '' ']'
+ '[' nonus == USA ']'
+ NB_BLOCK_FILENAME=population
+ S3_PATH=s3:///data/population.zip
+ '[' -f /data/population.zip ']'
+ echo 'Using local census blocks file'
+ BLOCK_DOWNLOAD=/data/population.zip
+ unzip /data/population.zip -d /tmp/tmp.jAv86ZgUP8/import_neighborhood
+ '[' nonus '!=' USA ']'
+ cd /tmp/tmp.jAv86ZgUP8/import_neighborhood
+ rm population.zip
rm: cannot remove 'population.zip': No such file or directory
```

This is because the `population.zip` file was never moved to the tmpdir, only unzipped there, therefore there is nothing to remove.

This error could be avoided by switching to `rm -f population.zip`, but then the process fails with the following error:

```bash
+ echo 'Updating job status: IMPORTING' 'Downloading census blocks'
+ '[' -n '' ']'
+ '[' nonus == USA ']'
+ NB_BLOCK_FILENAME=population
+ S3_PATH=s3:///data/population.zip
+ '[' -f /data/population.zip ']'
+ echo 'Using local census blocks file'
+ BLOCK_DOWNLOAD=/data/population.zip
+ unzip /data/population.zip -d /tmp/tmp.MeseJ3QXln/import_neighborhood
+ '[' nonus '!=' USA ']'
+ cd /tmp/tmp.MeseJ3QXln/import_neighborhood
+ rm -f population.zip
+ for x in *
+ mv population.cpg population.cpg
mv: 'population.cpg' and 'population.cpg' are the same file
```

Therfore I believe this block does not add value and can be safely removed. Once these lines where delete, the analysis completed successfully.

After that the analysis proceeds like a charm.