### PR TITLE
Adjust score weights when there's no jobs data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Stop caching non-US population files
 - Downgrade django-countries package to fix country search in Neighborhoods admin
 - Throw errors rather than failing messily when total population is zero
+- Don't average a zero into combined scores when employment calculations are skipped
 
 ## [0.16.0] - 2022-09-06
 


### PR DESCRIPTION
## Overview

Rebecca reported that the combined scores were getting thrown off for analysis runs with no jobs data, because the zero was getting averaged in rather than skipped.

This adjust the combined scores that the employment score feeds into--the opportunity score, which is a weighted average of employment and education-related scores, and the overall score--to avoid averaging in a zero when we haven't calculated an employment score. The opportunity score also needed divide-by-zero protection after this change, since it makes it possible for all of the components that go into the opportunity score to be absent.

### Demo

Here's a comparison of three different versions of the same neighborhood ([Tiny Brussels](https://github.com/azavea/pfb-network-connectivity/files/9716343/tiny_brussels.zip)). The one on the left is with no jobs and without this fix, the middle one is with no jobs and with this fix, and the one on the right is with jobs data.
![image](https://user-images.githubusercontent.com/6598836/194083722-81053ae8-efde-4694-960d-9316d1a81452.png)

## Testing Instructions

Run an analysis (a small one, to save time) with and without the "Omit jobs data in analysis" option and confirm that the "Opportunity total" and the overall score are both affected by the change and seem reasonable.  It's a little hard to know exactly what the values should be, since they're weighted averages and the weights are buried in the analysis code, but the opportunity score should be somewhere in the range between the scores in that section that aren't showing "no data", and the overall score should move up or down depending on whether the employment score increases or decreases the opportunity score.

## Checklist

- [x] Add entry to CHANGELOG.md
