### PR TITLE
Fix analyses using pre-2018 census data (#934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Fixed
 - Ignore state for non-US neighborhoods when downloading OSM extract
+- Fix analyses using pre-2018 census data
 
 ## [0.16.1] - 2022-10-06
 

--- a/src/analysis/import/import_jobs.sh
+++ b/src/analysis/import/import_jobs.sh
@@ -35,14 +35,16 @@ NB_POSTGRESQL_PASSWORD - Default: gis
 }
 
 function fetch_census_data() {
+    set +e
     PFB_JOB_URL="http://lehd.ces.census.gov/data/lodes/LODES7/${PFB_STATE}/od/${NB_JOB_FILENAME}.gz"
     wget -nv -O "${JOB_DOWNLOAD}" "${PFB_JOB_URL}" 
     WGET_STATUS=$?
     set -e
-    # Recursively try prior years
-    if [[ $WGET_STATUS -eq 8 ]] && [[ $CENSUS_YEAR -gt 2017 ]]; then
-        (($CENSUS_YEAR--))
-        echo "No ${CENSUS_YEAR} job data available, falling back to ${CENSUS_YEAR-1} data..."
+    # Recursively try prior years as far back as 2016
+    if [[ $WGET_STATUS -eq 8 ]] && [[ $CENSUS_YEAR -gt 2016 ]]; then
+        PRIOR_YEAR=$CENSUS_YEAR
+        ((CENSUS_YEAR--))
+        echo "No ${PRIOR_YEAR} job data available, falling back to ${CENSUS_YEAR} data..."
         NB_JOB_FILENAME="${PFB_STATE}_od_${NB_DATA_TYPE}_JT00_${CENSUS_YEAR}.csv"
         S3_PATH="s3://${AWS_STORAGE_BUCKET_NAME}/data/${NB_JOB_FILENAME}.gz"
         JOB_DOWNLOAD="${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz"


### PR DESCRIPTION
## Overview

States like Alaska use census data from as far back as 2016. Our current default is 2019, but the import jobs script should recursively attempt prior years. This work stops recursive calls to fetch_census_data from crashing on 404s from the census data endpoint, which was happening when the most current census data for a state was prior to 2018.

## Testing Instructions

 * Verify that you can run an analysis job in Alaska


## Checklist

- [x] Add entry to CHANGELOG.md

Resolves #934
