### PR TITLE
Switch 'N/A' to 'No data' and use it when jobs score is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade base VM from Ubuntu 16.04 to 20.04
 - Add State Abbreviation, City FIPS to Admin Analysis Jobs table
 - Add Max Trip Distance (meters) to Admin Analysis Jobs forms
-- Make Places service show N/A for destination types w/o locations
+- Make Places service return "No data" for destination types w/o locations
+- Also return "No data" for employment score when it's zero (because jobs data was not provided)
 - Update Django and analysis containers to run Django 3.2
 - Replace Feedback link with City Ratings link, point Methodology link to City Ratings methodology page
 - Facilitate non-US analyses with custom population files, jobs files, and osm extracts

--- a/src/angularjs/src/app/components/places.service.js
+++ b/src/angularjs/src/app/components/places.service.js
@@ -67,17 +67,24 @@
                             ? scores.score_original
                             : Math.round(scores.score_normalized);          
                         if (scores.score_normalized === 0) {
+                            // If the score for a destination type is zero *and* the list of
+                            // features for that destination type is empty, show "No data" instead.
                             var found_destinations_url = results.destinations_urls.find(function(destinations_url) {
                                 return scoreKeyToDestinationsUrlName(key) === destinations_url.name;
                             });
                             if (found_destinations_url) {
                                 var destinations_promise = $http.get(found_destinations_url.url).then(function(response) {
                                     if (response.data.features.length === 0) {
-                                        scores.score_normalized = 'N/A' ;
+                                        scores.score_normalized = "No data";
                                     }
                                     return scores;
                                 });
                                 destinations_promises.push(destinations_promise)
+                            }
+                            // For employment there is no list of destinations, so just always
+                            // treat a score of exactly zero as "No data"
+                            if (key === "opportunity_employment") {
+                                scores.score_normalized = "No data";
                             }
                         }
                     });

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -44,7 +44,7 @@
                             <span ng-if="place.scores[m.name]"
                                 class="network-score small">{{ ::place.scores[m.name].score_normalized }}</span>
                             <span ng-if="!place.scores[m.name]"
-                                class="network-score small">N/A</span>
+                                class="network-score small">No data</span>
                         </li>
                         <li>
                             <a ui-sref="places.detail({uuid: place.neighborhood.uuid})"


### PR DESCRIPTION
## Overview

In PR #879 we changed the front end to show "N/A" when the score for a destination type comes out as zero due to there not being any of that type of destination in the data, as opposed to there being locations but they're 100% inaccessible via low-stress routes. There are in fact cases of the latter, so we couldn't just change all zeroes to "N/A".

This changes the annotation from "N/A" to "No data" and also applies it to the "Employment" line. But since employment isn't a destination type, we couldn't use the same "are there any actual locations?" test to decide whether a value is a true zero or a "no data" situation. Fortunately, there don't appear to be any true zeroes in the analysis jobs that have been run to date--I looked in the production database, and all the zero values were from non-US cities that appear to have been run without jobs data (and were subsequently updated to include it). So this just treats an employment score of exactly zero as "No data".

### Demo

![image](https://user-images.githubusercontent.com/6598836/187281799-bc031da0-c2b0-45f6-9f05-d78b5258000d.png)

### Notes

Applying this in the front end rather than in the analysis has some advantages and some disadvantages. The former include:
- The annotations will show up immediately when the new front end code is deployed, rather than having to wait until the next analysis job.
- The score calculation and export code in the analysis is pretty complex, and it would take some effort to adjust it to be able to distinguish between the "zero" and "no data" cases, and to adjust the tables to be able to store non-numeric answers. So leaving the output unchanged avoids that work.

The main disadvantage is that the distinction is not conclusively captured by the output of the analysis. The "Overall Scores (csv)" file will continue showing zeroes, so anything besides the front end that wants to distinguish between true zeroes and no-data cases will have to independently apply the same heuristics the front end does.

## Testing Instructions

- Hopefully you already have at least one completed analysis job with some true-zero and some no-data scores.  If not, run one.  Fitchburg, WI, has some of each.
- Also run an analysis with the "Omit jobs data in analysis" box checked, if you don't already have one.
- The scores list should show "No data" for destination types for which there are no points at all when you select the corresponding item from the "Destinations" list in the map layer picker; for destination types that have at least one location but none on low-stress roads, the score should show up as 0.
- For the job that was run without employment data, it should show "No data" instead of zero for the "Employment" score.


## Checklist

- [x] Add entry to CHANGELOG.md
