### PR TITLE
Fix CI for staging deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: CI Build
         run: ./scripts/cibuild
 
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Upgrade Django
 - Add fixture with sample analysis results
+- Fix CI for staging deployment
 
 ## [0.20.0] - 2024-03-04
 

--- a/deployment/aws-batch/docker-compose.yml
+++ b/deployment/aws-batch/docker-compose.yml
@@ -1,11 +1,12 @@
 services:
   update-job-defs:
-      image: update-job-defs
-      build:
-        context: .
-        dockerfile: Dockerfile
-      environment:
-        - AWS_PROFILE=pfb
-        - AWS_DEFAULT_REGION
-      volumes:
-        - $HOME/.aws:/root/.aws:ro
+    image: update-job-defs
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - AWS_DEFAULT_REGION
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+    volumes:
+      - $HOME/.aws:/root/.aws:ro


### PR DESCRIPTION
## Overview

This PR:
- updates the `infra` script to read in AWS creds related env vars
- updates `docker-compose` file used to update job def of batch jobs to pass in the env vars


### Demo

See the green checkmark of the following GH action job run:

https://github.com/azavea/pfb-network-connectivity/actions/runs/13292649266

Staging ECS tasks were cycled through earlier today

<img width="1555" alt="Screenshot 2025-02-12 at 3 58 07 PM" src="https://github.com/user-attachments/assets/aa326775-bb97-451e-9b83-9e10b4e13a37" />

## Testing Instructions

 * Push up a `test` branch and let the GH actions pick up the job
 * The job should succeed
 * A staging deployment should trigger


## Checklist

- [ ] Add entry to CHANGELOG.md

Resolves #963 
