### PR TITLE
Change crashes copy in layer picker (#930)

### DIFF
--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -45,7 +45,7 @@
                     ctl.lastJobScore = place.lastJob.overall_score;
                     ctl.mapLayers = {
                         dataLayers: [{
-                            name: 'crashes',
+                            name: 'Fatal Crashes (2016 - 2020)',
                             url: '/api/crashes/?uuid=' + place.lastJob.uuid
                         }],
                         tileLayers: place.results.tile_urls,


### PR DESCRIPTION
From "Crashes" to "Fatal Crashes (2016 - 2020)". The scrollbar overlaps a little with the text but only when it's highlighted.


![Screenshot from 2023-01-04 10-31-56](https://user-images.githubusercontent.com/36001800/210811530-03da349e-b1f8-408f-a74f-9a9eaac19c41.png)
![Screenshot from 2023-01-04 10-32-44](https://user-images.githubusercontent.com/36001800/210811531-9c1f3c72-1a93-4809-a770-2d5b71d37715.png)



Resolves #930
