### PR TITLE
Fix cleanup commands for non-US population files

### DIFF
--- a/src/analysis/import/import_neighborhood.sh
+++ b/src/analysis/import/import_neighborhood.sh
@@ -137,7 +137,7 @@ then
             else
                 echo "Using blocks file from PFB_POP_URL: ${PFB_POP_URL}"
             fi
-            wget -nv -O "${BLOCK_DOWNLOAD}" "${PFB_POP_URL}"      
+            wget -nv -O "${BLOCK_DOWNLOAD}" "${PFB_POP_URL}"
 
             if [ "${AWS_STORAGE_BUCKET_NAME}" ]; then
                 echo "Uploading census blocks file to S3 cache"
@@ -149,8 +149,8 @@ then
         if [ "${PFB_COUNTRY}" != "USA" ]; then
             # Rename unzipped files if not from census so they can be found easily
             cd $NB_TEMPDIR
-            rm "${NB_BLOCK_FILENAME}.zip"
-            for x in *; do mv "$x" "${NB_BLOCK_FILENAME}.${x##*.}"; done
+            rm -f "${NB_BLOCK_FILENAME}.zip"
+            for x in *; do mv -u "$x" "${NB_BLOCK_FILENAME}.${x##*.}"; done
             cd - 
         fi
 
@@ -166,7 +166,7 @@ then
                 AS boundary WHERE NOT ST_DWithin(blocks.geom, boundary.geom, \
                 ${NB_BOUNDARY_BUFFER});"
         echo "DONE: Finished removing blocks outside buffer"
-        
+
         if [ "${PFB_COUNTRY}" == "USA" ]; then
             # Discard blocks that are all water / no land area
             update_status "IMPORTING" "Removing water blocks"

--- a/src/analysis/import/import_neighborhood.sh
+++ b/src/analysis/import/import_neighborhood.sh
@@ -150,7 +150,7 @@ then
             # Rename unzipped files if not from census so they can be found easily
             cd $NB_TEMPDIR
             rm -f "${NB_BLOCK_FILENAME}.zip"
-            for x in *; do mv -u "$x" "${NB_BLOCK_FILENAME}.${x##*.}"; done
+            for x in *; do mv -n "$x" "${NB_BLOCK_FILENAME}.${x##*.}"; done
             cd - 
         fi
 


### PR DESCRIPTION
## Overview

When downloading a population file from S3, the file gets copied to the temporary directory and needs to be cleaned up, but when using the default local file (`/data/population.zip`) it doesn't, so the `rm` command to remove it after extraction fails.
Also, the command to rename the unzipped files to the default filename is necessary if they're not already named that (e.g. if the file is called `population.zip` but the files inside are called something else), but it crashes if they are.
This changes both commands so they'll still do their thing but will be more tolerant of the files being missing or already named correctly.

### Notes

This is an alternative to PR #902. I believe it addresses the issue raised there but preserves the cleanup that's needed when the population file is downloaded rather than loaded from the default local path.

## Testing Instructions

- Run a non-US analysis as described in PR #902, with no `PFB_POP_URL` value provided so that it gets the population file from `/data/population.zip`.  It should get past the place in `import_neighborhood.sh` that was crashing.
- Run a non-US analysis with `PFB_POP_URL` provided.  It should load the file from that location and should also get past that spot in `import_neighborhood.sh`.
