### PR TITLE
Add production release GitHub action workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,40 @@
+---
+name: Release
+about: When ready to cut a release
+title: Release X.Y.Z
+labels: release
+assignees: ""
+---
+
+- [ ] Confirm the staging environment is healthy (including Green checkmark on last [CI build](https://github.com/azavea/pfb-network-connectivity/actions/workflows/ci.yml)) and your local environment is on the `develop` branch and up to date
+- [ ] Start a new release branch:
+
+```bash
+$ git flow release start X.Y.Z
+```
+
+- [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
+- [ ] Ensure outstanding changes are committed:
+
+```bash
+$ git status # Is the git staging area clean?
+$ git add CHANGELOG.md
+$ git commit -m "X.Y.Z"
+```
+
+- [ ] Finish and merge the release branch:
+  - When prompted, keep default commit messages
+  - Use `X.Y.Z` as the tag message
+
+```bash
+$ git flow release finish -p X.Y.Z
+```
+
+- [ ] This will kick off a new develop build and staging deploy. Wait until that is fully done (Green checkbox on [build](https://github.com/azavea/pfb-network-connectivity/actions/workflows/ci.yml)) and staging is working from it.
+- [ ] Start a new [Deploy Production workflow](https://github.com/azavea/pfb-network-connectivity/actions/workflows/deploy_production.yml) with the SHA (see command below) of `release/X.Y.Z` that was tested on staging
+
+```bash
+$ git rev-parse --short=16 HEAD
+```
+
+- [ ] Run migrations, if applicable, following [these instructions](https://github.com/azavea/pfb-network-connectivity/tree/develop/deployment#migrations)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -10,16 +10,16 @@ assignees: ""
 - [ ] Start a new release branch:
 
 ```bash
-$ git flow release start X.Y.Z
+git flow release start X.Y.Z
 ```
 
 - [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
 - [ ] Ensure outstanding changes are committed:
 
 ```bash
-$ git status # Is the git staging area clean?
-$ git add CHANGELOG.md
-$ git commit -m "X.Y.Z"
+git status # Is the git staging area clean?
+git add CHANGELOG.md
+git commit -m "X.Y.Z"
 ```
 
 - [ ] Finish and merge the release branch:
@@ -27,14 +27,14 @@ $ git commit -m "X.Y.Z"
   - Use `X.Y.Z` as the tag message
 
 ```bash
-$ git flow release finish -p X.Y.Z
+git flow release finish -p X.Y.Z
 ```
 
-- [ ] This will kick off a new develop build and staging deploy. Wait until that is fully done (Green checkbox on [build](https://github.com/azavea/pfb-network-connectivity/actions/workflows/ci.yml)) and staging is working from it.
+- [ ] This will kick off a new develop build and staging deploy. Wait until that is fully done (Green checkbox on [build](https://github.com/azavea/pfb-network-connectivity/actions/workflows/ci.yml)) and [staging](https://staging.pfb.azavea.com/) is working from it.
 - [ ] Start a new [Deploy Production workflow](https://github.com/azavea/pfb-network-connectivity/actions/workflows/deploy_production.yml) with the SHA (see command below) of `release/X.Y.Z` that was tested on staging
 
 ```bash
-$ git rev-parse --short=16 HEAD
+git rev-parse --short=16 HEAD
 ```
 
 - [ ] Run migrations, if applicable, following [these instructions](https://github.com/azavea/pfb-network-connectivity/tree/develop/deployment#migrations)

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,0 +1,46 @@
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_commit:
+        description: "Short Git commit hash to deploy to production"
+        required: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      AWS_DEFAULT_REGION: "us-east-1"
+      BATCH_ANALYSIS_JOB_NAME_REVISION: "dummy-test-pfb-analysis-run-job:1"
+      DOCKER_BUILDKIT: 1
+      ENVIRONMENT: "production"
+      GIT_COMMIT: ${{ github.event.inputs.git_commit }}
+      PFB_AWS_BATCH_ANALYSIS_JOB_QUEUE_NAME: "dummy-test-pfb-analysis-job-queue"
+      PFB_AWS_BATCH_ANALYSIS_JOB_DEFINITION_NAME_REVISION: "dummy-test-pfb-analysis-run-job:1"
+      PFB_AWS_ECR_ENDPOINT: ${{ secrets.PFB_AWS_ECR_ENDPOINT }}
+      PFB_S3STORAGE_BUCKET: "production-pfb-static-us-east-1"
+      PFB_SETTINGS_BUCKET: "production-pfb-config-us-east-1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+
+      - name: CI Build
+        run: ./scripts/cibuild
+
+      - name: CI Publish
+        run: ./scripts/cipublish
+
+      - name: Infra Plan and Apply
+        run: |
+          unset AWS_PROFILE
+          ./scripts/infra plan
+          ./scripts/infra apply

--- a/src/angularjs/Dockerfile
+++ b/src/angularjs/Dockerfile
@@ -7,7 +7,7 @@ ENV NODE_OPTIONS --use-openssl-ca
 
 RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y rsync \
+RUN apt-get update && apt-get install -y --allow-unauthenticated rsync \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g bower gulp@3.9.0


### PR DESCRIPTION
## Overview

This PR:
- adds a workaround for an issue reported in [this run](https://github.com/azavea/pfb-network-connectivity/actions/runs/15654091349/job/44102780667) due to a very old Node and Debian version in the angularjs container
- creates release issue template that uses git flow
- includes a github action release workflow for production deployment

## Testing Instructions

 * Review the changes and make sure they make sense.
 * The newly added GitHub actions release workflow is derived from the [deployment steps](https://github.com/azavea/pfb-network-connectivity/tree/develop/deployment#deploying) and the [ci workflow](https://github.com/azavea/pfb-network-connectivity/blob/develop/.github/workflows/ci.yml).


## Checklist

- [ ] Add entry to CHANGELOG.md

Resolves https://github.com/azavea/pfb-network-connectivity/issues/965
