### PR TITLE
Raise errors when population is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use 'great-britain', not 'united-kingdom', in OSM extract URLs
 - Stop caching non-US population files
 - Downgrade django-countries package to fix country search in Neighborhoods admin
+- Throw errors rather than failing messily when total population is zero
 
 ## [0.16.0] - 2022-09-06
 

--- a/src/analysis/import/import_neighborhood.sh
+++ b/src/analysis/import/import_neighborhood.sh
@@ -190,6 +190,14 @@ then
         echo "Census Blocks in analysis: ${BLOCK_COUNT}"
         set_job_attr "census_block_count" "${BLOCK_COUNT}"
 
+        POPULATION=$(psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+            -t -c "SELECT SUM(pop10) FROM neighborhood_census_blocks;")
+        echo "Population is ${POPULATION}"
+        if [[ $POPULATION -eq 0 ]]; then
+            echo "Error: Total population of included census blocks is zero."
+            exit 1
+        fi
+
         # Remove NB_TEMPDIR
         rm -rf "${NB_TEMPDIR}"
     fi

--- a/src/django/pfb_analysis/management/commands/load_overall_scores.py
+++ b/src/django/pfb_analysis/management/commands/load_overall_scores.py
@@ -22,6 +22,10 @@ def load_scores(job, csv_filename, key_column, skip_columns):
                 if row_name == 'population_total':
                     metric[k] = int(metric[k])
             except ValueError:
+                # Letting an empty value get into the JSONB where it expects a number causes
+                # database errors, so raise an error here instead.
+                if row_name == 'population_total' and k == 'score_original':
+                    raise Exception("population_total.score_original must not be empty")
                 pass
         return metric
 


### PR DESCRIPTION
## Overview

This adds two checks for the situation that caused Milton Keynes to fail during final import and bring the API down with it.  The root of the problem was that there was no population in the imported blocks within the neighborhood boundary, but the way that error manifested was not helpful. It ran the whole analysis and imported the broken score results, then failed because the blank population value caused an error on the database level for any query that tried to load the record.

The two new pieces of error-checking:
- one early in the analysis, as soon as the blocks are imported, so that it will raise a more informative error and avoid running a whole analysis with bad data
- a second in the command that imports analysis results into the database, to raise an error if it encounters an empty population value, rather than importing it and causing the database to start throwing errors.

Resolves #911

### Notes

This is based on the branch for PR #912 because it needs those fixes, but I didn't want to make it all into one even-bigger PR.

## Testing Instructions

- Kick off an analysis for Milton Keynes ([milton-keynes.zip](https://github.com/azavea/pfb-network-connectivity/files/9676850/milton-keynes.zip)) using `https://pfb-public-documents.s3.amazonaws.com/population/tabblock2010_99_pophu.zip` for the "Population File URL" and checking the "Omit jobs data in analysis" box.  It should get as far as importing "census" blocks and truncating them to the boundary, but then instead of continuing it should print the message "Error: Total population of included census blocks is zero." and stop.
- Try to load this problematic overall scores file, [neighborhood_overall_scores.csv](https://github.com/azavea/pfb-network-connectivity/files/9676970/neighborhood_overall_scores.csv), onto a job in your local instance.  I.e. download it into the `src/django/` directory so it will be visiblel to the Django container then run
  ```
  ./scripts/django-manage load_overall_scores --skip-columns human_explanation JOB_UUID neighborhood_overall_scores.csv
  ```
  replacing JOB_UUID with the UUID of one of the analysis jobs in your database.  It should be one you don't care too much about, since I think it will overwrite some of the scores before it hits the crash.  But the result of the command should be that it throws an exception and does _not_ mess up the record and cause API calls to start crashing.

## Checklist

- [x] Add entry to CHANGELOG.md
