### PR TITLE
Increase analysis RAM allocation and fix provisioning

### DIFF
--- a/deployment/aws-batch/job-definitions/production-pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/production-pfb-analysis-run-job.json
@@ -5,7 +5,7 @@
     "containerProperties": {
         "image": "{image}",
         "vcpus": 8,
-        "memory": 30720,
+        "memory": 61000,
         "command": [
             "/pfb/scripts/entrypoint.sh"
         ],

--- a/deployment/aws-batch/job-definitions/staging-pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/staging-pfb-analysis-run-job.json
@@ -4,8 +4,8 @@
     "parameters": {},
     "containerProperties": {
         "image": "{image}",
-        "vcpus": 2,
-        "memory": 12288,
+        "vcpus": 8,
+        "memory": 61000,
         "command": [
             "/pfb/scripts/entrypoint.sh"
         ],
@@ -26,19 +26,19 @@
             "value": "2680"
         }, {
             "name": "PFB_MAINTENANCE_WORK_MEM",
-            "value": "2048MB"
+            "value": "4092MB"
         }, {
             "name": "PFB_MAX_WAL_SIZE",
             "value": "4096MB"
         }, {
             "name": "PFB_SHARED_BUFFERS",
-            "value": "3072MB"
+            "value": "7168MB"
         }, {
             "name": "PFB_TEMP_FILE_LIMIT",
-            "value": "104857600"
+            "value": "26214400"
         }, {
             "name": "PFB_WORK_MEM",
-            "value": "1536MB"
+            "value": "3072MB"
         }],
         "mountPoints": [{
             "sourceVolume": "pgdata",

--- a/deployment/aws-batch/job-definitions/staging-pfb-analysis-run-job.json
+++ b/deployment/aws-batch/job-definitions/staging-pfb-analysis-run-job.json
@@ -26,19 +26,19 @@
             "value": "2680"
         }, {
             "name": "PFB_MAINTENANCE_WORK_MEM",
-            "value": "4092MB"
+            "value": "8GB"
         }, {
             "name": "PFB_MAX_WAL_SIZE",
-            "value": "4096MB"
+            "value": "8GB"
         }, {
             "name": "PFB_SHARED_BUFFERS",
-            "value": "7168MB"
+            "value": "24GB"
         }, {
             "name": "PFB_TEMP_FILE_LIMIT",
-            "value": "26214400"
+            "value": "100GB"
         }, {
             "name": "PFB_WORK_MEM",
-            "value": "3072MB"
+            "value": "3GB"
         }],
         "mountPoints": [{
             "sourceVolume": "pgdata",

--- a/scripts/infra
+++ b/scripts/infra
@@ -52,10 +52,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [[ -n "${PFB_SETTINGS_BUCKET}" ]]; then
         pushd "${TERRAFORM_DIR}"
 
-        aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${PFB_SETTINGS_BUCKET}.tfvars"
-
         case "${1}" in
             plan)
+                aws s3 cp "s3://${PFB_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${PFB_SETTINGS_BUCKET}.tfvars"
+
                 update_batch_definitions
 
                 docker-compose run --rm \
@@ -111,6 +111,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 ;;
             apply-mgmt)
                 docker-compose run --rm terraform apply "${PFB_SETTINGS_BUCKET}-mgmt.tfplan"
+                ;;
+            update-tfvars)
+                aws s3 cp "${PFB_SETTINGS_BUCKET}.tfvars" \
+                    "s3://${PFB_SETTINGS_BUCKET}/terraform/terraform.tfvars" --sse
                 ;;
             *)
                 echo "ERROR: I don't have support for that Terraform subcommand!"

--- a/src/angularjs/.bowerrc
+++ b/src/angularjs/.bowerrc
@@ -1,3 +1,5 @@
 {
-  "directory": "bower_components"
+  "directory": "bower_components",
+  "registry": "https://registry.bower.io",
+  "strict-ssl": false
 }

--- a/src/angularjs/Dockerfile
+++ b/src/angularjs/Dockerfile
@@ -3,6 +3,9 @@ FROM node:6.17-stretch
 MAINTAINER Azavea
 
 ENV ANGULAR_DIR /opt/pfb/angularjs
+ENV NODE_OPTIONS --use-openssl-ca
+
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y rsync \
     && rm -rf /var/lib/apt/lists/*

--- a/src/tilegarden/Dockerfile
+++ b/src/tilegarden/Dockerfile
@@ -1,10 +1,9 @@
-FROM node:12.19-stretch-slim
+FROM node:12.19-buster-slim
 
 ENV BASE_DIR /opt/pfb/tilegarden
 
 # Install git for git dependencies
-RUN apt-get update -y
-RUN apt-get install git jq -y
+RUN apt-get update -y && apt-get install -y git jq python2 && apt-get clean
 RUN yarn global add carto
 
 # Copy files needed for installing packages first


### PR DESCRIPTION
## Overview

The functional change here is increasing the memory allocation to the analysis Batch task to use the full RAM available on the i3.2xlarge instance we're using in the Batch compute environment.  I had [previously concluded](https://github.com/azavea/pfb-network-connectivity/issues/839#issuecomment-978232796) that the jobs were only using about half of the 32GB we had allocated, but the biggest jobs have been crashing recently and it's possible memory is to blame.  And there's no reason not to use all the memory on the instance.

I'm opening this as a draft PR because I already deployed the job definition update to production, so what's left is the changes I made in the course of spinning up my dev instance again and doing a limited deploy (I reused the containers, so only the services that have the job definition ID embedded in their parameters needed to change).

Here's what else is going on here:
- There are separate job definition templates for staging and production, and historically staging used smaller instances and lower resource allocations.  That probably made sense early in development, but I think at this point it makes more sense to make staging as similar to production as we can, so I updated all the staging parameters to match the production ones.
- I added an 'update-tfvars' subcommand to `infra`, just for convenience.
- The base image for the `angularjs` and `tilegarden` containers is old enough that its package directory no longer exists in the main Debian repo.  For `tilegarden`, I was able to update the base image from `stretch` to `buster` and it worked fine.  The `angularjs` container uses an older version of Node, and the Grunt build failed with the oldest Node version I could get with `buster`, so I left it on `stretch` and updated the apt repo to use http://archive.debian.org/debian.
- Along the same lines (things being old): the Bower registry is still plugging along, but the `bower install` started throwing "certificate expired" errors.  I think the certificate is actually fine and the problem is that it's based on a root certificate that the container doesn't have because it's too new.  But I didn't go into it too much, just worked around it as recommended [here](https://github.com/bower/bower/issues/2608).

Resolves #940 (hopefully)

## Testing Instructions

When the time comes, this should be tested by:
- Spinning up a dev instance and making sure the front end, API, and analysis (run by hand from the command logged by the API) work as usual.
- Doing a staging deploy to make sure the provisioning parts are working.

## Checklist

- [ ] Add entry to CHANGELOG.md

