### PR TITLE
Only get state OSM extracts for US states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
-## [0.16.0] - 2022-10-06
+## [0.16.1] - 2022-10-06
 
 #### Fixed
 - Use 'great-britain', not 'united-kingdom', in OSM extract URLs
@@ -181,7 +181,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.0] - 2017-04-21
 
 
-[Upcoming release]: https://github.com/azavea/pfb-network-connectivity/compare/0.16.0...HEAD
+[Upcoming release]: https://github.com/azavea/pfb-network-connectivity/compare/0.16.1...HEAD
+[0.16.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.16.0...0.16.1
 [0.16.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.15.1...0.16.0
 [0.15.1]: https://github.com/azavea/pfb-network-connectivity/compare/0.15.0...0.15.1
 [0.15.0]: https://github.com/azavea/pfb-network-connectivity/compare/0.14.0...0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Upcoming release]
 
+#### Fixed
+- Ignore state for non-US neighborhoods when downloading OSM extract
+
 ## [0.16.1] - 2022-10-06
 
 #### Fixed

--- a/src/analysis/scripts/download_osm_extract.py
+++ b/src/analysis/scripts/download_osm_extract.py
@@ -118,14 +118,14 @@ def local_filepath_for_region(local_dir, region):
 
 
 def download_from_geofabrik(local_dir, continent, country_name, state_abbrev):
-    # Use state level extracts available at:
-    #   http://download.geofabrik.de/north-america.html
-    # We have to process the neighborhood state abbrev to a full name in format found in the url
-    region = country_name if state_abbrev is None else state_abbrev
+    # Use state level extracts available at: http://download.geofabrik.de/north-america.html
+    # We have to convert the state abbrev to a full name in the format found in the url.
+    # For non-US places, never use state extracts.
+    region = country_name if country_name != "us" or state_abbrev is None else state_abbrev
     logger.info('Downloading OSM extract from Geofabrik for {}'.format(region))
     # get region
     osm_extract_url = GEOFABRIK_URL_TEMPLATE.format(continent, country_name)
-    if state_abbrev:
+    if country_name == "us" and state_abbrev is not None:
         state_name = us.states.lookup(state_abbrev).name.lower().replace(' ', '-')
         osm_extract_url = osm_extract_url + "/" + state_name
     osm_extract_url = osm_extract_url + "-latest.osm.pbf"


### PR DESCRIPTION
## Overview
The OSM downloader was treating any state abbreviation as a US state and trying to download a state extract for it.  But now there are non-US neighborhoods with states that are using this script, so it needed to have that logic protected by a "only in the US" check.

Geofabrik has state-level extracts for several other countries, but knowing which countries it has and which it doesn't, and getting the names to match up exactly right, would be fiddly and error-prone, so we'll just stick with national extracts.

Resolves #915

### Notes
I noticed when I went to update the changelog that I had missed some steps when I updated it for the last release, so I fixed that up here.

## Testing Instructions
I tested it by adding `raise Exception("Time to download OSM extract from " + osm_extract_url)` to the `download_from_geofabrik` function right before it actually tries to download from Geofabrik.  That way I could kick off several different analysis runs (in the US and elsewhere, with and without the state field set) and not have to wait for it to actually try to download the extract or finish the analysis.  I just verified that all the URLs it said it was going to grab were correct.

Note that you have to make sure the file it needs isn't in the `osm-data-cache` on your S3 bucket, or the script will download it from there and not try to get it from Geofabrik.

## Checklist

- [x] Add entry to CHANGELOG.md
